### PR TITLE
use TLSF allocator in demo

### DIFF
--- a/pendulum_control/CMakeLists.txt
+++ b/pendulum_control/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(rclcpp REQUIRED)
 find_package(rmw_implementation_cmake REQUIRED)
 find_package(pendulum_msgs REQUIRED)
 find_package(rttest)
+find_package(tlsf_cpp)
 
 include_directories(include)
 
@@ -33,7 +34,8 @@ macro(targets)
   ament_target_dependencies(pendulum_demo${target_suffix}
     "pendulum_msgs"
     "rclcpp${target_suffix}"
-    "rttest")
+    "rttest"
+    "tlsf_cpp")
 
   add_executable(pendulum_logger${target_suffix}
     src/pendulum_logger.cpp)

--- a/pendulum_control/package.xml
+++ b/pendulum_control/package.xml
@@ -12,10 +12,12 @@
   <build_depend>rmw_implementation_cmake</build_depend>
   <build_depend>pendulum_msgs</build_depend>
   <build_depend>rttest</build_depend>
+  <build_depend>tlsf_cpp</build_depend>
 
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>pendulum_msgs</exec_depend>
   <exec_depend>rttest</exec_depend>
+  <exec_depend>tlsf_cpp</exec_depend>
 
   <test_depend>ament_cmake_nose</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/pendulum_control/src/pendulum_logger.cpp
+++ b/pendulum_control/src/pendulum_logger.cpp
@@ -80,6 +80,7 @@ int main(int argc, char * argv[])
   auto subscription = logger_node->create_subscription<pendulum_msgs::msg::RttestResults>(
     "pendulum_statistics", logging_callback, qos_profile);
 
+  printf("Logger node initialized.\n");
   rclcpp::spin(logger_node);
   fstream.close();
 }


### PR DESCRIPTION
A bit of refactoring to use the TLSF allocator in the pendulum demo.

Should have been done last release, forgot because it wasn't ticketed (except in the tutorial page).

needs ros2/realtime_support#30