### PR TITLE
(fix) quickfix for printing error message on windows

### DIFF
--- a/intra_process_demo/src/image_pipeline/camera_node.cpp
+++ b/intra_process_demo/src/image_pipeline/camera_node.cpp
@@ -21,7 +21,16 @@
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
-  auto camera_node = std::make_shared<CameraNode>("image");
-  rclcpp::spin(camera_node);
-  return 0;
+  try
+  {
+    auto camera_node = std::make_shared<CameraNode>("image");
+    rclcpp::spin(camera_node);
+    return 0;
+  }
+  catch( const std::exception& e )
+  {
+    fprintf(stderr, "Failed to open camera node. Exiting..\n");
+    return 1;
+  }
+  
 }

--- a/intra_process_demo/src/image_pipeline/camera_node.cpp
+++ b/intra_process_demo/src/image_pipeline/camera_node.cpp
@@ -21,16 +21,15 @@
 int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
-  try
-  {
-    auto camera_node = std::make_shared<CameraNode>("image");
-    rclcpp::spin(camera_node);
-    return 0;
-  }
-  catch( const std::exception& e )
-  {
-    fprintf(stderr, "Failed to open camera node. Exiting..\n");
+
+  std::shared_ptr<CameraNode> camera_node = nullptr;
+  try {
+    camera_node = std::make_shared<CameraNode>("image");
+  } catch (const std::exception & e) {
+    fprintf(stderr, "%s Exiting..\n", e.what());
     return 1;
   }
-  
+
+  rclcpp::spin(camera_node);
+  return 0;
 }

--- a/intra_process_demo/src/image_pipeline/image_pipeline_all_in_one.cpp
+++ b/intra_process_demo/src/image_pipeline/image_pipeline_all_in_one.cpp
@@ -26,15 +26,23 @@ int main(int argc, char * argv[])
   rclcpp::executors::SingleThreadedExecutor executor;
 
   // Connect the nodes as a pipeline: camera_node -> watermark_node -> image_view_node
-  auto camera_node = std::make_shared<CameraNode>("image");
-  auto watermark_node =
-    std::make_shared<WatermarkNode>("image", "watermarked_image", "Hello world!");
-  auto image_view_node = std::make_shared<ImageViewNode>("watermarked_image");
+  try
+  {
+    auto camera_node = std::make_shared<CameraNode>("image");
+    auto watermark_node =
+      std::make_shared<WatermarkNode>("image", "watermarked_image", "Hello world!");
+    auto image_view_node = std::make_shared<ImageViewNode>("watermarked_image");
 
-  executor.add_node(camera_node);
-  executor.add_node(watermark_node);
-  executor.add_node(image_view_node);
+    executor.add_node(camera_node);
+    executor.add_node(watermark_node);
+    executor.add_node(image_view_node);
 
-  executor.spin();
-  return 0;
+    executor.spin();
+    return 0;
+  }
+  catch( const std::exception& e )
+  {
+    fprintf(stderr, "Failed to open camera node. Exiting..\n");
+    return 1;
+  }
 }

--- a/intra_process_demo/src/image_pipeline/image_pipeline_all_in_one.cpp
+++ b/intra_process_demo/src/image_pipeline/image_pipeline_all_in_one.cpp
@@ -26,23 +26,21 @@ int main(int argc, char * argv[])
   rclcpp::executors::SingleThreadedExecutor executor;
 
   // Connect the nodes as a pipeline: camera_node -> watermark_node -> image_view_node
-  try
-  {
-    auto camera_node = std::make_shared<CameraNode>("image");
-    auto watermark_node =
-      std::make_shared<WatermarkNode>("image", "watermarked_image", "Hello world!");
-    auto image_view_node = std::make_shared<ImageViewNode>("watermarked_image");
-
-    executor.add_node(camera_node);
-    executor.add_node(watermark_node);
-    executor.add_node(image_view_node);
-
-    executor.spin();
-    return 0;
-  }
-  catch( const std::exception& e )
-  {
-    fprintf(stderr, "Failed to open camera node. Exiting..\n");
+  std::shared_ptr<CameraNode> camera_node = nullptr;
+  try {
+    camera_node = std::make_shared<CameraNode>("image");
+  } catch (const std::exception & e) {
+    fprintf(stderr, "%s Exiting ..\n", e.what());
     return 1;
   }
+  auto watermark_node =
+    std::make_shared<WatermarkNode>("image", "watermarked_image", "Hello world!");
+  auto image_view_node = std::make_shared<ImageViewNode>("watermarked_image");
+
+  executor.add_node(camera_node);
+  executor.add_node(watermark_node);
+  executor.add_node(image_view_node);
+
+  executor.spin();
+  return 0;
 }

