### PR TITLE
Remove unused rmw typesupport call

### DIFF
--- a/intra_process_demo/CMakeLists.txt
+++ b/intra_process_demo/CMakeLists.txt
@@ -111,9 +111,6 @@ if(AMENT_ENABLE_TESTING)
         list(APPEND RCLCPP_DEMOS_EXPECTED_OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/test/${executable}")
       endforeach()
 
-      # get typesupport of rmw implementation to include / link against the corresponding interfaces
-      get_rmw_typesupport(typesupport_impl "${rmw_implementation}")
-
       set(RCLCPP_DEMOS_EXECUTABLE "")
       foreach(executable ${demo_executables})
         list(APPEND RCLCPP_DEMOS_EXECUTABLE "$<TARGET_FILE:${executable}${target_suffix}>")


### PR DESCRIPTION
While working on ros2/rmw#63 I noticed that the result of this call is never used, so I'm deleting it.