### PR TITLE
change WallTimer to TimerBase

### DIFF
--- a/intra_process_demo/src/two_node_pipeline/two_node_pipeline.cpp
+++ b/intra_process_demo/src/two_node_pipeline/two_node_pipeline.cpp
@@ -29,7 +29,7 @@ struct Producer : public rclcpp::Node
     pub_ = this->create_publisher<std_msgs::msg::Int32>(output, rmw_qos_profile_default);
     std::weak_ptr<std::remove_pointer<decltype(pub_.get())>::type> captured_pub = pub_;
     // Create a timer which publishes on the output topic at ~1Hz.
-    timer_ = this->create_wall_timer(1_s, [captured_pub]() {
+    auto callback = [captured_pub]() -> void {
       auto pub_ptr = captured_pub.lock();
       if (!pub_ptr) {
         return;
@@ -39,11 +39,13 @@ struct Producer : public rclcpp::Node
       msg->data = count++;
       printf("Published message with value: %d, and address: %p\n", msg->data, msg.get());
       pub_ptr->publish(msg);
-    });
+    };
+    timer_ = this->create_wall_timer(1_s, callback);
   }
 
   rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr pub_;
-  rclcpp::WallTimer::SharedPtr timer_;
+  //rclcpp::WallTimer::SharedPtr timer_;
+  rclcpp::TimerBase::SharedPtr timer_;
 };
 
 // Node that consumes messages.

--- a/intra_process_demo/src/two_node_pipeline/two_node_pipeline.cpp
+++ b/intra_process_demo/src/two_node_pipeline/two_node_pipeline.cpp
@@ -44,7 +44,6 @@ struct Producer : public rclcpp::Node
   }
 
   rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr pub_;
-  //rclcpp::WallTimer::SharedPtr timer_;
   rclcpp::TimerBase::SharedPtr timer_;
 };
 


### PR DESCRIPTION
to avoid exposing the callback signature template argument.

Connects to ros2/rclcpp#159