### PR TITLE
add composition use cases

### DIFF
--- a/composition/CMakeLists.txt
+++ b/composition/CMakeLists.txt
@@ -1,0 +1,168 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(composition)
+
+if(NOT WIN32)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(ament_index_cpp REQUIRED)
+find_package(class_loader REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rmw_implementation_cmake REQUIRED)
+find_package(rosidl_cmake REQUIRED)
+find_package(std_msgs REQUIRED)
+
+# get the rmw implementations ahead of time
+find_package(rmw_implementation_cmake REQUIRED)
+get_available_rmw_implementations(rmw_implementations)
+foreach(rmw_implementation ${rmw_implementations})
+  find_package("${rmw_implementation}" REQUIRED)
+endforeach()
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "srv/LoadNode.srv"
+)
+
+include_directories(include)
+
+# create ament index resource which references the libraries in the binary dir
+set(node_plugins "")
+
+macro(targets)
+  get_rclcpp_information("${rmw_implementation}" "rclcpp${target_suffix}")
+
+  add_library(talker_component${target_suffix} SHARED
+    src/talker_component.cpp)
+  target_compile_definitions(talker_component${target_suffix}
+    PRIVATE "COMPOSITION_BUILDING_DLL")
+  ament_target_dependencies(talker_component${target_suffix}
+    "rclcpp${target_suffix}"
+    "std_msgs"
+    "class_loader")
+  rclcpp_register_node_plugins(talker_component${target_suffix} "composition::Talker${target_suffix}")
+  set(node_plugins "${node_plugins}composition::Talker${target_suffix};$<TARGET_FILE:talker_component${target_suffix}>\n")
+
+  add_library(listener_component${target_suffix} SHARED
+    src/listener_component.cpp)
+  target_compile_definitions(listener_component${target_suffix}
+    PRIVATE "COMPOSITION_BUILDING_DLL")
+  ament_target_dependencies(listener_component${target_suffix}
+    "rclcpp${target_suffix}"
+    "std_msgs"
+    "class_loader")
+  rclcpp_register_node_plugins(listener_component${target_suffix} "composition::Listener${target_suffix}")
+  set(node_plugins "${node_plugins}composition::Listener${target_suffix};$<TARGET_FILE:listener_component${target_suffix}>\n")
+
+  add_executable(manual_composition${target_suffix}
+    src/manual_composition.cpp)
+  target_link_libraries(manual_composition${target_suffix}
+    talker_component${target_suffix}
+    listener_component${target_suffix})
+  ament_target_dependencies(manual_composition${target_suffix}
+    "rclcpp${target_suffix}")
+
+  add_executable(linktime_composition${target_suffix}
+    src/linktime_composition.cpp)
+  set(libs
+    talker_component${target_suffix}
+    listener_component${target_suffix})
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(libs
+      "-Wl,--no-as-needed"
+      ${libs}
+      "-Wl,--as-needed")
+  endif()
+  target_link_libraries(linktime_composition${target_suffix} ${libs})
+  ament_target_dependencies(linktime_composition${target_suffix}
+    "rclcpp${target_suffix}"
+    "class_loader")
+
+  add_executable(dlopen_composition${target_suffix}
+    src/dlopen_composition.cpp)
+  ament_target_dependencies(dlopen_composition${target_suffix}
+    "rclcpp${target_suffix}"
+    "class_loader")
+
+  add_executable(api_composition${target_suffix}
+    src/api_composition.cpp)
+  if(NOT "${target_suffix}" STREQUAL "")
+    target_compile_definitions(api_composition${target_suffix}
+      PRIVATE "RMW_IMPLEMENTATION_SUFFIX=${target_suffix}")
+  endif()
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_link_libraries(api_composition${target_suffix} "stdc++fs")
+  endif()
+  ament_target_dependencies(api_composition${target_suffix}
+    "rclcpp${target_suffix}"
+    "ament_index_cpp"
+    "class_loader")
+  get_rmw_typesupport(typesupport_impls "${rmw_implementation}" LANGUAGE "cpp")
+  foreach(typesupport_impl ${typesupport_impls})
+    rosidl_target_interfaces(api_composition${target_suffix}
+      ${PROJECT_NAME} ${typesupport_impl})
+  endforeach()
+
+  add_executable(api_composition_cli${target_suffix}
+    src/api_composition_cli.cpp)
+  ament_target_dependencies(api_composition_cli${target_suffix}
+    "rclcpp${target_suffix}")
+  get_rmw_typesupport(typesupport_impls "${rmw_implementation}" LANGUAGE "cpp")
+  foreach(typesupport_impl ${typesupport_impls})
+    rosidl_target_interfaces(api_composition_cli${target_suffix}
+      ${PROJECT_NAME} ${typesupport_impl})
+  endforeach()
+
+  install(TARGETS
+    talker_component${target_suffix}
+    listener_component${target_suffix}
+    manual_composition${target_suffix}
+    linktime_composition${target_suffix}
+    dlopen_composition${target_suffix}
+    api_composition${target_suffix}
+    api_composition_cli${target_suffix}
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin)
+endmacro()
+
+call_for_each_rmw_implementation(targets GENERATE_DEFAULT)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  file(GENERATE
+    OUTPUT
+    "test_ament_index/$<CONFIG>/share/ament_index/resource_index/node_plugin/${PROJECT_NAME}"
+    CONTENT "${node_plugins}")
+
+  macro(tests)
+    set(MANUAL_COMPOSITION_EXECUTABLE $<TARGET_FILE:manual_composition${target_suffix}>)
+    set(LINKTIME_COMPOSITION_EXECUTABLE $<TARGET_FILE:linktime_composition${target_suffix}>)
+    set(DLOPEN_COMPOSITION_EXECUTABLE $<TARGET_FILE:dlopen_composition${target_suffix}>)
+    set(TALKER_LIBRARY $<TARGET_FILE:talker_component${target_suffix}>)
+    set(LISTENER_LIBRARY $<TARGET_FILE:listener_component${target_suffix}>)
+    set(API_COMPOSITION_EXECUTABLE $<TARGET_FILE:api_composition${target_suffix}>)
+    set(API_COMPOSITION_CLI_EXECUTABLE $<TARGET_FILE:api_composition_cli${target_suffix}>)
+    set(EXPECTED_OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/test/composition")
+
+    configure_file(
+      test/test_composition.py.in
+      test_composition${target_suffix}.py.genexp
+      @ONLY
+    )
+    file(GENERATE
+      OUTPUT test_composition${target_suffix}_$<CONFIGURATION>.py
+      INPUT test_composition${target_suffix}.py.genexp)
+    ament_add_nose_test(test_composition${target_suffix}
+      "${CMAKE_CURRENT_BINARY_DIR}/test_composition${target_suffix}_$<CONFIGURATION>.py"
+      APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/test_ament_index/$<CONFIG>
+      TIMEOUT 60)
+  endmacro()
+
+  call_for_each_rmw_implementation(tests)
+endif()
+
+ament_package()

--- a/composition/include/composition/listener_component.hpp
+++ b/composition/include/composition/listener_component.hpp
@@ -1,0 +1,37 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COMPOSITION__LISTENER_COMPONENT_HPP_
+#define COMPOSITION__LISTENER_COMPONENT_HPP_
+
+#include "composition/visibility_control.h"
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/string.hpp"
+
+namespace composition
+{
+
+class Listener : public rclcpp::Node
+{
+public:
+  COMPOSITION_PUBLIC
+  Listener();
+
+private:
+  rclcpp::subscription::Subscription<std_msgs::msg::String>::SharedPtr sub_;
+};
+
+}  // namespace composition
+
+#endif  // COMPOSITION__LISTENER_COMPONENT_HPP_

--- a/composition/include/composition/talker_component.hpp
+++ b/composition/include/composition/talker_component.hpp
@@ -1,0 +1,42 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COMPOSITION__TALKER_COMPONENT_HPP_
+#define COMPOSITION__TALKER_COMPONENT_HPP_
+
+#include "composition/visibility_control.h"
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/string.hpp"
+
+namespace composition
+{
+
+class Talker : public rclcpp::Node
+{
+public:
+  COMPOSITION_PUBLIC
+  Talker();
+
+protected:
+  void on_timer();
+
+private:
+  size_t count_;
+  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr pub_;
+  rclcpp::timer::TimerBase::SharedPtr timer_;
+};
+
+}  // namespace composition
+
+#endif  // COMPOSITION__TALKER_COMPONENT_HPP_

--- a/composition/include/composition/visibility_control.h
+++ b/composition/include/composition/visibility_control.h
@@ -1,0 +1,58 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COMPOSITION__VISIBILITY_CONTROL_H_
+#define COMPOSITION__VISIBILITY_CONTROL_H_
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define COMPOSITION_EXPORT __attribute__ ((dllexport))
+    #define COMPOSITION_IMPORT __attribute__ ((dllimport))
+  #else
+    #define COMPOSITION_EXPORT __declspec(dllexport)
+    #define COMPOSITION_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef COMPOSITION_BUILDING_DLL
+    #define COMPOSITION_PUBLIC COMPOSITION_EXPORT
+  #else
+    #define COMPOSITION_PUBLIC COMPOSITION_IMPORT
+  #endif
+  #define COMPOSITION_PUBLIC_TYPE COMPOSITION_PUBLIC
+  #define COMPOSITION_LOCAL
+#else
+  #define COMPOSITION_EXPORT __attribute__ ((visibility("default")))
+  #define COMPOSITION_IMPORT
+  #if __GNUC__ >= 4
+    #define COMPOSITION_PUBLIC __attribute__ ((visibility("default")))
+    #define COMPOSITION_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define COMPOSITION_PUBLIC
+    #define COMPOSITION_LOCAL
+  #endif
+  #define COMPOSITION_PUBLIC_TYPE
+#endif
+
+#if __cplusplus
+}
+#endif
+
+#endif  // COMPOSITION__VISIBILITY_CONTROL_H_

