### PR TITLE
Fix pendulum segfault in binaries

### DIFF
--- a/pendulum_control/src/pendulum_demo.cpp
+++ b/pendulum_control/src/pendulum_demo.cpp
@@ -53,19 +53,14 @@ static void * (* prev_malloc_hook)(size_t, const void *);
 static void * testing_malloc(size_t size, const void * caller)
 {
   (void)caller;
-  /*
-  // Maximum depth we are willing to traverse into the stack trace.
-  static const int MAX_DEPTH = 2;
-  // Instantiate a buffer to store the traced symbols.
-  void * backtrace_buffer[MAX_DEPTH];
-  */
-  if (running) {
-    throw std::runtime_error("Called malloc during realtime execution phase!");
-  }
-
   // Set the malloc implementation to the default malloc hook so that we can call it implicitly
   // to initialize a string, otherwise this function will loop infinitely.
   __malloc_hook = prev_malloc_hook;
+
+  if (running) {
+    fprintf(stderr, "Called malloc during realtime execution phase!\n");
+    exit(-1);
+  }
 
   // Execute the requested malloc.
   void * mem = malloc(size);


### PR DESCRIPTION
I am still unable to reproduce the segfault observed by @dirk-thomas in the source build, and @tfoote was unable to reproduce it in docker. However, after reproducing it in the binaries and observing that the segfault originates in the exception thrown in the `malloc_hook`, I realized two problems with the implementation:

1. The `malloc_hook` function needs to restore the system malloc to `__malloc_hook` before trying to malloc within the function, else it will infinitely call the custom `malloc_hook`. This happens when the exception is thrown because the exception will try to allocate memory.
2. Throwing an exception within a C function, which is generally bad, and especially bad because malloc is usually called from global `new`, a C++ function that is marked noexcept.

I have no idea why the exception is never seen in a source build, even a source build with RelWithDebInfo build type (which is what the binaries use).

@dirk-thomas, since your Linux VM appears to most consistently reproduce the problem, can you download the artifact from the packaging job for this branch and test this change?

http://ci.ros2.org/view/packaging/job/ros2_packaging_linux/38/