--- a/intra_process_demo/src/image_pipeline/image_pipeline_with_two_image_view.cpp
+++ b/intra_process_demo/src/image_pipeline/image_pipeline_with_two_image_view.cpp
@@ -27,17 +27,25 @@ int main(int argc, char * argv[])
 
   // Connect the nodes as a pipeline: camera_node -> watermark_node -> image_view_node
   // And the extra image view as a fork:                           \-> image_view_node2
-  auto camera_node = std::make_shared<CameraNode>("image");
-  auto watermark_node =
-    std::make_shared<WatermarkNode>("image", "watermarked_image", "Hello world!");
-  auto image_view_node = std::make_shared<ImageViewNode>("watermarked_image");
-  auto image_view_node2 = std::make_shared<ImageViewNode>("watermarked_image", "image_view_node2");
+  try
+  {
+    auto camera_node = std::make_shared<CameraNode>("image");
+    auto watermark_node =
+      std::make_shared<WatermarkNode>("image", "watermarked_image", "Hello world!");
+    auto image_view_node = std::make_shared<ImageViewNode>("watermarked_image");
+    auto image_view_node2 = std::make_shared<ImageViewNode>("watermarked_image", "image_view_node2");
 
-  executor.add_node(camera_node);
-  executor.add_node(watermark_node);
-  executor.add_node(image_view_node);
-  executor.add_node(image_view_node2);
+    executor.add_node(camera_node);
+    executor.add_node(watermark_node);
+    executor.add_node(image_view_node);
+    executor.add_node(image_view_node2);
 
-  executor.spin();
-  return 0;
+    executor.spin();
+    return 0;
+  }
+  catch( const std::exception& e )
+  {
+    fprintf(stderr, "Failed to open camera node. Exiting..\n");
+    return 1;
+  }
 }

--- a/intra_process_demo/src/image_pipeline/image_pipeline_with_two_image_view.cpp
+++ b/intra_process_demo/src/image_pipeline/image_pipeline_with_two_image_view.cpp
@@ -27,25 +27,23 @@ int main(int argc, char * argv[])
 
   // Connect the nodes as a pipeline: camera_node -> watermark_node -> image_view_node
   // And the extra image view as a fork:                           \-> image_view_node2
-  try
-  {
-    auto camera_node = std::make_shared<CameraNode>("image");
-    auto watermark_node =
-      std::make_shared<WatermarkNode>("image", "watermarked_image", "Hello world!");
-    auto image_view_node = std::make_shared<ImageViewNode>("watermarked_image");
-    auto image_view_node2 = std::make_shared<ImageViewNode>("watermarked_image", "image_view_node2");
-
-    executor.add_node(camera_node);
-    executor.add_node(watermark_node);
-    executor.add_node(image_view_node);
-    executor.add_node(image_view_node2);
-
-    executor.spin();
-    return 0;
-  }
-  catch( const std::exception& e )
-  {
-    fprintf(stderr, "Failed to open camera node. Exiting..\n");
+  std::shared_ptr<CameraNode> camera_node = nullptr;
+  try {
+    camera_node = std::make_shared<CameraNode>("image");
+  } catch (const std::exception & e) {
+    fprintf(stderr, "%s Exiting..\n", e.what());
     return 1;
   }
+  auto watermark_node =
+    std::make_shared<WatermarkNode>("image", "watermarked_image", "Hello world!");
+  auto image_view_node = std::make_shared<ImageViewNode>("watermarked_image");
+  auto image_view_node2 = std::make_shared<ImageViewNode>("watermarked_image", "image_view_node2");
+
+  executor.add_node(camera_node);
+  executor.add_node(watermark_node);
+  executor.add_node(image_view_node);
+  executor.add_node(image_view_node2);
+
+  executor.spin();
+  return 0;
 }


### PR DESCRIPTION
not the most elegant solution, but it works and correctly prints the error message on windows. The tutorials are complete and do make sense to the users with this.

see https://github.com/ros2/demos/issues/68