--- a/composition/package.xml
+++ b/composition/package.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>composition</name>
+  <version>0.0.0</version>
+  <description>Examples for composing multiple nodes in a single process.</description>
+  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>ament_index_cpp</build_depend>
+  <build_depend>class_loader</build_depend>
+  <build_depend>rclcpp</build_depend>
+  <build_depend>rmw_implementation_cmake</build_depend>
+  <build_depend>rosidl_cmake</build_depend>
+  <build_depend>std_msgs</build_depend>
+
+  <exec_depend>ament_index_cpp</exec_depend>
+  <exec_depend>class_loader</exec_depend>
+  <exec_depend>rclcpp</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+
+  <test_depend>ament_cmake_nose</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>launch</test_depend>
+  <test_depend>launch_testing</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/composition/src/api_composition.cpp
+++ b/composition/src/api_composition.cpp
@@ -12,7 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <experimental/filesystem>
+#ifdef __clang__
+// TODO(dirk-thomas) custom implementation until we can use libc++ 3.9
+#include <string>
+namespace fs
+{
+class path
+{
+public:
+  explicit path(const std::string & p)
+  : path_(p)
+  {}
+  bool is_absolute()
+  {
+    return path_[0] == '/';
+  }
+
+private:
+  std::string path_;
+};
+}  // namespace fs
+#else
+# include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#endif
+
 #include <cstring>
 #include <memory>
 #include <sstream>
