### PR TITLE
Prevent pendulum_control demos from using typesupport introspection

### DIFF
--- a/pendulum_control/CMakeLists.txt
+++ b/pendulum_control/CMakeLists.txt
@@ -32,23 +32,23 @@ macro(targets)
   add_executable(pendulum_demo${target_suffix}
     src/pendulum_demo.cpp)
   ament_target_dependencies(pendulum_demo${target_suffix}
-    "pendulum_msgs"
     "rclcpp${target_suffix}"
+    "pendulum_msgs"
     "rttest"
     "tlsf_cpp")
 
   add_executable(pendulum_logger${target_suffix}
     src/pendulum_logger.cpp)
   ament_target_dependencies(pendulum_logger${target_suffix}
-    "pendulum_msgs"
     "rclcpp${target_suffix}"
+    "pendulum_msgs"
     "rttest")
 
   add_executable(pendulum_teleop${target_suffix}
     src/pendulum_teleop.cpp)
   ament_target_dependencies(pendulum_teleop${target_suffix}
-    "pendulum_msgs"
     "rclcpp${target_suffix}"
+    "pendulum_msgs"
     "rttest")
 
   install(TARGETS

--- a/pendulum_control/test/test_pendulum_demo.py.in
+++ b/pendulum_control/test/test_pendulum_demo.py.in
@@ -20,6 +20,7 @@ def test_executable():
 
     launch_descriptor = LaunchDescriptor()
 
+    rmw_implementation = '@rmw_implementation@'
     pendulum_logger_executable = '@RCLCPP_DEMO_PENDULUM_LOGGER_EXECUTABLE@'
     pendulum_logger_output_file = '@RCLCPP_DEMO_PENDULUM_LOGGER_EXPECTED_OUTPUT@'
     pendulum_logger_name = 'test_executable_0'
@@ -36,7 +37,9 @@ def test_executable():
     pendulum_demo_executable = '@RCLCPP_DEMO_PENDULUM_DEMO_EXECUTABLE@'
     pendulum_demo_output_file = '@RCLCPP_DEMO_PENDULUM_DEMO_EXPECTED_OUTPUT@'
     pendulum_demo_name = 'test_executable_1'
-    pendulum_demo_handler = create_handler(pendulum_demo_name, launch_descriptor, pendulum_demo_output_file)
+    pendulum_demo_handler = create_handler(
+        pendulum_demo_name, launch_descriptor, pendulum_demo_output_file,
+        filtered_rmw_implementation=rmw_implementation)
     assert pendulum_demo_handler, 'Cannot find appropriate handler for %s' % pendulum_demo_output_file
     output_handlers.append(pendulum_demo_handler)
     launch_descriptor.add_process(

--- a/pendulum_control/test/test_pendulum_teleop.py.in
+++ b/pendulum_control/test/test_pendulum_teleop.py.in
@@ -21,6 +21,7 @@ def test_executable():
 
     launch_descriptor = LaunchDescriptor()
 
+    rmw_implementation = '@rmw_implementation@'
     pendulum_demo_executable = '@RCLCPP_DEMO_PENDULUM_DEMO_EXECUTABLE@'
     pendulum_demo_output_file = '@RCLCPP_DEMO_PENDULUM_DEMO_TELEOP_EXPECTED_OUTPUT@'
     pendulum_demo_name = 'test_executable_0'
@@ -37,7 +38,9 @@ def test_executable():
     pendulum_teleop_executable = '@RCLCPP_DEMO_PENDULUM_TELEOP_EXECUTABLE@'
     pendulum_teleop_output_file = '@RCLCPP_DEMO_PENDULUM_TELEOP_EXPECTED_OUTPUT@'
     pendulum_teleop_name = 'test_executable_1'
-    pendulum_teleop_handler = create_handler(pendulum_teleop_name, launch_descriptor, pendulum_teleop_output_file)
+    pendulum_teleop_handler = create_handler(
+        pendulum_teleop_name, launch_descriptor, pendulum_teleop_output_file,
+        filtered_rmw_implementation=rmw_implementation)
     assert pendulum_teleop_handler, 'Cannot find appropriate handler for %s' % pendulum_teleop_output_file
     output_handlers.append(pendulum_teleop_handler)
     execute_with_delay_command = os.path.join(


### PR DESCRIPTION
[This commit](https://github.com/ros2/rosidl/pull/158/commits/1e4b0741cbd82da5e62b0822ab24f293ede12ba4#diff-4845b4409f48ba8429ddbfdb2d93816fR8) caused pendulum_control tests to start failing for rmw implementations without typesupport introspection support e.g. http://ci.ros2.org/job/ci_linux/1615/testReport/(root)/projectroot/test_demo_pendulum_teleop__rmw_connext_cpp/

This fixes the failing `pendulum_control` tests for connext static (and opensplice). 

http://ci.ros2.org/job/ci_linux/1627/testReport/ (pendulum demos don't run on windows or os x)

(after approved I'll fix the commit history)