### PR TITLE
use sensor profile since the message might come from the bridge which needs handle large and therefore can't use the default profile

### DIFF
--- a/image_tools/src/cam2image.cpp
+++ b/image_tools/src/cam2image.cpp
@@ -123,7 +123,7 @@ int main(int argc, char * argv[])
     };
 
   // Set the QoS profile for the subscription to the flip message.
-  rmw_qos_profile_t custom_flip_qos_profile = rmw_qos_profile_default;
+  rmw_qos_profile_t custom_flip_qos_profile = rmw_qos_profile_sensor_data;
   custom_flip_qos_profile.depth = 10;
 
   auto sub = node->create_subscription<std_msgs::msg::Bool>(


### PR DESCRIPTION
Connect to ros2/ros1_bridge#12