@@ -31,8 +55,6 @@
 #define STRINGIFY(s) ""
 #endif
 const char * executable_suffix = STRINGIFY(RMW_IMPLEMENTATION_SUFFIX);
-
-namespace fs = std::experimental::filesystem;
 
 
 std::vector<std::string> split(

--- a/composition/src/api_composition.cpp
+++ b/composition/src/api_composition.cpp
@@ -1,0 +1,152 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <experimental/filesystem>
+#include <cstring>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "ament_index_cpp/get_resource.hpp"
+#include "class_loader/class_loader.h"
+#include "composition/srv/load_node.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+#ifdef RMW_IMPLEMENTATION_SUFFIX
+#define STRINGIFY_(s) #s
+#define STRINGIFY(s) STRINGIFY_(s)
+#else
+#define STRINGIFY(s) ""
+#endif
+const char * executable_suffix = STRINGIFY(RMW_IMPLEMENTATION_SUFFIX);
+
+namespace fs = std::experimental::filesystem;
+
+
+std::vector<std::string> split(
+  const std::string & s, char delim, bool skip_empty = false)
+{
+  std::vector<std::string> result;
+  std::stringstream ss;
+  ss.str(s);
+  std::string item;
+  while (std::getline(ss, item, delim)) {
+    if (skip_empty && item == "") {
+      continue;
+    }
+    result.push_back(item);
+  }
+  return result;
+}
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  auto node = rclcpp::Node::make_shared("api_composition");
+
+  rclcpp::executors::SingleThreadedExecutor exec;
+  exec.add_node(node);
+
+  std::vector<class_loader::ClassLoader *> loaders;
+  std::vector<std::shared_ptr<rclcpp::Node>> nodes;
+
+  auto server = node->create_service<composition::srv::LoadNode>(
+    "load_node",
+    [&exec, &loaders, &nodes](
+      const std::shared_ptr<rmw_request_id_t>,
+      const std::shared_ptr<composition::srv::LoadNode::Request> request,
+      std::shared_ptr<composition::srv::LoadNode::Response> response)
+  {
+    // get node plugin resource from package
+    std::string content;
+    std::string base_path;
+    if (!ament_index_cpp::get_resource("node_plugin", request->package_name, content, &base_path)) {
+      fprintf(stderr, "Could not find requested resource in ament index\n");
+      response->success = false;
+      return;
+    }
+
+    std::string plugin_name = request->plugin_name + executable_suffix;
+    std::vector<std::string> lines = split(content, '\n', true);
+    for (auto line : lines) {
+      std::vector<std::string> parts = split(line, ';');
+      if (parts.size() != 2) {
+        fprintf(stderr, "Invalid resource entry\n");
+        response->success = false;
+        return;
+      }
+      // match plugin name with the same rmw suffix as this executable
+      if (parts[0] != plugin_name) {
+        continue;
+      }
+
+      // remove rmw suffix from plugin name to match registered class name
+      std::string class_name = parts[0].substr(
+        0, parts[0].length() - strlen(executable_suffix));
+
+      // load node plugin
+      std::string library_path = parts[1];
+      if (!fs::path(library_path).is_absolute()) {
+        library_path = base_path + "/" + library_path;
+      }
+      printf("Load library %s\n", library_path.c_str());
+      class_loader::ClassLoader * loader;
+      try {
+        loader = new class_loader::ClassLoader(library_path);
+      } catch (const std::exception & ex) {
+        fprintf(stderr, "Failed to load library: %s\n", ex.what());
+        response->success = false;
+        return;
+      } catch (...) {
+        fprintf(stderr, "Failed to load library\n");
+        response->success = false;
+        return;
+      }
+      auto classes = loader->getAvailableClasses<rclcpp::Node>();
+      for (auto clazz : classes) {
+        if (clazz == class_name) {
+          printf("Instantiate class %s\n", clazz.c_str());
+          auto node = loader->createInstance<rclcpp::Node>(clazz);
+          exec.add_node(node);
+          nodes.push_back(node);
+          loaders.push_back(loader);
+          response->success = true;
+          return;
+        }
+      }
+
+      // no matching class found in loader
+      delete loader;
+      fprintf(
+        stderr, "Failed to find class with the requested plugin name '%s' in "
+        "the loaded library\n",
+        plugin_name.c_str());
+      response->success = false;
+      return;
+    }
+    fprintf(
+      stderr, "Failed to find plugin name '%s' in prefix '%s'\n",
+      plugin_name.c_str(), base_path.c_str());
+    response->success = false;
+  });
+
+  exec.spin();
+
+  for (auto node : nodes) {
+    exec.remove_node(node);
+  }
+  nodes.clear();
+  return 0;
+}

