### PR TITLE
Fix pendulum demo regressions for rclcpp_library

### DIFF
--- a/pendulum_control/include/pendulum_control/rtt_executor.hpp
+++ b/pendulum_control/include/pendulum_control/rtt_executor.hpp
@@ -33,16 +33,16 @@
 namespace pendulum_control
 {
 /// Instrumented executor that syncs Executor::spin functions with rttest_spin.
-class RttExecutor : public executor::Executor
+class RttExecutor : public rclcpp::executor::Executor
 {
 public:
   /// Constructor
   /**
    * Extends default Executor constructor
    */
-  RttExecutor(memory_strategy::MemoryStrategy::SharedPtr ms =
-    memory_strategies::create_default_strategy())
-  : executor::Executor(ms), running(false)
+  RttExecutor(rclcpp::memory_strategy::MemoryStrategy::SharedPtr ms =
+    rclcpp::memory_strategies::create_default_strategy())
+  : rclcpp::executor::Executor(ms), running(false)
   {
     rttest_ready = rttest_running();
     memset(&start_time_, 0, sizeof(timespec));


### PR DESCRIPTION
I have no idea why leaving out the namespace in these files worked before.

@wjwwood 

Connects to ros2/ros2#147