### PR TITLE
make producer / consumer plugins in a shared library and load them with pluginlib

### DIFF
--- a/intra_process_comms/CMakeLists.txt
+++ b/intra_process_comms/CMakeLists.txt
@@ -7,6 +7,7 @@ if(NOT WIN32)
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rmw_implementation REQUIRED)
@@ -23,9 +24,19 @@ ament_package()
 ## Example of intra-process comms
 ##
 
+add_library(two_node_pipeline_plugins SHARED
+  src/two_node_pipeline/two_node_pipeline_plugins.cpp)
+ament_target_dependencies(two_node_pipeline_plugins
+  "rclcpp" "std_msgs" "pluginlib" "rmw_implementation")
+
+install(TARGETS two_node_pipeline_plugins
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)
+
 add_executable_for_each_rmw_implementations(two_node_pipeline
   src/two_node_pipeline/two_node_pipeline.cpp
-  TARGET_DEPENDENCIES "rclcpp" "std_msgs"
+  TARGET_DEPENDENCIES "rclcpp" "std_msgs" "pluginlib"
   INSTALL)
 
 add_executable_for_each_rmw_implementations(cyclic_pipeline

--- a/intra_process_comms/package.xml
+++ b/intra_process_comms/package.xml
@@ -19,5 +19,8 @@
   <exec_depend>rmw_implementation</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
 
-  <export><build_type>ament_cmake</build_type></export>
+  <export>
+    <build_type>ament_cmake</build_type>
+    <intra_process_comms_example plugin="${prefix}/two_node_pipeline_plugins.xml"/>
+  </export>
 </package>

--- a/intra_process_comms/src/two_node_pipeline/two_node_pipeline_plugins.cpp
+++ b/intra_process_comms/src/two_node_pipeline/two_node_pipeline_plugins.cpp
@@ -15,12 +15,16 @@
 #include <chrono>
 #include <cstdio>
 
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_list_macros.h>
 #include <rclcpp/rclcpp.hpp>
 #include <std_msgs/msg/int32.hpp>
 
 struct Producer : public rclcpp::Node
 {
+  Producer()
+    : Producer("number")
+  {}
+
   Producer(const std::string & output, const std::string & name = "producer")
   : Node(name, true)
   {
@@ -38,8 +42,14 @@ struct Producer : public rclcpp::Node
   rclcpp::WallTimer::SharedPtr timer_;
 };
 
+PLUGINLIB_EXPORT_CLASS(Producer, rclcpp::Node)
+
 struct Consumer : public rclcpp::Node
 {
+  Consumer()
+    : Consumer("number")
+  {}
+
   Consumer(const std::string & input, const std::string & name = "consumer")
   : Node(name, true)
   {
@@ -52,18 +62,4 @@ struct Consumer : public rclcpp::Node
   rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr sub_;
 };
 
-int main(int argc, char * argv[])
-{
-  rclcpp::init(argc, argv);
-  rclcpp::executors::SingleThreadedExecutor executor;
-
-  pluginlib::ClassLoader<rclcpp::Node> loader("intra_process_comms_example", "rclcpp::Node");
-
-  auto producer = loader.createInstance("intra_process_comms_example/producer");
-  auto consumer = loader.createInstance("intra_process_comms_example/consumer");
-
-  executor.add_node(producer);
-  executor.add_node(consumer);
-  executor.spin();
-  return 0;
-}
+PLUGINLIB_EXPORT_CLASS(Consumer, rclcpp::Node)

--- a/intra_process_comms/two_node_pipeline_plugins.xml
+++ b/intra_process_comms/two_node_pipeline_plugins.xml
@@ -1,0 +1,8 @@
+<library path="lib/libtwo_node_pipeline_plugins">
+  <class name="intra_process_comms_example/producer" type="Producer" base_class_type="rclcpp::Node">
+    <description>This is a producer plugin.</description>
+  </class>
+  <class name="intra_process_comms_example/consumer" type="Consumer" base_class_type="rclcpp::Node">
+    <description>This is a consumer plugin.</description>
+  </class>
+</library>


### PR DESCRIPTION
Simple example using `pluginlib` (https://github.com/ros/pluginlib/tree/ros2) and indirectly `class loader` (https://github.com/ros/class_loader/tree/ros2).

Before this can be considered it must be possible to build a shared library which only depends on `rclcpp` but not a specific rmw implementation. Currently `rclcpp` depends directly on the headers of a specific implementation:
- https://github.com/ros2/rclcpp/blob/65300405bef94cc391253083f7140041c69c737f/rclcpp/include/rclcpp/node.hpp#L27
- https://github.com/ros2/rclcpp/blob/65300405bef94cc391253083f7140041c69c737f/rclcpp/include/rclcpp/node_impl.hpp#L30-L31