--- a/composition/src/api_composition_cli.cpp
+++ b/composition/src/api_composition_cli.cpp
@@ -1,0 +1,58 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <string>
+
+#include "composition/srv/load_node.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+int main(int argc, char * argv[])
+{
+  if (argc != 3) {
+    fprintf(stderr, "Requires exactly two arguments to be passed: package name and plugin name\n");
+    return 1;
+  }
+
+  rclcpp::init(argc, argv);
+  auto node = rclcpp::Node::make_shared("api_composition_cli");
+  auto client = node->create_client<composition::srv::LoadNode>("load_node");
+
+  while (!client->wait_for_service(1_s)) {
+    if (!rclcpp::ok()) {
+      printf("api_composition_cli was interrupted while waiting for the service. Exiting.\n");
+      return 0;
+    }
+    printf("service not available, waiting again...\n");
+  }
+
+  auto request = std::make_shared<composition::srv::LoadNode::Request>();
+  request->package_name = argv[1];
+  request->plugin_name = argv[2];
+
+  printf("Sending request...\n");
+  auto result = client->async_send_request(request);
+  printf("Waiting for response...\n");
+  if (rclcpp::spin_until_future_complete(node, result) !=
+    rclcpp::executor::FutureReturnCode::SUCCESS)
+  {
+    fprintf(stderr, "api_composition_cli was interrupted. Exiting.\n");
+    return 1;
+  }
+  printf("Result of load_node: success = %s\n", result.get()->success ? "true" : "false");
+
+  rclcpp::shutdown();
+
+  return result.get()->success ? 0 : 1;
+}

