### PR TITLE
Fix flaky test in pendulum demo

### DIFF
--- a/pendulum_control/test/pendulum_demo.regex
+++ b/pendulum_control/test/pendulum_demo.regex
@@ -7,7 +7,7 @@ rttest statistics:
     - Min: \d+ ns
     - Max: \d+ ns
     - Mean: \d+.\d+ ns
-    - Standard deviation: \d+\.\d+(e\+\d+)?
+    - Standard deviation: \d+(\.\d+)?(e[\+\-]\d+)?
 
 
 PendulumMotor received \d+ messages


### PR DESCRIPTION
The output regex was a bit too strict.. not a common point of failure but I have on at least one occasion gotten:
```
5: [test_executable_1] Latency (time after deadline was missed):
5: [test_executable_1] - Min: 6774 ns
5: [test_executable_1] - Max: 2951825 ns
5: [test_executable_1] - Mean: 65343.5 ns
5: [test_executable_1] - Standard deviation: 1370
```
instead of the more common standard deviation format of 1367.81 or 1.35819e+08, for example.


http://ci.ros2.org/job/ci_linux/1386/ has finished without issues but I've triggered another round since #70 was merged:

[![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=1387)](http://ci.ros2.org/job/ci_linux/1387/)
[![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1084)](http://ci.ros2.org/job/ci_osx/1084/)
[![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=1398)](http://ci.ros2.org/job/ci_windows/1398/)