### PR TITLE
Minimal implementation of realtime control demo

### DIFF
--- a/pendulum_control/CMakeLists.txt
+++ b/pendulum_control/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 2.8.3)
+
+project(pendulum_control)
+
+if(APPLE OR WIN32)
+  message(STATUS "The pendulum_control demo is only supported on Linux. Package will not be built.")
+  return()
+endif()
+
+find_package(ament_cmake REQUIRED)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
+
+find_package(rclcpp REQUIRED)
+find_package(rmw_implementation REQUIRED)
+find_package(pendulum_msgs REQUIRED)
+find_package(rttest)
+
+if(NOT rttest_FOUND)
+  message(STATUS "rttest not found. pendulum_control package will not be built.")
+  return()
+endif()
+
+add_executable_for_each_rmw_implementations(pendulum_demo
+  src/pendulum_demo.cpp
+  TARGET_DEPENDENCIES
+  "rclcpp"
+  "pendulum_msgs"
+  "rttest"
+  INSTALL
+)
+
+if(AMENT_ENABLE_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/pendulum_control/README.md
+++ b/pendulum_control/README.md
@@ -1,0 +1,65 @@
+## Build instructions
+
+If you haven't already, clone [rttest](https://github.com/jacquelinekay/rttest) into your ament workspace.
+
+Build:
+
+```
+./src/ament/ament_tools/scripts/ament.py build --build-tests --symlink-install --only pendulum_control
+```
+
+Run:
+
+```
+. install/setup.bash
+./build/pendulum_control/pendulum_demo[__rmw_opensplice/__rmw_connext]
+```
+The demo should work with both middleware implementations.
+
+A few command line arguments related to real-time performance profiling are provided by rttest.
+See https://github.com/ros2/rttest/blob/master/README.md for more information.
+
+## Running with real-time performance
+
+The demo will print out its performance statistics continuously and at the end of the program.
+
+Example final output:
+```
+rttest statistics:
+  - Minor pagefaults: 0
+  - Major pagefaults: 0
+  Latency (time after deadline was missed):
+    - Min: 2414 ns
+    - Max: 45949 ns
+    - Mean: 8712.12 ns
+    - Standard deviation: 1438.74
+```
+
+Ideally you want to see 0 minor or major pagefaults and an average latency of less than 30,000 nanosceonds
+(3% of the 1 millisecond update period).
+
+If you see pagefaults, you may not have permission to lock memory via `mlockall`.
+You can run the program as sudo, or you can adjust the system limits for memory locking.
+
+Add to `/etc/security/limits.conf`:
+```
+<user>    -   memlock   <limit in kB>
+```
+
+A limit of `-1` is unlimited.
+If you choose this, you may need to accompany it with `ulimit -l unlimited` after editing the file.
+
+After saving the file, log out and log back in.
+
+If you see a high mean latency in the results, you may need to adjust the maximum priority for processes.
+
+Add to `/etc/security/limits.conf`:
+```
+<user>    -   rtprio   <maximum priority>
+```
+
+The range of the priority is 0-99.
+However, do NOT set the limit to 99 because then your processes could interfere with important system processes that run at the top priority (e.g. watchdog).
+This demo will attempt to run the control loop at priority 98.
+
+With these settings you can get decent performance even if you don't have the RT_PREEMPT kernel installed, but you will likely see an unacceptably large maximum latency and periodic latency spikes.

--- a/pendulum_control/package.xml
+++ b/pendulum_control/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>pendulum_control</name>
+  <version>0.0.0</version>
+  <description>Demonstrates ROS 2's realtime capabilities with a simulated inverted pendulum.</description>
+  <maintainer email="jackie@osrfoundation.org">Jackie Kay</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>rclcpp</build_depend>
+  <build_depend>rmw_implementation</build_depend>
+  <build_depend>pendulum_msgs</build_depend>
+  <build_depend>rttest</build_depend>
+
+  <exec_depend>rclcpp</exec_depend>
+  <exec_depend>rmw_implementation</exec_depend>
+  <exec_depend>pendulum_msgs</exec_depend>
+  <exec_depend>rttest</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/pendulum_control/src/pendulum_controller.hpp
+++ b/pendulum_control/src/pendulum_controller.hpp
@@ -1,0 +1,136 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PENDULUM_DEMO_PENDULUM_CONTROLLER_HPP_
+#define PENDULUM_DEMO_PENDULUM_CONTROLLER_HPP_
+
+#include <chrono>
+
+#include <pendulum_msgs/msg/joint_command.hpp>
+#include <pendulum_msgs/msg/joint_state.hpp>
+
+#ifndef PI
+#define PI 3.14159265359
+#endif
+
+namespace pendulum_control
+{
+
+struct PIDProperties
+{
+  // Properties of a PID controller
+  double p = 1;
+  double i = 0;
+  double d = 0;
+  double command = PI / 2;
+};
+
+class PendulumController
+{
+public:
+  PendulumController(std::chrono::nanoseconds period, PIDProperties pid)
+  : publish_period_(period), pid_(pid),
+    command_message_(std::make_shared<pendulum_msgs::msg::JointCommand>()),
+    message_ready_(false)
+  {
+    command_message_->position = pid_.command;
+    dt_ = publish_period_.count() / (1000.0 * 1000.0 * 1000.0);
+    if (isnan(dt_) || dt_ == 0) {
+      throw std::runtime_error("Invalid dt_ calculated in PendulumController constructor");
+    }
+  }
+
+  // Calculate new command based on new sensor state and PID controller properties
+  void on_sensor_message(const pendulum_msgs::msg::JointState::SharedPtr msg)
+  {
+    ++messages_received;
+
+    if (isnan(msg->position)) {
+      throw std::runtime_error("Sensor value was NaN in on_sensor_message callback");
+    }
+    double error = pid_.command - msg->position;
+    double p_gain = pid_.p * error;
+    i_gain_ = pid_.i * (i_gain_ + error * dt_);
+    double d_gain = pid_.d * (error - last_error_) / dt_;
+    last_error_ = error;
+
+    // TODO consider filtering the PID output
+    command_message_->position = msg->position + p_gain + i_gain_ + d_gain;
+    // limits
+    if (command_message_->position > PI) {
+      command_message_->position = PI;
+    } else if (command_message_->position < 0) {
+      command_message_->position = 0;
+    }
+
+    if (isnan(command_message_->position)) {
+      throw std::runtime_error("Resulting command was NaN in on_sensor_message callback");
+    }
+    message_ready_ = true;
+  }
+
+  const pendulum_msgs::msg::JointCommand::SharedPtr get_next_command_message()
+  {
+    return command_message_;
+  }
+
+  bool next_message_ready() const
+  {
+    return message_ready_;
+  }
+
+  std::chrono::nanoseconds get_publish_period() const
+  {
+    return publish_period_;
+  }
+
+  void set_pid_properties(const PIDProperties & properties)
+  {
+    pid_ = properties;
+  }
+
+  const PIDProperties & get_pid_properties() const
+  {
+    return pid_;
+  }
+
+  void set_command(double command)
+  {
+    pid_.command = command;
+  }
+
+  double get_command() const
+  {
+    return pid_.command;
+  }
+
+  // gather statistics
+  size_t messages_received = 0;
+
+private:
+  // controller should publish less frequently than the motor
+  std::chrono::nanoseconds publish_period_;
+  PIDProperties pid_;
+  pendulum_msgs::msg::JointCommand::SharedPtr command_message_;
+  bool message_ready_;
+
+  // state for PID controller
+  double last_error_ = 0;
+  double i_gain_ = 0;
+  double dt_;
+};
+
+}  /* namespace pendulum_demo */
+
+#endif  /* PENDULUM_DEMO_PENDULUM_CONTROLLER_HPP_ */

--- a/pendulum_control/src/pendulum_demo.cpp
+++ b/pendulum_control/src/pendulum_demo.cpp
@@ -1,0 +1,188 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <rclcpp/memory_strategies.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/strategies/message_pool_memory_strategy.hpp>
+
+#include <rttest/rttest.h>
+
+#include <pendulum_msgs/msg/joint_command.hpp>
+#include <pendulum_msgs/msg/joint_state.hpp>
+
+#include "pendulum_controller.hpp"
+#include "pendulum_motor.hpp"
+#include "rtt_executor.hpp"
+
+struct OutputThreadArgs
+{
+  std::shared_ptr<pendulum_control::RttExecutor> executor;
+  std::shared_ptr<pendulum_control::PendulumMotor> pendulum_motor;
+  std::shared_ptr<pendulum_control::PendulumController> pendulum_controller;
+
+  OutputThreadArgs(std::shared_ptr<pendulum_control::RttExecutor> exec,
+    std::shared_ptr<pendulum_control::PendulumMotor> motor,
+    std::shared_ptr<pendulum_control::PendulumController> controller)
+  : executor(exec), pendulum_motor(motor), pendulum_controller(controller) {}
+};
+
+void * live_output_thread(void * args)
+{
+  OutputThreadArgs * ptr_args = static_cast<OutputThreadArgs *>(args);
+  auto executor = ptr_args->executor;
+  auto pendulum_motor = ptr_args->pendulum_motor;
+  auto pendulum_controller = ptr_args->pendulum_controller;
+
+  // background task: don't want to interfere with performance
+  if (rttest_set_sched_priority(0, SCHED_IDLE) != 0) {
+    perror("Couldn't set priority of output thread to IDLE");
+  }
+
+  struct rttest_results stats;
+
+  while (executor->is_rttest_ready()) {
+    // Collect statistics
+    if (executor->is_running()) {
+      executor->get_rtt_results(stats);
+
+      printf("Commanded motor angle: %f\n", pendulum_controller->get_command());
+      printf("Actual motor angle: %f\n", pendulum_motor->get_position());
+
+      printf("Mean latency: %f ns\n", stats.mean_latency);
+      printf("Min latency: %d ns\n", stats.min_latency);
+      printf("Max latency: %d ns\n", stats.max_latency);
+
+      printf("Minor pagefaults during execution: %lu\n", stats.minor_pagefaults);
+      printf("Major pagefaults during execution: %lu\n\n", stats.major_pagefaults);
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+  }
+  return 0;
+}
+
+using namespace rclcpp::strategies::message_pool_memory_strategy;
+using rclcpp::memory_strategies::static_memory_strategy::StaticMemoryStrategy;
+
+int main(int argc, char * argv[])
+{
+  // Initialization phase
+
+  // TODO(jacquelinekay) runtime tuning of controller properties and physical characteristics
+  pendulum_control::PendulumProperties properties;
+  pendulum_control::PIDProperties pid;
+
+  auto pendulum_motor = std::make_shared<pendulum_control::PendulumMotor>(
+    std::chrono::nanoseconds(970000), properties);
+  auto pendulum_controller = std::make_shared<pendulum_control::PendulumController>(
+    std::chrono::nanoseconds(960000), pid);
+
+  rttest_read_args(argc, argv);
+  rclcpp::init(argc, argv);
+
+  rclcpp::memory_strategies::static_memory_strategy::ObjectPoolBounds bounds;
+  auto memory_strategy = std::make_shared<StaticMemoryStrategy>(bounds);
+  auto state_msg_strategy =
+    std::make_shared<MessagePoolMemoryStrategy<pendulum_msgs::msg::JointState, 1>>();
+  auto command_msg_strategy =
+    std::make_shared<MessagePoolMemoryStrategy<pendulum_msgs::msg::JointCommand, 1>>();
+
+  // The controller node represents user code
+  auto controller_node = rclcpp::node::Node::make_shared("pendulum_controller");
+
+  // The "motor" node simulates motors and sensors
+  // It provides sensor data and changes the physical model based on the command
+  auto motor_node = rclcpp::node::Node::make_shared("pendulum_motor");
+
+  rmw_qos_profile_t qos_profile = rmw_qos_profile_default;
+  qos_profile.depth = 1;
+
+  auto sensor_pub = motor_node->create_publisher<pendulum_msgs::msg::JointState>("pendulum_sensor",
+      qos_profile);
+
+  auto motor_subscribe_callback =
+    [&pendulum_motor](const pendulum_msgs::msg::JointCommand::SharedPtr msg) -> void
+    {
+      pendulum_motor->on_command_message(msg);
+    };
+
+  auto command_sub = motor_node->create_subscription<pendulum_msgs::msg::JointCommand>
+      ("pendulum_command", qos_profile, motor_subscribe_callback,
+      nullptr, false, command_msg_strategy);
+
+  auto controller_subscribe_callback =
+    [&pendulum_controller](const pendulum_msgs::msg::JointState::SharedPtr msg) -> void
+    {
+      pendulum_controller->on_sensor_message(msg);
+    };
+
+  auto command_pub = controller_node->create_publisher<pendulum_msgs::msg::JointCommand>(
+    "pendulum_command", qos_profile);
+  auto sensor_sub = controller_node->create_subscription<pendulum_msgs::msg::JointState>
+      ("pendulum_sensor", qos_profile, controller_subscribe_callback,
+      nullptr, false, state_msg_strategy);
+
+  auto executor = std::make_shared<pendulum_control::RttExecutor>(memory_strategy);
+  executor->add_node(motor_node);
+  executor->add_node(controller_node);
+
+  auto motor_publish_callback =
+    [&sensor_pub, &pendulum_motor]()
+    {
+      if (pendulum_motor->next_message_ready()) {
+        auto msg = pendulum_motor->get_next_sensor_message();
+        sensor_pub->publish(msg);
+      }
+    };
+
+  auto controller_publish_callback =
+    [&command_pub, &pendulum_controller]()
+    {
+      if (pendulum_controller->next_message_ready()) {
+        auto msg = pendulum_controller->get_next_command_message();
+        command_pub->publish(msg);
+      }
+    };
+
+  // Add timers for publishers
+  auto motor_publisher_timer = motor_node->create_wall_timer
+      (pendulum_motor->get_publish_period(), motor_publish_callback);
+  auto controller_publisher_timer = controller_node->create_wall_timer
+      (pendulum_controller->get_publish_period(), controller_publish_callback);
+  if (rttest_set_sched_priority(98, SCHED_RR)) {
+    perror("Couldn't set scheduling priority and policy");
+  }
+
+  // Create output thread
+  // Must be a pthread so that we can set the scheduler
+  pthread_t output_thread;
+  OutputThreadArgs ptr_args(executor, pendulum_motor, pendulum_controller);
+  void * args = static_cast<void *>(&ptr_args);
+  pthread_create(&output_thread, NULL, live_output_thread, static_cast<void *>(args));
+
+  if (rttest_lock_and_prefault_dynamic() != 0) {
+    perror("Couldn't lock memory");
+  }
+
+  // End initialization phase
+  // Execution phase
+  executor->spin();
+  pendulum_motor->set_done(true);
+
+  // End execution phase
+  // Teardown phase
+  void * status;
+  pthread_join(output_thread, &status);
+  printf("PendulumMotor received %lu messages\n", pendulum_motor->messages_received);
+  printf("PendulumController received %lu messages\n", pendulum_controller->messages_received);
+}

--- a/pendulum_control/src/pendulum_motor.hpp
+++ b/pendulum_control/src/pendulum_motor.hpp
@@ -1,0 +1,214 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PENDULUM_DEMO_PENDULUM_MOTOR_HPP_
+#define PENDULUM_DEMO_PENDULUM_MOTOR_HPP_
+
+#include <chrono>
+
+#include <rttest/rttest.h>
+#include <rttest/utils.h>
+
+#include <pendulum_msgs/msg/joint_command.hpp>
+#include <pendulum_msgs/msg/joint_state.hpp>
+
+#ifndef GRAVITY
+#define GRAVITY 9.80665
+#endif
+
+#ifndef PI
+#define PI 3.14159265359
+#endif
+
+namespace pendulum_control
+{
+
+struct PendulumProperties
+{
+  double mass = 0.01;  // mass of the weight on the end of the pendulum in kilograms
+  double length = 0.5;  // length of the pendulum in meters
+};
+
+struct PendulumState
+{
+  double position = 0;  // Angle from the ground in radians (p in diagram)
+  double velocity = 0;  // Angular velocity in radians/sec
+  double acceleration = 0;  // Angular acceleration in radians/sec^2
+  double torque = 0;  // Torque on the joint (currently unused)
+};
+
+class PendulumMotor
+{
+public:
+  PendulumMotor(std::chrono::nanoseconds period, PendulumProperties properties)
+  : publish_period_(period), properties_(properties),
+    physics_update_period_(std::chrono::nanoseconds(1000000)),
+    sensor_message_(std::make_shared<pendulum_msgs::msg::JointState>()),
+    message_ready_(false), done_(false)
+  {
+    dt_ = physics_update_period_.count() / (1000.0 * 1000.0 * 1000.0);
+    long_to_timespec(physics_update_period_.count(), &physics_update_timespec_);
+
+    pthread_attr_init(&thread_attr_);
+    struct sched_param thread_param;
+    thread_param.sched_priority = 90;
+    pthread_attr_setschedparam(&thread_attr_, &thread_param);
+    pthread_attr_setschedpolicy(&thread_attr_, SCHED_RR);
+    pthread_create(&physics_update_thread_, &thread_attr_,
+      &pendulum_control::PendulumMotor::physics_update_wrapper, this);
+  }
+
+  // Update forces on motor based on command
+  void on_command_message(const pendulum_msgs::msg::JointCommand::SharedPtr msg)
+  {
+    ++messages_received;
+    // Assume direct, instantaneous position control
+    // TODO(jacquelinekay): do we want to simulate a motor model?
+    state_.position = msg->position;
+
+    if (state_.position > PI) {
+      state_.position = PI;
+    } else if (state_.position < 0) {
+      state_.position = 0;
+    }
+
+    if (isnan(state_.position)) {
+      throw std::runtime_error("Tried to set state to NaN in on_command_message callback");
+    }
+  }
+
+  const pendulum_msgs::msg::JointState::SharedPtr get_next_sensor_message()
+  {
+    return sensor_message_;
+  }
+
+  bool next_message_ready() const
+  {
+    return message_ready_;
+  }
+
+  void set_done(bool done)
+  {
+    done_ = done;
+  }
+
+  bool done() const
+  {
+    return done_;
+  }
+
+  std::chrono::nanoseconds get_publish_period() const
+  {
+    return publish_period_;
+  }
+
+  double get_position() const
+  {
+    return state_.position;
+  }
+
+  PendulumState get_state() const
+  {
+    return state_;
+  }
+
+  void set_state(const PendulumState & state)
+  {
+    state_ = state;
+  }
+
+  const PendulumProperties & get_properties() const
+  {
+    return properties_;
+  }
+
+  void set_properties(const PendulumProperties & properties)
+  {
+    properties_ = properties;
+  }
+
+  size_t messages_received = 0;
+
+private:
+  static void * physics_update_wrapper(void * args)
+  {
+    PendulumMotor * motor = static_cast<PendulumMotor *>(args);
+    if (!motor) {
+      return NULL;
+    }
+    return motor->physics_update();
+  }
+  // Set kinematic and dynamic properties of the pendulum based on state inputs
+  void * physics_update()
+  {
+    rttest_lock_and_prefault_dynamic();
+    while (!done_) {
+      state_.acceleration = GRAVITY * std::sin(state_.position - PI / 2.0) / properties_.length +
+        state_.torque / (properties_.mass + properties_.length);
+      state_.velocity += state_.acceleration * dt_;
+      state_.position += state_.velocity * dt_;
+      if (state_.position > PI) {
+        state_.position = PI;
+      } else if (state_.position < 0) {
+        state_.position = 0;
+      }
+
+      if (isnan(state_.position)) {
+        throw std::runtime_error("Tried to set state to NaN in on_command_message callback");
+      }
+
+      sensor_message_->velocity = state_.velocity;
+      // Simulate a noisy sensor on position
+      sensor_message_->position = state_.position;
+
+      message_ready_ = true;
+      // high resolution sleep
+      clock_nanosleep(CLOCK_MONOTONIC, 0, &physics_update_timespec_, NULL);
+    }
+    return 0;
+  }
+
+  // motor should publish more frequently than the controller
+  std::chrono::nanoseconds publish_period_;
+
+  // Physics should update most frequently, in separate RT thread
+  struct timespec physics_update_timespec_;
+  double dt_;
+
+  // Physical qualities of the pendulum
+  // *INDENT-OFF* (prevent uncrustify from ruining my sweet ASCII art)
+  /*
+       M
+        \
+         \ length
+       p  \
+     0 ----------- pi
+   */
+  // *INDENT-ON*
+
+  PendulumProperties properties_;
+  PendulumState state_;
+
+  std::chrono::nanoseconds physics_update_period_;
+  pendulum_msgs::msg::JointState::SharedPtr sensor_message_;
+  bool message_ready_;
+  bool done_;
+
+  pthread_t physics_update_thread_;
+  pthread_attr_t thread_attr_;
+};
+
+}  /* namespace pendulum_demo */
+
+#endif  /* PENDULUM_DEMO_PENDULUM_MOTOR_HPP_ */

--- a/pendulum_control/src/rtt_executor.hpp
+++ b/pendulum_control/src/rtt_executor.hpp
@@ -1,0 +1,107 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PENDULUM_DEMO_RTT_EXECUTOR_HPP_
+#define PENDULUM_DEMO_RTT_EXECUTOR_HPP_
+
+#include <cassert>
+#include <cstdlib>
+#include <memory>
+#include <vector>
+
+#include <rttest/rttest.h>
+#include <rttest/utils.h>
+
+#include <rmw/rmw.h>
+
+#include <rclcpp/executor.hpp>
+#include <rclcpp/macros.hpp>
+#include <rclcpp/memory_strategies.hpp>
+
+namespace pendulum_control
+{
+class RttExecutor : public executor::Executor
+{
+public:
+  RttExecutor(memory_strategy::MemoryStrategy::SharedPtr ms =
+    memory_strategy::create_default_strategy())
+  : executor::Executor(ms), running(false)
+  {
+    rttest_ready = rttest_running();
+  }
+
+  virtual ~RttExecutor() {}
+
+  bool is_rttest_ready() const
+  {
+    return rttest_ready;
+  }
+
+  bool is_running() const
+  {
+    return rclcpp::ok() && running;
+  }
+
+  void get_rtt_results(struct rttest_results & output) const
+  {
+    output = results;
+  }
+
+  void spin()
+  {
+    rttest_spin(RttExecutor::loop_callback, static_cast<void *>(this));
+    running = false;
+    rttest_write_results();
+    rttest_finish();
+    rttest_ready = rttest_running();
+  }
+
+  int rtt_spin_some(size_t i)
+  {
+    running = true;
+    if (i == 0) {
+      clock_gettime(0, &start_time_);
+    }
+    return rttest_spin_once(RttExecutor::loop_callback, static_cast<void *>(this), &start_time_, i);
+  }
+
+  static void * loop_callback(void * arg)
+  {
+    RttExecutor * executor = static_cast<RttExecutor *>(arg);
+    if (!executor || !rclcpp::utilities::ok()) {
+      return 0;
+    }
+    // Single-threaded spin_some: do as much work as we have available
+    executor->spin_some();
+
+    rttest_get_statistics(executor->results);
+    executor->running = true;
+    return 0;
+  }
+
+  struct rttest_results results;
+  bool running;
+  bool rttest_ready;
+
+protected:
+  struct timespec start_time_;
+
+private:
+  RCLCPP_DISABLE_COPY(RttExecutor);
+
+};
+
+} /* namespace pendulum_demo */
+
+#endif /* PENDULUM_DEMO_RTT_EXECUTOR_HPP_ */

--- a/pendulum_msgs/CMakeLists.txt
+++ b/pendulum_msgs/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 2.8.3)
+
+project(pendulum_msgs)
+
+if(NOT WIN32)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+rosidl_generate_interfaces(pendulum_msgs
+  "msg/JointState.msg"
+  "msg/JointCommand.msg"
+)
+
+ament_package()

--- a/pendulum_msgs/msg/JointCommand.msg
+++ b/pendulum_msgs/msg/JointCommand.msg
@@ -1,0 +1,1 @@
+float64 position

--- a/pendulum_msgs/msg/JointState.msg
+++ b/pendulum_msgs/msg/JointState.msg
@@ -1,0 +1,3 @@
+float64 position
+float64 velocity
+float64 effort

--- a/pendulum_msgs/package.xml
+++ b/pendulum_msgs/package.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>pendulum_msgs</name>
+  <version>0.0.0</version>
+  <description>Custom messages for real-time pendulum control.</description>
+  <maintainer email="jackie@osrfoundation.org">Jackie Kay</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>rosidl_default_generators</build_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
This pull request adds:

* `pendulum_control` package
* `pendulum_msgs` package for custom message types. (Originally I considered using `sensor_msgs::JointState`, but since it contains a string field, it is not a fixed size message.)
* `RttExecutor`: an executor instrumented for collecting data for real-time performance statistics
* pendulum_demo.cpp: provides a main function that intializes rclcpp, nodes, publishers/subscribers, and executor. Print output to screen in a separate, low-priority thread.
* `PendulumController`: Store PID properties, provide the next command message based on the received sensor message.
* `PendulumMotor`: Abstraction for the physical state of the pendulum system. Change the state based on the command message and provide the next sensor message. Runs a separate "physics update" thread to update the state of the pendulum.

The `README.md` file contains more information about how to configure your system to see "soft" real-time performance results.