--- a/composition/src/dlopen_composition.cpp
+++ b/composition/src/dlopen_composition.cpp
@@ -1,0 +1,57 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "class_loader/class_loader.h"
+#include "rclcpp/rclcpp.hpp"
+
+int main(int argc, char * argv[])
+{
+  if (argc < 2) {
+    fprintf(stderr, "Requires at least one argument to be passed with the library to load\n");
+    return 1;
+  }
+  rclcpp::init(argc, argv);
+  rclcpp::executors::SingleThreadedExecutor exec;
+  std::vector<class_loader::ClassLoader *> loaders;
+  std::vector<std::shared_ptr<rclcpp::Node>> nodes;
+
+  std::vector<std::string> libraries;
+  for (int i = 1; i < argc; ++i) {
+    libraries.push_back(argv[i]);
+  }
+  for (auto library : libraries) {
+    printf("Load library %s\n", library.c_str());
+    auto loader = new class_loader::ClassLoader(library);
+    auto classes = loader->getAvailableClasses<rclcpp::Node>();
+    for (auto clazz : classes) {
+      printf("Instantiate class %s\n", clazz.c_str());
+      auto node = loader->createInstance<rclcpp::Node>(clazz);
+      exec.add_node(node);
+      nodes.push_back(node);
+    }
+    loaders.push_back(loader);
+  }
+
+  exec.spin();
+
+  for (auto node : nodes) {
+    exec.remove_node(node);
+  }
+  nodes.clear();
+  return 0;
+}

