### PR TITLE
Add delay to pendulum_teleop

### DIFF
--- a/pendulum_control/CMakeLists.txt
+++ b/pendulum_control/CMakeLists.txt
@@ -100,6 +100,11 @@ if(AMENT_ENABLE_TESTING)
       @ONLY
     )
 
+    configure_file(
+      test/execute_with_delay.py
+      execute_with_delay.py
+    )
+
     ament_add_nose_test(test_demo_pendulum__${middleware_impl}
       "${CMAKE_CURRENT_BINARY_DIR}/test_pendulum__${middleware_impl}.py"
       TIMEOUT 20)

--- a/pendulum_control/test/execute_with_delay.py
+++ b/pendulum_control/test/execute_with_delay.py
@@ -12,19 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import argparse
 import subprocess
 import sys
 import time
 
 
 def main():
-    if len(sys.argv) < 3:
-        print("usage: execute_with_delay.py <delay (ms)> <executable> [args ...]")
-        exit()
-    delay_time = float(sys.argv[1]) * 0.001
+    parser = argparse.ArgumentParser(description='Delay and execute an executable.')
+    parser.add_argument('delay', metavar='T', type=float, help='Start delay in ms')
+    parser.add_argument('executable', metavar='exec', type=str, nargs='+',
+                        help='Executable to execute, with a variable number of arguments.')
+    args = parser.parse_args()
+
+    delay_time = args.delay * 0.001
     time.sleep(delay_time)
-    subprocess.call(sys.argv[2:], stdout=sys.stdout, stderr=sys.stderr)
+    return subprocess.call(args.executable)
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/pendulum_control/test/execute_with_delay.py
+++ b/pendulum_control/test/execute_with_delay.py
@@ -1,0 +1,30 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import subprocess
+import sys
+import time
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("usage: execute_with_delay.py <delay (ms)> <executable> [args ...]")
+        exit()
+    delay_time = float(sys.argv[1]) * 0.001
+    time.sleep(delay_time)
+    subprocess.call(sys.argv[2:], stdout=sys.stdout, stderr=sys.stderr)
+
+if __name__ == '__main__':
+    main()

--- a/pendulum_control/test/test_pendulum_teleop.py.in
+++ b/pendulum_control/test/test_pendulum_teleop.py.in
@@ -1,4 +1,6 @@
 import os
+import sys
+
 from launch import LaunchDescriptor
 from launch.exit_handler import ignore_exit_handler
 from launch.launcher import DefaultLauncher
@@ -33,8 +35,12 @@ def test_executable():
     pendulum_teleop_handler = create_handler(pendulum_teleop_name, launch_descriptor, pendulum_teleop_output_file)
     assert pendulum_teleop_handler, 'Cannot find appropriate handler for %s' % pendulum_teleop_output_file
     output_handlers.append(pendulum_teleop_handler)
+    execute_with_delay_command = os.path.join(
+        os.path.abspath(os.path.dirname(__file__)), 'execute_with_delay.py')
+
     launch_descriptor.add_process(
-        cmd=[pendulum_teleop_executable, '100'],
+        #cmd=[pendulum_teleop_executable, '100'],
+        cmd=[sys.executable, execute_with_delay_command, '500', pendulum_teleop_executable, '100'],
         name=pendulum_teleop_name,
         exit_handler=ignore_exit_handler,
         output_handlers=[pendulum_teleop_handler],

--- a/pendulum_control/test/test_pendulum_teleop.py.in
+++ b/pendulum_control/test/test_pendulum_teleop.py.in
@@ -39,7 +39,6 @@ def test_executable():
         os.path.abspath(os.path.dirname(__file__)), 'execute_with_delay.py')
 
     launch_descriptor.add_process(
-        #cmd=[pendulum_teleop_executable, '100'],
         cmd=[sys.executable, execute_with_delay_command, '500', pendulum_teleop_executable, '100'],
         name=pendulum_teleop_name,
         exit_handler=ignore_exit_handler,


### PR DESCRIPTION
due to nondeterministic startup issues, sometimes the teleop node will start and publish a message before the demo can do its thing

we really need a latched message but those aren't implemented yet so this is the hack around it