### PR TITLE
remove HeapPoolMemoryStrategy

### DIFF
--- a/pendulum_control/CMakeLists.txt
+++ b/pendulum_control/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable_for_each_rmw_implementations(pendulum_teleop
   TARGET_DEPENDENCIES
   "rclcpp"
   "pendulum_msgs"
+  "rttest"
   INSTALL
 )
 

--- a/pendulum_control/include/pendulum_control/rtt_executor.hpp
+++ b/pendulum_control/include/pendulum_control/rtt_executor.hpp
@@ -40,7 +40,7 @@ public:
    * Extends default Executor constructor
    */
   RttExecutor(memory_strategy::MemoryStrategy::SharedPtr ms =
-    memory_strategy::create_default_strategy())
+    memory_strategies::create_default_strategy())
   : executor::Executor(ms), running(false)
   {
     rttest_ready = rttest_running();


### PR DESCRIPTION
I will change the memory strategy back when there's an acceptable replacement that uses the new MemoryStrategy API.

Connects to ros2/rclcpp#137