--- a/composition/src/linktime_composition.cpp
+++ b/composition/src/linktime_composition.cpp
@@ -1,0 +1,54 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "class_loader/class_loader.h"
+#include "rclcpp/rclcpp.hpp"
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::executors::SingleThreadedExecutor exec;
+  std::vector<class_loader::ClassLoader *> loaders;
+  std::vector<std::shared_ptr<rclcpp::Node>> nodes;
+
+  std::vector<std::string> libraries = {
+    // all classes from libraries linked by the linker (rather then dlopen)
+    // are registered under the library_path ""
+    "",
+  };
+  for (auto library : libraries) {
+    printf("Load library %s\n", library.c_str());
+    auto loader = new class_loader::ClassLoader(library);
+    auto classes = loader->getAvailableClasses<rclcpp::Node>();
+    for (auto clazz : classes) {
+      printf("Instantiate class %s\n", clazz.c_str());
+      auto node = loader->createInstance<rclcpp::Node>(clazz);
+      exec.add_node(node);
+      nodes.push_back(node);
+    }
+    loaders.push_back(loader);
+  }
+
+  exec.spin();
+
+  for (auto node : nodes) {
+    exec.remove_node(node);
+  }
+  nodes.clear();
+  return 0;
+}

--- a/composition/src/listener_component.cpp
+++ b/composition/src/listener_component.cpp
@@ -1,0 +1,44 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "composition/listener_component.hpp"
+
+#include <iostream>
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/string.hpp"
+
+namespace composition
+{
+
+Listener::Listener()
+: Node("listener")
+{
+  auto callback =
+    [](const typename std_msgs::msg::String::SharedPtr msg) -> void
+    {
+      printf("I heard: [%s]\n", msg->data.c_str());
+      std::flush(std::cout);
+    };
+
+  sub_ = create_subscription<std_msgs::msg::String>(
+    "chatter", callback);
+}
+
+}  // namespace composition
+
+#include "class_loader/class_loader_register_macro.h"
+
+CLASS_LOADER_REGISTER_CLASS(composition::Listener, rclcpp::Node)

--- a/composition/src/manual_composition.cpp
+++ b/composition/src/manual_composition.cpp
@@ -1,0 +1,33 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
+#include "composition/listener_component.hpp"
+#include "composition/talker_component.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::executors::SingleThreadedExecutor exec;
+
+  auto talker = std::make_shared<composition::Talker>();
+  exec.add_node(talker);
+  auto listener = std::make_shared<composition::Listener>();
+  exec.add_node(listener);
+
+  exec.spin();
+  return 0;
+}

--- a/composition/src/talker_component.cpp
+++ b/composition/src/talker_component.cpp
@@ -1,0 +1,46 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "composition/talker_component.hpp"
+
+#include <iostream>
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/string.hpp"
+
+namespace composition
+{
+
+Talker::Talker()
+: Node("talker"), count_(0)
+{
+  pub_ = create_publisher<std_msgs::msg::String>("chatter");
+  timer_ = create_wall_timer(1_s, std::bind(&Talker::on_timer, this));
+}
+
+void Talker::on_timer()
+{
+  auto msg = std::make_shared<std_msgs::msg::String>();
+  msg->data = "Hello World: " + std::to_string(++count_);
+  printf("Publishing: '%s'\n", msg->data.c_str());
+  std::flush(std::cout);
+  pub_->publish(msg);
+}
+
+}  // namespace composition
+
+#include "class_loader/class_loader_register_macro.h"
+
+CLASS_LOADER_REGISTER_CLASS(composition::Talker, rclcpp::Node)

--- a/composition/srv/LoadNode.srv
+++ b/composition/srv/LoadNode.srv
@@ -1,0 +1,4 @@
+string package_name
+string plugin_name
+---
+bool success

--- a/composition/test/composition.regex
+++ b/composition/test/composition.regex
@@ -1,0 +1,1 @@
+I heard: \[Hello World: \d+\]

