### PR TITLE
Consistent naming when using CMake variable for rmw implementation

### DIFF
--- a/image_tools/CMakeLists.txt
+++ b/image_tools/CMakeLists.txt
@@ -55,9 +55,9 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   # get the rmw implementations ahead of time
-  get_available_rmw_implementations(middleware_implementations)
-  foreach(middleware_impl ${middleware_implementations})
-    find_package("${middleware_impl}" REQUIRED)
+  get_available_rmw_implementations(rmw_implementations)
+  foreach(rmw_implementation ${rmw_implementations})
+    find_package("${rmw_implementation}" REQUIRED)
   endforeach()
 
   # These are the regex's for validating the output of the executables.

--- a/pendulum_control/CMakeLists.txt
+++ b/pendulum_control/CMakeLists.txt
@@ -73,9 +73,9 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   # get the rmw implementations ahead of time
-  get_available_rmw_implementations(middleware_implementations)
-  foreach(middleware_impl ${middleware_implementations})
-    find_package("${middleware_impl}" REQUIRED)
+  get_available_rmw_implementations(rmw_implementations)
+  foreach(rmw_implementation ${rmw_implementations})
+    find_package("${rmw_implementation}" REQUIRED)
   endforeach()
 
   set(RCLCPP_DEMO_PENDULUM_LOGGER_EXPECTED_OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/test/pendulum_logger")
@@ -83,24 +83,24 @@ if(BUILD_TESTING)
   set(RCLCPP_DEMO_PENDULUM_DEMO_TELEOP_EXPECTED_OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/test/pendulum_demo_teleop")
   set(RCLCPP_DEMO_PENDULUM_TELEOP_EXPECTED_OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/test/pendulum_teleop")
 
-  foreach(middleware_impl ${middleware_implementations})
+  foreach(rmw_implementation ${rmw_implementations})
     # FastRTPS doesn't (yet) support the use of custom allocators, so it will
     # fail this test, which requires that no actual allocation happens during
     # execution.
-    if(NOT ${middleware_impl} STREQUAL "rmw_fastrtps_cpp")
-      set(RCLCPP_DEMO_PENDULUM_LOGGER_EXECUTABLE "${CMAKE_CURRENT_BINARY_DIR}/pendulum_logger__${middleware_impl}")
-      set(RCLCPP_DEMO_PENDULUM_DEMO_EXECUTABLE "${CMAKE_CURRENT_BINARY_DIR}/pendulum_demo__${middleware_impl}")
-      set(RCLCPP_DEMO_PENDULUM_TELEOP_EXECUTABLE "${CMAKE_CURRENT_BINARY_DIR}/pendulum_teleop__${middleware_impl}")
+    if(NOT ${rmw_implementation} STREQUAL "rmw_fastrtps_cpp")
+      set(RCLCPP_DEMO_PENDULUM_LOGGER_EXECUTABLE "${CMAKE_CURRENT_BINARY_DIR}/pendulum_logger__${rmw_implementation}")
+      set(RCLCPP_DEMO_PENDULUM_DEMO_EXECUTABLE "${CMAKE_CURRENT_BINARY_DIR}/pendulum_demo__${rmw_implementation}")
+      set(RCLCPP_DEMO_PENDULUM_TELEOP_EXECUTABLE "${CMAKE_CURRENT_BINARY_DIR}/pendulum_teleop__${rmw_implementation}")
 
       configure_file(
         test/test_pendulum_demo.py.in
-        test_pendulum__${middleware_impl}.py
+        test_pendulum__${rmw_implementation}.py
         @ONLY
       )
 
       configure_file(
         test/test_pendulum_teleop.py.in
-        test_pendulum_teleop__${middleware_impl}.py
+        test_pendulum_teleop__${rmw_implementation}.py
         @ONLY
       )
 
@@ -109,22 +109,22 @@ if(BUILD_TESTING)
         execute_with_delay.py
       )
 
-      file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_demo_pendulum__${middleware_impl}")
-      ament_add_nose_test(test_demo_pendulum__${middleware_impl}
-        "${CMAKE_CURRENT_BINARY_DIR}/test_pendulum__${middleware_impl}.py"
+      file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_demo_pendulum__${rmw_implementation}")
+      ament_add_nose_test(test_demo_pendulum__${rmw_implementation}
+        "${CMAKE_CURRENT_BINARY_DIR}/test_pendulum__${rmw_implementation}.py"
         TIMEOUT 20
-        ENV RCL_ASSERT_RMW_ID_MATCHES=${middleware_impl}
+        ENV RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
         # since the test generates a .csv file in the cwd
-        WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_demo_pendulum__${middleware_impl}")
-      set_tests_properties(test_demo_pendulum__${middleware_impl}
-      PROPERTIES DEPENDS "test_demo_pendulum__${middleware_impl} test_demo_pendulum__${middleware_impl}")
+        WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_demo_pendulum__${rmw_implementation}")
+      set_tests_properties(test_demo_pendulum__${rmw_implementation}
+      PROPERTIES DEPENDS "test_demo_pendulum__${rmw_implementation} test_demo_pendulum__${rmw_implementation}")
 
-      ament_add_nose_test(test_demo_pendulum_teleop__${middleware_impl}
-        "${CMAKE_CURRENT_BINARY_DIR}/test_pendulum_teleop__${middleware_impl}.py"
+      ament_add_nose_test(test_demo_pendulum_teleop__${rmw_implementation}
+        "${CMAKE_CURRENT_BINARY_DIR}/test_pendulum_teleop__${rmw_implementation}.py"
         TIMEOUT 20
-        ENV RCL_ASSERT_RMW_ID_MATCHES=${middleware_impl})
-      set_tests_properties(test_demo_pendulum_teleop__${middleware_impl}
-      PROPERTIES DEPENDS "test_demo_pendulum_teleop__${middleware_impl} test_demo_pendulum_teleop__${middleware_impl}")
+        ENV RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation})
+      set_tests_properties(test_demo_pendulum_teleop__${rmw_implementation}
+      PROPERTIES DEPENDS "test_demo_pendulum_teleop__${rmw_implementation} test_demo_pendulum_teleop__${rmw_implementation}")
     endif()
   endforeach()
 endif()


### PR DESCRIPTION
The pendulum demo_teleop test was failing in http://ci.ros2.org/job/ci_linux/1819/ because `rmw_implementation` was being templated into [the test script](https://github.com/ros2/demos/blob/700e32d0c55df515c83a59c03a33dce321299abb/pendulum_control/test/test_pendulum_teleop.py.in) instead of `middleware_impl`.

I've unified these two variables so that the correct RMW implementation's output is filtered, and furthermore so mistakes like this don't happen again. I've extended the change to other packages too that were using the two variables.

Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=1823)](http://ci.ros2.org/job/ci_linux/1823/)
OS X [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1359)](http://ci.ros2.org/job/ci_osx/1359/)
Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=1732)](http://ci.ros2.org/job/ci_windows/1732/)