### PR TITLE
Avoid passing 'this' pointer to the callback closure

### DIFF
--- a/intra_process_demo/src/cyclic_pipeline/cyclic_pipeline.cpp
+++ b/intra_process_demo/src/cyclic_pipeline/cyclic_pipeline.cpp
@@ -29,7 +29,7 @@ struct IncrementerPipe : public rclcpp::Node
     // Create a subscription on the input topic.
     sub = this->create_subscription_with_unique_ptr_callback<std_msgs::msg::Int32>(
       in, rmw_qos_profile_default,
-      [this](std_msgs::msg::Int32::UniquePtr & msg) {
+      [this](std_msgs::msg::Int32::UniquePtr msg) {
         printf("Received message with value:         %d, and address: %p\n", msg->data, msg.get());
         printf("  sleeping for 1 second...\n");
         if (!rclcpp::sleep_for(1_s)) {

--- a/intra_process_demo/src/image_pipeline/watermark_node.hpp
+++ b/intra_process_demo/src/image_pipeline/watermark_node.hpp
@@ -35,7 +35,7 @@ public:
     pub_ = this->create_publisher<sensor_msgs::msg::Image>(output, qos);
     // Create a subscription on the output topic.
     sub_ = this->create_subscription_with_unique_ptr_callback<sensor_msgs::msg::Image>(input, qos,
-      [this, text](sensor_msgs::msg::Image::UniquePtr & msg) {
+      [this, text](sensor_msgs::msg::Image::UniquePtr msg) {
         // Create a cv::Mat from the image message (without copying).
         cv::Mat cv_mat(
           msg->width, msg->height,

--- a/intra_process_demo/src/two_node_pipeline/two_node_pipeline.cpp
+++ b/intra_process_demo/src/two_node_pipeline/two_node_pipeline.cpp
@@ -48,7 +48,7 @@ struct Consumer : public rclcpp::Node
   {
     // Create a subscription on the input topic which prints on receipt of new messages.
     sub_ = this->create_subscription_with_unique_ptr_callback<std_msgs::msg::Int32>(
-      input, rmw_qos_profile_default, [](std_msgs::msg::Int32::UniquePtr & msg) {
+      input, rmw_qos_profile_default, [](std_msgs::msg::Int32::UniquePtr msg) {
       printf(" Received message with value: %d, and address: %p\n", msg->data, msg.get());
     });
   }

--- a/intra_process_demo/src/two_node_pipeline/two_node_pipeline.cpp
+++ b/intra_process_demo/src/two_node_pipeline/two_node_pipeline.cpp
@@ -26,13 +26,18 @@ struct Producer : public rclcpp::Node
   {
     // Create a publisher on the output topic.
     pub_ = this->create_publisher<std_msgs::msg::Int32>(output, rmw_qos_profile_default);
+    std::weak_ptr<std::remove_pointer<decltype(pub_.get())>::type> captured_pub = pub_;
     // Create a timer which publishes on the output topic at ~1Hz.
-    timer_ = this->create_wall_timer(1_s, [this]() {
+    timer_ = this->create_wall_timer(1_s, [captured_pub]() {
+      auto pub_ptr = captured_pub.lock();
+      if (!pub_ptr) {
+        return;
+      }
       static int32_t count = 0;
       std_msgs::msg::Int32::UniquePtr msg(new std_msgs::msg::Int32());
       msg->data = count++;
       printf("Published message with value: %d, and address: %p\n", msg->data, msg.get());
-      pub_->publish(msg);
+      pub_ptr->publish(msg);
     });
   }
 


### PR DESCRIPTION
Pass a `weak_ptr` of the `shared_ptr` of the `Publisher` to the callback to avoid invalid pointers of `this`

Depends on https://github.com/ros2/demos/pull/27