### PR TITLE
Ensure using correct rmw implementation in tests

### DIFF
--- a/intra_process_demo/CMakeLists.txt
+++ b/intra_process_demo/CMakeLists.txt
@@ -129,7 +129,8 @@ if(BUILD_TESTING)
 
       ament_add_nose_test(test_demo_${exe_list_underscore}${target_suffix}
         "${CMAKE_CURRENT_BINARY_DIR}/test_${exe_list_underscore}${target_suffix}_$<CONFIGURATION>.py"
-        TIMEOUT 30)
+        TIMEOUT 30
+        ENV RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation})
       set_tests_properties(test_demo_${exe_list_underscore}${target_suffix}
         PROPERTIES DEPENDS "test_demo_${exe_list_underscore}${target_suffix} test_demo_${exe_list_underscore}${target_suffix}")
     endforeach()

--- a/pendulum_control/CMakeLists.txt
+++ b/pendulum_control/CMakeLists.txt
@@ -109,13 +109,15 @@ if(BUILD_TESTING)
 
       ament_add_nose_test(test_demo_pendulum__${middleware_impl}
         "${CMAKE_CURRENT_BINARY_DIR}/test_pendulum__${middleware_impl}.py"
-        TIMEOUT 20)
+        TIMEOUT 20
+        ENV RCL_ASSERT_RMW_ID_MATCHES=${middleware_impl})
       set_tests_properties(test_demo_pendulum__${middleware_impl}
       PROPERTIES DEPENDS "test_demo_pendulum__${middleware_impl} test_demo_pendulum__${middleware_impl}")
 
       ament_add_nose_test(test_demo_pendulum_teleop__${middleware_impl}
         "${CMAKE_CURRENT_BINARY_DIR}/test_pendulum_teleop__${middleware_impl}.py"
-        TIMEOUT 20)
+        TIMEOUT 20
+        ENV RCL_ASSERT_RMW_ID_MATCHES=${middleware_impl})
       set_tests_properties(test_demo_pendulum_teleop__${middleware_impl}
       PROPERTIES DEPENDS "test_demo_pendulum_teleop__${middleware_impl} test_demo_pendulum_teleop__${middleware_impl}")
     endif()

--- a/pendulum_control/test/test_pendulum_demo.py.in
+++ b/pendulum_control/test/test_pendulum_demo.py.in
@@ -1,6 +1,7 @@
 import os
 from launch import LaunchDescriptor
 from launch.exit_handler import ignore_exit_handler
+from launch.output_handler import ConsoleOutput
 from launch.launcher import DefaultLauncher
 from launch_testing import create_handler
 
@@ -24,7 +25,7 @@ def test_executable():
         cmd=[pendulum_logger_executable],
         name=pendulum_logger_name,
         exit_handler=ignore_exit_handler,
-        output_handlers=[pendulum_logger_handler],
+        output_handlers=[pendulum_logger_handler, ConsoleOutput()],
     )
 
     pendulum_demo_executable = '@RCLCPP_DEMO_PENDULUM_DEMO_EXECUTABLE@'
@@ -37,7 +38,7 @@ def test_executable():
         cmd=[pendulum_demo_executable, '-i', '1000'],
         name=pendulum_demo_name,
         exit_handler=ignore_exit_handler,
-        output_handlers=[pendulum_demo_handler],
+        output_handlers=[pendulum_demo_handler, ConsoleOutput()],
     )
 
     launcher = DefaultLauncher()

--- a/pendulum_control/test/test_pendulum_demo.py.in
+++ b/pendulum_control/test/test_pendulum_demo.py.in
@@ -1,8 +1,10 @@
 import os
+
 from launch import LaunchDescriptor
 from launch.exit_handler import ignore_exit_handler
-from launch.output_handler import ConsoleOutput
 from launch.launcher import DefaultLauncher
+from launch.output_handler import ConsoleOutput
+
 from launch_testing import create_handler
 
 

--- a/pendulum_control/test/test_pendulum_teleop.py.in
+++ b/pendulum_control/test/test_pendulum_teleop.py.in
@@ -3,6 +3,7 @@ import sys
 
 from launch import LaunchDescriptor
 from launch.exit_handler import ignore_exit_handler
+from launch.output_handler import ConsoleOutput
 from launch.launcher import DefaultLauncher
 from launch_testing import create_handler
 
@@ -26,7 +27,7 @@ def test_executable():
         cmd=[pendulum_demo_executable, '-i', '0'],
         name=pendulum_demo_name,
         exit_handler=ignore_exit_handler,
-        output_handlers=[pendulum_demo_handler],
+        output_handlers=[pendulum_demo_handler, ConsoleOutput()],
     )
 
     pendulum_teleop_executable = '@RCLCPP_DEMO_PENDULUM_TELEOP_EXECUTABLE@'
@@ -42,7 +43,7 @@ def test_executable():
         cmd=[sys.executable, execute_with_delay_command, '500', pendulum_teleop_executable, '100'],
         name=pendulum_teleop_name,
         exit_handler=ignore_exit_handler,
-        output_handlers=[pendulum_teleop_handler],
+        output_handlers=[pendulum_teleop_handler, ConsoleOutput()],
     )
 
     launcher = DefaultLauncher()

--- a/pendulum_control/test/test_pendulum_teleop.py.in
+++ b/pendulum_control/test/test_pendulum_teleop.py.in
@@ -3,8 +3,9 @@ import sys
 
 from launch import LaunchDescriptor
 from launch.exit_handler import ignore_exit_handler
-from launch.output_handler import ConsoleOutput
 from launch.launcher import DefaultLauncher
+from launch.output_handler import ConsoleOutput
+
 from launch_testing import create_handler
 
 


### PR DESCRIPTION
Have been discussing adding image_tools tests with @wjwwood but in the meantime this is the change for the existing tests.

Connects to ros2/examples#96