--- a/composition/test/test_composition.py.in
+++ b/composition/test/test_composition.py.in
@@ -1,0 +1,105 @@
+# Copyright 2016 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from unittest.case import SkipTest
+
+from launch import LaunchDescriptor
+from launch.exit_handler import default_exit_handler
+from launch.exit_handler import exit_on_error_exit_handler
+from launch.launcher import DefaultLauncher
+from launch.output_handler import ConsoleOutput
+from launch_testing import create_handler
+
+
+def test_manual_composition():
+    name = 'test_manual_composition'
+    executable = '@MANUAL_COMPOSITION_EXECUTABLE@'
+    launch(name, [executable])
+
+
+def test_linktime_composition():
+    if os.name == 'nt':
+        print('The link time registration of classes does not work on Windows')
+        raise SkipTest
+    name = 'test_linktime_composition'
+    executable = '@LINKTIME_COMPOSITION_EXECUTABLE@'
+    launch(name, [executable])
+
+
+def test_dlopen_composition():
+    name = 'test_dlopen_composition'
+    executable = '@DLOPEN_COMPOSITION_EXECUTABLE@'
+    talker_library = '@TALKER_LIBRARY@'
+    listener_library = '@LISTENER_LIBRARY@'
+    launch(name, [executable, talker_library, listener_library])
+
+
+def test_api_composition():
+    import sys
+    name = 'test_api_composition'
+    executable = '@API_COMPOSITION_EXECUTABLE@'
+    additional_processes = [
+        {
+            'cmd': [
+                '@API_COMPOSITION_CLI_EXECUTABLE@',
+                'composition', 'composition::Talker'],
+            'name': 'load_talker_component',
+            'exit_handler': exit_on_error_exit_handler,
+        },
+        {
+            'cmd': [
+                '@API_COMPOSITION_CLI_EXECUTABLE@',
+                'composition', 'composition::Listener'],
+            'name': 'load_listener_component',
+            'exit_handler': exit_on_error_exit_handler,
+        },
+    ]
+    launch(name, [executable], additional_processes=additional_processes)
+
+
+def launch(name, cmd, additional_processes=None):
+    launch_descriptor = LaunchDescriptor()
+
+    rmw_implementation = '@rmw_implementation@'
+    output_file = '@EXPECTED_OUTPUT@'
+    handler = create_handler(
+        name, launch_descriptor, output_file,
+        filtered_rmw_implementation=rmw_implementation)
+    assert handler, 'Cannot find appropriate handler for %s' % output_file
+    launch_descriptor.add_process(
+        cmd=cmd,
+        name=name,
+        exit_handler=default_exit_handler,
+        output_handlers=[ConsoleOutput(), handler],
+    )
+    for additional_process in (additional_processes or []):
+        launch_descriptor.add_process(**additional_process)
+
+    launcher = DefaultLauncher()
+    launcher.add_launch_descriptor(launch_descriptor)
+    rc = launcher.launch()
+
+    assert rc == 0, \
+        "The launch file failed with exit code '" + str(rc) + "'. " \
+        'Maybe the client did not receive any messages?'
+
+    handler.check()
+
+
+if __name__ == '__main__':
+    test_manual_composition()
+    test_linktime_composition()
+    test_dlopen_composition()
+    test_api_composition()


### PR DESCRIPTION
This package contains multiple different ways how multiple nodes can be composed into a single process. The talker and listener nodes are compiled into shared libraries in all cases.
- `manual_composition`:
  - custom written `main` uses the headers of the nodes and instantiates concrete nodes
  - executable links against node libraries
- `linktime_composition`:
  - the nodes in each library are registered using `class_loader`
  - "generic" `main` using `class_loader` (on the library "")
  - executable links against node libraries with `-Wl,--no-as-needed` (since it doesn't directly require any symbols from the libraries)
- `dlopen_composition`:
  - the nodes in each library are registered using `class_loader`
  - "generic" `main` using `class_loader` to load the shared libraries
  - executable not linked against node libraries, but gets shared library paths as command line arguments

--

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=1872)](http://ci.ros2.org/job/ci_linux/1872/)
* OS X [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1434)](http://ci.ros2.org/job/ci_osx/1434/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=1809)](http://ci.ros2.org/job/ci_windows/1809/)