### PR TITLE
don't run the pendulum test with fastrtps

### DIFF
--- a/pendulum_control/CMakeLists.txt
+++ b/pendulum_control/CMakeLists.txt
@@ -84,39 +84,43 @@ if(AMENT_ENABLE_TESTING)
   set(RCLCPP_DEMO_PENDULUM_TELEOP_EXPECTED_OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/test/pendulum_teleop")
 
   foreach(middleware_impl ${middleware_implementations})
-    set(RCLCPP_DEMO_PENDULUM_LOGGER_EXECUTABLE "${CMAKE_CURRENT_BINARY_DIR}${test_executable_subfolder}/pendulum_logger__${middleware_impl}${test_executable_extension}")
-    set(RCLCPP_DEMO_PENDULUM_DEMO_EXECUTABLE "${CMAKE_CURRENT_BINARY_DIR}${test_executable_subfolder}/pendulum_demo__${middleware_impl}${test_executable_extension}")
-    set(RCLCPP_DEMO_PENDULUM_TELEOP_EXECUTABLE "${CMAKE_CURRENT_BINARY_DIR}${test_executable_subfolder}/pendulum_teleop__${middleware_impl}${test_executable_extension}")
+    # FastRTPS doesn't (yet) support the use of custom allocators, so it will
+    # fail this test, which requires that no actual allocation happens during
+    # execution.
+    if(NOT ${middleware_impl} STREQUAL "rmw_fastrtps_cpp")
+      set(RCLCPP_DEMO_PENDULUM_LOGGER_EXECUTABLE "${CMAKE_CURRENT_BINARY_DIR}${test_executable_subfolder}/pendulum_logger__${middleware_impl}${test_executable_extension}")
+      set(RCLCPP_DEMO_PENDULUM_DEMO_EXECUTABLE "${CMAKE_CURRENT_BINARY_DIR}${test_executable_subfolder}/pendulum_demo__${middleware_impl}${test_executable_extension}")
+      set(RCLCPP_DEMO_PENDULUM_TELEOP_EXECUTABLE "${CMAKE_CURRENT_BINARY_DIR}${test_executable_subfolder}/pendulum_teleop__${middleware_impl}${test_executable_extension}")
 
-    configure_file(
-      test/test_pendulum_demo.py.in
-      test_pendulum__${middleware_impl}.py
-      @ONLY
-    )
+      configure_file(
+        test/test_pendulum_demo.py.in
+        test_pendulum__${middleware_impl}.py
+        @ONLY
+      )
 
-    configure_file(
-      test/test_pendulum_teleop.py.in
-      test_pendulum_teleop__${middleware_impl}.py
-      @ONLY
-    )
+      configure_file(
+        test/test_pendulum_teleop.py.in
+        test_pendulum_teleop__${middleware_impl}.py
+        @ONLY
+      )
 
-    configure_file(
-      test/execute_with_delay.py
-      execute_with_delay.py
-    )
+      configure_file(
+        test/execute_with_delay.py
+        execute_with_delay.py
+      )
 
-    ament_add_nose_test(test_demo_pendulum__${middleware_impl}
-      "${CMAKE_CURRENT_BINARY_DIR}/test_pendulum__${middleware_impl}.py"
-      TIMEOUT 20)
-    set_tests_properties(test_demo_pendulum__${middleware_impl}
-    PROPERTIES DEPENDS "test_demo_pendulum__${middleware_impl} test_demo_pendulum__${middleware_impl}")
+      ament_add_nose_test(test_demo_pendulum__${middleware_impl}
+        "${CMAKE_CURRENT_BINARY_DIR}/test_pendulum__${middleware_impl}.py"
+        TIMEOUT 20)
+      set_tests_properties(test_demo_pendulum__${middleware_impl}
+      PROPERTIES DEPENDS "test_demo_pendulum__${middleware_impl} test_demo_pendulum__${middleware_impl}")
 
-    ament_add_nose_test(test_demo_pendulum_teleop__${middleware_impl}
-      "${CMAKE_CURRENT_BINARY_DIR}/test_pendulum_teleop__${middleware_impl}.py"
-      TIMEOUT 20)
-    set_tests_properties(test_demo_pendulum_teleop__${middleware_impl}
-    PROPERTIES DEPENDS "test_demo_pendulum_teleop__${middleware_impl} test_demo_pendulum_teleop__${middleware_impl}")
-
+      ament_add_nose_test(test_demo_pendulum_teleop__${middleware_impl}
+        "${CMAKE_CURRENT_BINARY_DIR}/test_pendulum_teleop__${middleware_impl}.py"
+        TIMEOUT 20)
+      set_tests_properties(test_demo_pendulum_teleop__${middleware_impl}
+      PROPERTIES DEPENDS "test_demo_pendulum_teleop__${middleware_impl} test_demo_pendulum_teleop__${middleware_impl}")
+    endif()
   endforeach()
 endif()
 


### PR DESCRIPTION
FastRTPS doesn't (yet) support the use of custom allocators, so it will fail this test, which requires that no actual allocation happens during execution.
