### PR TITLE
Demo nodes

### DIFF
--- a/demo_nodes_cpp/CMakeLists.txt
+++ b/demo_nodes_cpp/CMakeLists.txt
@@ -1,0 +1,120 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(demo_nodes_cpp)
+
+if(NOT WIN32)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(example_interfaces REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rmw REQUIRED)
+find_package(rmw_implementation_cmake REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+
+function(custom_executable subfolder target)
+  add_executable(${target}${target_suffix} src/${subfolder}/${target}.cpp)
+  # TODO(dhood): Allow dependencies to be listed in arbitrary order without affecting the selected
+  # typesupport. See https://github.com/ros2/ros2/issues/253
+  ament_target_dependencies(${target}${target_suffix}
+    "rclcpp${target_suffix}"
+    "std_msgs"
+    "example_interfaces")
+  install(TARGETS ${target}${target_suffix}
+    DESTINATION bin)
+endfunction()
+
+macro(targets)
+  if(NOT target_suffix STREQUAL "")
+    get_rclcpp_information("${rmw_implementation}" "rclcpp${target_suffix}")
+  endif()
+
+  # Tutorials of Publish/Subscribe with Topics
+  custom_executable(topics talker)
+  custom_executable(topics listener)
+  custom_executable(topics listener_best_effort)
+  custom_executable(topics imu_listener)
+  ament_target_dependencies(imu_listener${target_suffix}
+    "sensor_msgs")
+  custom_executable(topics allocator_tutorial)
+
+  # Tutorials of Request/Response with Services
+  custom_executable(services add_two_ints_client)
+  custom_executable(services add_two_ints_client_async)
+  custom_executable(services add_two_ints_server)
+
+  # Tutorials of Parameters with Asynchronous and Synchronous
+  custom_executable(parameters list_parameters)
+  custom_executable(parameters list_parameters_async)
+  custom_executable(parameters parameter_events)
+  custom_executable(parameters parameter_events_async)
+  custom_executable(parameters set_and_get_parameters)
+  custom_executable(parameters set_and_get_parameters_async)
+  custom_executable(parameters ros2param)
+endmacro()
+
+call_for_each_rmw_implementation(targets GENERATE_DEFAULT)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  # Add each test case.  Multi-executable tests can be specified in
+  # semicolon-separated strings, like  exe1;exe2.
+  set(tutorial_tests
+    list_parameters_async
+    list_parameters
+    parameter_events_async
+    parameter_events
+    set_and_get_parameters_async
+    set_and_get_parameters
+    "talker:listener")
+  set(service_tutorial_tests
+    "add_two_ints_server:add_two_ints_client"
+    "add_two_ints_server:add_two_ints_client_async")
+
+  macro(tests)
+    set(tutorial_tests_to_test ${tutorial_tests})
+    list(APPEND tutorial_tests_to_test ${service_tutorial_tests})
+
+    foreach(tutorial_test ${tutorial_tests_to_test})
+      string(REPLACE ":" ";" tutorial_executables "${tutorial_test}")
+      set(DEMO_NODES_CPP_EXPECTED_OUTPUT "")
+      foreach(executable ${tutorial_executables})
+        list(APPEND DEMO_NODES_CPP_EXPECTED_OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/test/${executable}")
+      endforeach()
+
+      set(DEMO_NODES_CPP_EXECUTABLE "")
+      foreach(executable ${tutorial_executables})
+        list(APPEND DEMO_NODES_CPP_EXECUTABLE "$<TARGET_FILE:${executable}${target_suffix}>")
+      endforeach()
+
+      string(REPLACE ";" "_" exe_list_underscore "${tutorial_executables}")
+      configure_file(
+        test/test_executables_tutorial.py.in
+        test_${exe_list_underscore}${target_suffix}.py.configured
+        @ONLY
+      )
+      file(GENERATE
+        OUTPUT "test_${exe_list_underscore}${target_suffix}_$<CONFIGURATION>.py"
+        INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_${exe_list_underscore}${target_suffix}.py.configured"
+      )
+
+      ament_add_nose_test(test_tutorial_${exe_list_underscore}${target_suffix}
+        "${CMAKE_CURRENT_BINARY_DIR}/test_${exe_list_underscore}${target_suffix}_$<CONFIGURATION>.py"
+        TIMEOUT 30
+        ENV RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation})
+      foreach(executable ${tutorial_executables})
+        set_property(
+          TEST test_tutorial_${exe_list_underscore}${target_suffix}
+          APPEND PROPERTY DEPENDS ${executable}${target_suffix})
+      endforeach()
+    endforeach()
+  endmacro()
+
+  call_for_each_rmw_implementation(tests)
+endif()
+
+ament_package()

--- a/demo_nodes_cpp/CMakeLists.txt
+++ b/demo_nodes_cpp/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.5)
 project(demo_nodes_cpp)
 
 if(NOT WIN32)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra")
 endif()
 
 find_package(ament_cmake REQUIRED)

--- a/demo_nodes_cpp/package.xml
+++ b/demo_nodes_cpp/package.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>demo_nodes_cpp</name>
+  <version>0.0.0</version>
+  <description>
+    C++ nodes which were previously in the ros2/examples repository but are now just used for demo purposes.
+  </description>
+  <maintainer email="william@osrfoundation.org">William Woodall</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <build_depend>example_interfaces</build_depend>
+  <build_depend>rclcpp</build_depend>
+  <build_depend>rmw_implementation</build_depend>
+  <build_depend>rmw_implementation_cmake</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>std_msgs</build_depend>
+
+  <exec_depend>example_interfaces</exec_depend>
+  <exec_depend>rclcpp</exec_depend>
+  <exec_depend>rmw_implementation</exec_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+
+  <test_depend>ament_cmake_nose</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>launch</test_depend>
+  <test_depend>launch_testing</test_depend>
+  <test_depend>rclcpp</test_depend>
+  <test_depend>rmw_implementation</test_depend>
+  <test_depend>rosidl_default_generators</test_depend>
+  <test_depend>rosidl_default_runtime</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/demo_nodes_cpp/src/parameters/list_parameters.cpp
+++ b/demo_nodes_cpp/src/parameters/list_parameters.cpp
@@ -1,0 +1,51 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+
+  auto node = rclcpp::Node::make_shared("list_parameters");
+
+  // TODO(esteve): Make the parameter service automatically start with the node.
+  auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
+
+  auto parameters_client = std::make_shared<rclcpp::parameter_client::SyncParametersClient>(node);
+
+  // Set several differnet types of parameters.
+  auto set_parameters_results = parameters_client->set_parameters({
+    rclcpp::parameter::ParameterVariant("foo", 2),
+    rclcpp::parameter::ParameterVariant("bar", "hello"),
+    rclcpp::parameter::ParameterVariant("baz", 1.45),
+    rclcpp::parameter::ParameterVariant("foo.first", 8),
+    rclcpp::parameter::ParameterVariant("foo.second", 42),
+    rclcpp::parameter::ParameterVariant("foobar", true),
+  });
+
+  // List the details of a few parameters up to a namespace depth of 10.
+  auto parameters_and_prefixes = parameters_client->list_parameters({"foo", "bar"}, 10);
+  for (auto & name : parameters_and_prefixes.names) {
+    std::cout << "Parameter name: " << name << std::endl;
+  }
+  for (auto & prefix : parameters_and_prefixes.prefixes) {
+    std::cout << "Parameter prefix: " << prefix << std::endl;
+  }
+
+  return 0;
+}

--- a/demo_nodes_cpp/src/parameters/list_parameters_async.cpp
+++ b/demo_nodes_cpp/src/parameters/list_parameters_async.cpp
@@ -1,0 +1,61 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+
+  auto node = rclcpp::Node::make_shared("list_parameters_async");
+
+  // TODO(esteve): Make the parameter service automatically start with the node.
+  auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
+
+  auto parameters_client = std::make_shared<rclcpp::parameter_client::AsyncParametersClient>(node);
+
+  // Set several differnet types of parameters.
+  auto results = parameters_client->set_parameters({
+    rclcpp::parameter::ParameterVariant("foo", 2),
+    rclcpp::parameter::ParameterVariant("bar", "hello"),
+    rclcpp::parameter::ParameterVariant("baz", 1.45),
+    rclcpp::parameter::ParameterVariant("foo.first", 8),
+    rclcpp::parameter::ParameterVariant("foo.second", 42),
+    rclcpp::parameter::ParameterVariant("foobar", true),
+  });
+  // Wait for the result.
+  rclcpp::spin_until_future_complete(node, results);
+
+  // List the details of a few parameters up to a namespace depth of 10.
+  auto parameter_list_future = parameters_client->list_parameters({"foo", "bar"}, 10);
+
+  if (rclcpp::spin_until_future_complete(node, parameter_list_future) !=
+    rclcpp::executor::FutureReturnCode::SUCCESS)
+  {
+    printf("list_parameters service call failed, exiting tutorial.");
+    return -1;
+  }
+  auto parameter_list = parameter_list_future.get();
+  for (auto & name : parameter_list.names) {
+    std::cout << "Parameter name: " << name << std::endl;
+  }
+  for (auto & prefix : parameter_list.prefixes) {
+    std::cout << "Parameter prefix: " << prefix << std::endl;
+  }
+
+  return 0;
+}

--- a/demo_nodes_cpp/src/parameters/parameter_events.cpp
+++ b/demo_nodes_cpp/src/parameters/parameter_events.cpp
@@ -1,0 +1,72 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+
+void on_parameter_event(const rcl_interfaces::msg::ParameterEvent::SharedPtr event)
+{
+  // TODO(wjwwood): The message should have an operator<<, which would replace all of this.
+  std::cout << "Parameter event:" << std::endl << " new parameters:" << std::endl;
+  for (auto & new_parameter : event->new_parameters) {
+    std::cout << "  " << new_parameter.name << std::endl;
+  }
+  std::cout << " changed parameters:" << std::endl;
+  for (auto & changed_parameter : event->changed_parameters) {
+    std::cout << "  " << changed_parameter.name << std::endl;
+  }
+  std::cout << " deleted parameters:" << std::endl;
+  for (auto & deleted_parameter : event->deleted_parameters) {
+    std::cout << "  " << deleted_parameter.name << std::endl;
+  }
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+
+  auto node = rclcpp::Node::make_shared("parameter_events");
+
+  // TODO(esteve): Make the parameter service automatically start with the node.
+  auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
+
+  auto parameters_client = std::make_shared<rclcpp::parameter_client::SyncParametersClient>(node);
+
+  // Setup callback for changes to parameters.
+  auto sub = parameters_client->on_parameter_event(on_parameter_event);
+
+  // Set several differnet types of parameters.
+  auto set_parameters_results = parameters_client->set_parameters({
+    rclcpp::parameter::ParameterVariant("foo", 2),
+    rclcpp::parameter::ParameterVariant("bar", "hello"),
+    rclcpp::parameter::ParameterVariant("baz", 1.45),
+    rclcpp::parameter::ParameterVariant("foobar", true),
+  });
+
+  // Change the value of some of them.
+  set_parameters_results = parameters_client->set_parameters({
+    rclcpp::parameter::ParameterVariant("foo", 3),
+    rclcpp::parameter::ParameterVariant("bar", "world"),
+  });
+
+  // TODO(wjwwood): Create and use delete_parameter
+
+  rclcpp::sleep_for(100_ms);
+
+  rclcpp::spin_some(node);
+
+  return 0;
+}

--- a/demo_nodes_cpp/src/parameters/parameter_events.cpp
+++ b/demo_nodes_cpp/src/parameters/parameter_events.cpp
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
 #include <iostream>
 #include <memory>
 
 #include "rclcpp/rclcpp.hpp"
+
+using namespace std::chrono_literals;
 
 void on_parameter_event(const rcl_interfaces::msg::ParameterEvent::SharedPtr event)
 {
@@ -64,7 +67,7 @@ int main(int argc, char ** argv)
 
   // TODO(wjwwood): Create and use delete_parameter
 
-  rclcpp::sleep_for(100_ms);
+  rclcpp::sleep_for(100ms);
 
   rclcpp::spin_some(node);
 

--- a/demo_nodes_cpp/src/parameters/parameter_events_async.cpp
+++ b/demo_nodes_cpp/src/parameters/parameter_events_async.cpp
@@ -1,0 +1,74 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+
+void on_parameter_event(const rcl_interfaces::msg::ParameterEvent::SharedPtr event)
+{
+  // TODO(wjwwood): The message should have an operator<<, which would replace all of this.
+  std::cout << "Parameter event:" << std::endl << " new parameters:" << std::endl;
+  for (auto & new_parameter : event->new_parameters) {
+    std::cout << "  " << new_parameter.name << std::endl;
+  }
+  std::cout << " changed parameters:" << std::endl;
+  for (auto & changed_parameter : event->changed_parameters) {
+    std::cout << "  " << changed_parameter.name << std::endl;
+  }
+  std::cout << " deleted parameters:" << std::endl;
+  for (auto & deleted_parameter : event->deleted_parameters) {
+    std::cout << "  " << deleted_parameter.name << std::endl;
+  }
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+
+  auto node = rclcpp::Node::make_shared("parameter_events");
+
+  // TODO(esteve): Make the parameter service automatically start with the node.
+  auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
+
+  auto parameters_client = std::make_shared<rclcpp::parameter_client::AsyncParametersClient>(node);
+
+  // Setup callback for changes to parameters.
+  auto sub = parameters_client->on_parameter_event(on_parameter_event);
+
+  // Set several differnet types of parameters.
+  auto set_parameters_results = parameters_client->set_parameters({
+    rclcpp::parameter::ParameterVariant("foo", 2),
+    rclcpp::parameter::ParameterVariant("bar", "hello"),
+    rclcpp::parameter::ParameterVariant("baz", 1.45),
+    rclcpp::parameter::ParameterVariant("foobar", true),
+  });
+  rclcpp::spin_until_future_complete(node, set_parameters_results);
+
+  // Change the value of some of them.
+  set_parameters_results = parameters_client->set_parameters({
+    rclcpp::parameter::ParameterVariant("foo", 3),
+    rclcpp::parameter::ParameterVariant("bar", "world"),
+  });
+  rclcpp::spin_until_future_complete(node, set_parameters_results);
+
+  // TODO(wjwwood): Create and use delete_parameter
+
+  rclcpp::sleep_for(100_ms);
+
+  rclcpp::spin_some(node);
+
+  return 0;
+}

--- a/demo_nodes_cpp/src/parameters/parameter_events_async.cpp
+++ b/demo_nodes_cpp/src/parameters/parameter_events_async.cpp
@@ -12,10 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
 #include <iostream>
 #include <memory>
 
 #include "rclcpp/rclcpp.hpp"
+
+using namespace std::chrono_literals;
 
 void on_parameter_event(const rcl_interfaces::msg::ParameterEvent::SharedPtr event)
 {
@@ -66,7 +69,7 @@ int main(int argc, char ** argv)
 
   // TODO(wjwwood): Create and use delete_parameter
 
-  rclcpp::sleep_for(100_ms);
+  rclcpp::sleep_for(100ms);
 
   rclcpp::spin_some(node);
 

--- a/demo_nodes_cpp/src/parameters/ros2param.cpp
+++ b/demo_nodes_cpp/src/parameters/ros2param.cpp
@@ -1,0 +1,164 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <inttypes.h>
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+
+#define USAGE \
+  "USAGE:\n  ros2param get <node/variable>\n  ros2param set <node/variable> <value>\n" \
+  "  ros2param list <node>"
+
+typedef enum
+{
+  PARAM_NONE,
+  PARAM_GET,
+  PARAM_SET,
+  PARAM_LIST,
+} param_operation_t;
+
+rclcpp::parameter::ParameterVariant
+parse_args(int argc, char ** argv, std::string & remote_node, param_operation_t & op)
+{
+  if (argc < 3) {
+    return rclcpp::parameter::ParameterVariant();
+  }
+
+  std::string verb = argv[1];
+  std::string name = argv[2];
+
+  if (verb == "list") {
+    op = PARAM_LIST;
+    remote_node = name;
+    return rclcpp::parameter::ParameterVariant();
+  }
+
+  size_t slash = name.find('/');
+  if ((slash == std::string::npos) ||
+    (slash == 0) ||
+    (slash == (name.size() - 1)))
+  {
+    return rclcpp::parameter::ParameterVariant();
+  }
+  remote_node = name.substr(0, slash);
+  std::string variable = name.substr(slash + 1, name.size() - slash - 1);
+
+
+  if ((verb == "get") && (argc == 3)) {
+    op = PARAM_GET;
+    return rclcpp::parameter::ParameterVariant(variable, 0);
+  }
+  if ((verb == "set") && (argc == 4)) {
+    op = PARAM_SET;
+    std::string value = argv[3];
+    char * endptr;
+    int l = strtol(value.c_str(), &endptr, 10);
+    if ((errno == 0) && (*endptr == '\0')) {
+      return rclcpp::parameter::ParameterVariant(variable, l);
+    }
+    errno = 0;
+    double d = strtod(value.c_str(), &endptr);
+    if ((errno == 0) && (*endptr == '\0')) {
+      return rclcpp::parameter::ParameterVariant(variable, d);
+    }
+    if ((value == "true") || (value == "True")) {
+      return rclcpp::parameter::ParameterVariant(variable, true);
+    }
+    if ((value == "false") || (value == "False")) {
+      return rclcpp::parameter::ParameterVariant(variable, false);
+    }
+    return rclcpp::parameter::ParameterVariant(variable, value);
+  }
+  return rclcpp::parameter::ParameterVariant();
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+
+  std::string remote_node;
+  param_operation_t op = PARAM_NONE;
+
+  auto var = parse_args(argc, argv, remote_node, op);
+
+  if (op == PARAM_NONE) {
+    fprintf(stderr, "%s\n", USAGE);
+    return 1;
+  }
+
+  auto node = rclcpp::Node::make_shared("ros2param");
+  auto parameters_client =
+    std::make_shared<rclcpp::parameter_client::AsyncParametersClient>(node, remote_node);
+  auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
+
+  if (op == PARAM_GET) {
+    auto get_parameters_result = parameters_client->get_parameters({var.get_name()});
+    auto get_result = rclcpp::spin_until_future_complete(
+      node, get_parameters_result, std::chrono::milliseconds(1000));
+    if ((get_result != rclcpp::executor::FutureReturnCode::SUCCESS) ||
+      (get_parameters_result.get().size() != 1) ||
+      (get_parameters_result.get()[0].get_type() == rclcpp::parameter::PARAMETER_NOT_SET))
+    {
+      fprintf(stderr, "Failed to get parameter\n");
+      return 1;
+    }
+
+    auto result = get_parameters_result.get()[0];
+    if (result.get_type() == rclcpp::parameter::PARAMETER_BOOL) {
+      printf("%s\n", result.get_value<bool>() ? "true" : "false");
+    } else if (result.get_type() == rclcpp::parameter::PARAMETER_INTEGER) {
+      printf("%" PRId64 "\n", result.get_value<int64_t>());
+    } else if (result.get_type() == rclcpp::parameter::PARAMETER_DOUBLE) {
+      printf("%f\n", result.get_value<double>());
+    } else if (result.get_type() == rclcpp::parameter::PARAMETER_STRING) {
+      printf("%s\n", result.get_value<std::string>().c_str());
+    } else if (result.get_type() == rclcpp::parameter::PARAMETER_BYTES) {
+      fprintf(stderr, "BYTES type not implemented\n");
+      return 1;
+    }
+
+  } else if (op == PARAM_SET) {
+    auto set_parameters_result = parameters_client->set_parameters({var});
+    auto set_result = rclcpp::spin_until_future_complete(
+      node, set_parameters_result, std::chrono::milliseconds(1000));
+    if (set_result != rclcpp::executor::FutureReturnCode::SUCCESS) {
+      fprintf(stderr, "Failed to set parameter\n");
+      return 1;
+    }
+  } else if (op == PARAM_LIST) {
+    auto list_parameters_result = parameters_client->list_parameters({}, 10);
+    auto list_result = rclcpp::spin_until_future_complete(
+      node, list_parameters_result, std::chrono::milliseconds(10000));
+    if (list_result == rclcpp::executor::FutureReturnCode::SUCCESS) {
+      printf("Node %s has %zu parameters:\n", remote_node.c_str(),
+        list_parameters_result.get().names.size());
+      for (auto name : list_parameters_result.get().names) {
+        printf("%s\n", name.c_str());
+      }
+    } else if (list_result == rclcpp::executor::FutureReturnCode::TIMEOUT) {
+      fprintf(stderr, "Timed out trying to list parameters: 10 seconds\n");
+      return 1;
+    } else {
+      fprintf(stderr, "Error listing parameters\n");
+      return 1;
+    }
+  } else {
+    fprintf(stderr, "%s\n", USAGE);
+    return 1;
+  }
+  return 0;
+}

--- a/demo_nodes_cpp/src/parameters/set_and_get_parameters.cpp
+++ b/demo_nodes_cpp/src/parameters/set_and_get_parameters.cpp
@@ -1,0 +1,53 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+
+  auto node = rclcpp::Node::make_shared("set_and_get_parameters");
+
+  // TODO(wjwwood): Make the parameter service automatically start with the node.
+  auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
+
+  auto parameters_client = std::make_shared<rclcpp::parameter_client::SyncParametersClient>(node);
+
+  // Set several different types of parameters.
+  auto set_parameters_results = parameters_client->set_parameters({
+    rclcpp::parameter::ParameterVariant("foo", 2),
+    rclcpp::parameter::ParameterVariant("bar", "hello"),
+    rclcpp::parameter::ParameterVariant("baz", 1.45),
+    rclcpp::parameter::ParameterVariant("foobar", true),
+  });
+  // Check to see if they were set.
+  for (auto & result : set_parameters_results) {
+    if (!result.successful) {
+      std::cerr << "Failed to set parameter: " << result.reason << std::endl;
+    }
+  }
+
+  // Get a few of the parameters just set.
+  for (auto & parameter : parameters_client->get_parameters({"foo", "baz"})) {
+    std::cout << "Parameter name: " << parameter.get_name() << std::endl;
+    std::cout << "Parameter value (" << parameter.get_type_name() << "): " <<
+      parameter.value_to_string() << std::endl;
+  }
+
+  return 0;
+}

--- a/demo_nodes_cpp/src/parameters/set_and_get_parameters_async.cpp
+++ b/demo_nodes_cpp/src/parameters/set_and_get_parameters_async.cpp
@@ -1,0 +1,67 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+
+  auto node = rclcpp::Node::make_shared("set_and_get_parameters_async");
+
+  // TODO(wjwwood): Make the parameter service automatically start with the node.
+  auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
+
+  auto parameters_client = std::make_shared<rclcpp::parameter_client::AsyncParametersClient>(node);
+
+  // Set several different types of parameters.
+  auto results = parameters_client->set_parameters({
+    rclcpp::parameter::ParameterVariant("foo", 2),
+    rclcpp::parameter::ParameterVariant("bar", "hello"),
+    rclcpp::parameter::ParameterVariant("baz", 1.45),
+    rclcpp::parameter::ParameterVariant("foobar", true),
+  });
+  // Wait for the results.
+  if (rclcpp::spin_until_future_complete(node, results) !=
+    rclcpp::executor::FutureReturnCode::SUCCESS)
+  {
+    printf("set_parameters service call failed. Exiting tutorial.\n");
+    return -1;
+  }
+  // Check to see if they were set.
+  for (auto & result : results.get()) {
+    if (!result.successful) {
+      std::cerr << "Failed to set parameter: " << result.reason << std::endl;
+    }
+  }
+
+  // Get a few of the parameters just set.
+  auto parameters = parameters_client->get_parameters({"foo", "baz"});
+  if (rclcpp::spin_until_future_complete(node, parameters) !=
+    rclcpp::executor::FutureReturnCode::SUCCESS)
+  {
+    printf("get_parameters service call failed. Exiting tutorial.\n");
+    return -1;
+  }
+  for (auto & parameter : parameters.get()) {
+    std::cout << "Parameter name: " << parameter.get_name() << std::endl;
+    std::cout << "Parameter value (" << parameter.get_type_name() << "): " <<
+      parameter.value_to_string() << std::endl;
+  }
+
+  return 0;
+}

--- a/demo_nodes_cpp/src/services/add_two_ints_client.cpp
+++ b/demo_nodes_cpp/src/services/add_two_ints_client.cpp
@@ -1,0 +1,69 @@
+// Copyright 2014 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "example_interfaces/srv/add_two_ints.hpp"
+
+// TODO(wjwwood): make this into a method of rclcpp::client::Client.
+example_interfaces::srv::AddTwoInts_Response::SharedPtr send_request(
+  rclcpp::Node::SharedPtr node,
+  rclcpp::client::Client<example_interfaces::srv::AddTwoInts>::SharedPtr client,
+  example_interfaces::srv::AddTwoInts_Request::SharedPtr request)
+{
+  auto result = client->async_send_request(request);
+  // Wait for the result.
+  if (rclcpp::spin_until_future_complete(node, result) ==
+    rclcpp::executor::FutureReturnCode::SUCCESS)
+  {
+    return result.get();
+  } else {
+    return NULL;
+  }
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+
+  auto node = rclcpp::Node::make_shared("add_two_ints_client");
+
+  auto client = node->create_client<example_interfaces::srv::AddTwoInts>("add_two_ints");
+  auto request = std::make_shared<example_interfaces::srv::AddTwoInts::Request>();
+  request->a = 2;
+  request->b = 3;
+
+  while (!client->wait_for_service(1_s)) {
+    if (!rclcpp::ok()) {
+      printf("add_two_ints_client was interrupted while waiting for the service. Exiting.\n");
+      return 0;
+    }
+    printf("service not available, waiting again...\n");
+  }
+
+  // TODO(wjwwood): make it like `client->send_request(node, request)->sum`
+  // TODO(wjwwood): consider error condition
+  auto result = send_request(node, client, request);
+  if (result) {
+    printf("Result of add_two_ints: %zd\n", result->sum);
+  } else {
+    printf("add_two_ints_client was interrupted. Exiting.\n");
+  }
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/demo_nodes_cpp/src/services/add_two_ints_client.cpp
+++ b/demo_nodes_cpp/src/services/add_two_ints_client.cpp
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
 #include <iostream>
 #include <memory>
 
 #include "rclcpp/rclcpp.hpp"
 
 #include "example_interfaces/srv/add_two_ints.hpp"
+
+using namespace std::chrono_literals;
 
 // TODO(wjwwood): make this into a method of rclcpp::client::Client.
 example_interfaces::srv::AddTwoInts_Response::SharedPtr send_request(
@@ -47,7 +50,7 @@ int main(int argc, char ** argv)
   request->a = 2;
   request->b = 3;
 
-  while (!client->wait_for_service(1_s)) {
+  while (!client->wait_for_service(1s)) {
     if (!rclcpp::ok()) {
       printf("add_two_ints_client was interrupted while waiting for the service. Exiting.\n");
       return 0;

--- a/demo_nodes_cpp/src/services/add_two_ints_client_async.cpp
+++ b/demo_nodes_cpp/src/services/add_two_ints_client_async.cpp
@@ -1,0 +1,55 @@
+// Copyright 2014 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "example_interfaces/srv/add_two_ints.hpp"
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+
+  auto node = rclcpp::Node::make_shared("add_two_ints_client");
+
+  auto client = node->create_client<example_interfaces::srv::AddTwoInts>("add_two_ints");
+
+  while (!client->wait_for_service(1_s)) {
+    if (!rclcpp::ok()) {
+      printf("add_two_ints_client was interrupted while waiting for the service. Exiting.\n");
+      return 0;
+    }
+    printf("service not available, waiting again...\n");
+  }
+
+  auto request = std::make_shared<example_interfaces::srv::AddTwoInts::Request>();
+  request->a = 2;
+  request->b = 3;
+
+  auto future_result = client->async_send_request(request);
+
+  // Wait for the result.
+  if (rclcpp::spin_until_future_complete(node, future_result) ==
+    rclcpp::executor::FutureReturnCode::SUCCESS)
+  {
+    printf("Result of add_two_ints: %zd\n", future_result.get()->sum);
+  } else {
+    printf("add_two_ints_client_async was interrupted. Exiting.\n");
+  }
+
+  rclcpp::shutdown();
+  return 0;
+}

--- a/demo_nodes_cpp/src/services/add_two_ints_client_async.cpp
+++ b/demo_nodes_cpp/src/services/add_two_ints_client_async.cpp
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
 #include <iostream>
 #include <memory>
 
 #include "rclcpp/rclcpp.hpp"
 
 #include "example_interfaces/srv/add_two_ints.hpp"
+
+using namespace std::chrono_literals;
 
 int main(int argc, char ** argv)
 {
@@ -27,7 +30,7 @@ int main(int argc, char ** argv)
 
   auto client = node->create_client<example_interfaces::srv::AddTwoInts>("add_two_ints");
 
-  while (!client->wait_for_service(1_s)) {
+  while (!client->wait_for_service(1s)) {
     if (!rclcpp::ok()) {
       printf("add_two_ints_client was interrupted while waiting for the service. Exiting.\n");
       return 0;

--- a/demo_nodes_cpp/src/services/add_two_ints_server.cpp
+++ b/demo_nodes_cpp/src/services/add_two_ints_server.cpp
@@ -1,0 +1,45 @@
+// Copyright 2014 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "example_interfaces/srv/add_two_ints.hpp"
+
+void handle_add_two_ints(
+  const std::shared_ptr<rmw_request_id_t> request_header,
+  const std::shared_ptr<example_interfaces::srv::AddTwoInts::Request> request,
+  std::shared_ptr<example_interfaces::srv::AddTwoInts::Response> response)
+{
+  (void)request_header;
+  std::cout << "Incoming request" << std::endl;
+  std::cout << "a: " << request->a << " b: " << request->b << std::endl;
+  response->sum = request->a + request->b;
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+
+  auto node = rclcpp::Node::make_shared("add_two_ints_server");
+
+  auto server =
+    node->create_service<example_interfaces::srv::AddTwoInts>("add_two_ints", handle_add_two_ints);
+
+  rclcpp::spin(node);
+
+  return 0;
+}

--- a/demo_nodes_cpp/src/topics/allocator_tutorial.cpp
+++ b/demo_nodes_cpp/src/topics/allocator_tutorial.cpp
@@ -1,0 +1,199 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <list>
+#include <memory>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/strategies/allocator_memory_strategy.hpp"
+#include "std_msgs/msg/u_int32.hpp"
+
+
+// For demonstration purposes only, not necessary for allocator_traits
+static uint32_t num_allocs = 0;
+static uint32_t num_deallocs = 0;
+// A very simple custom allocator. Counts calls to allocate and deallocate.
+template<typename T = void>
+struct MyAllocator
+{
+public:
+  using value_type = T;
+  using size_type = std::size_t;
+  using pointer = T *;
+  using const_pointer = const T *;
+  using difference_type = typename std::pointer_traits<pointer>::difference_type;
+
+  MyAllocator() noexcept
+  {
+  }
+
+  ~MyAllocator() noexcept {}
+
+  template<typename U>
+  MyAllocator(const MyAllocator<U> &) noexcept
+  {
+  }
+
+  T * allocate(size_t size, const void * = 0)
+  {
+    if (size == 0) {
+      return nullptr;
+    }
+    num_allocs++;
+    return static_cast<T *>(std::malloc(size * sizeof(T)));
+  }
+
+  void deallocate(T * ptr, size_t size)
+  {
+    (void)size;
+    if (!ptr) {
+      return;
+    }
+    num_deallocs++;
+    std::free(ptr);
+  }
+
+  template<typename U>
+  struct rebind
+  {
+    typedef MyAllocator<U> other;
+  };
+};
+
+template<typename T, typename U>
+constexpr bool operator==(const MyAllocator<T> &,
+  const MyAllocator<U> &) noexcept
+{
+  return true;
+}
+
+template<typename T, typename U>
+constexpr bool operator!=(const MyAllocator<T> &,
+  const MyAllocator<U> &) noexcept
+{
+  return false;
+}
+
+// Override global new and delete to count calls during execution.
+
+static bool is_running = false;
+static uint32_t global_runtime_allocs = 0;
+static uint32_t global_runtime_deallocs = 0;
+
+void * operator new(std::size_t size)
+{
+  if (is_running) {
+    global_runtime_allocs++;
+  }
+  return std::malloc(size);
+}
+
+
+void operator delete(void * ptr) noexcept
+{
+  if (ptr != nullptr) {
+    if (is_running) {
+      global_runtime_deallocs++;
+    }
+    std::free(ptr);
+    ptr = nullptr;
+  }
+}
+
+int main(int argc, char ** argv)
+{
+  using rclcpp::memory_strategies::allocator_memory_strategy::AllocatorMemoryStrategy;
+  rclcpp::init(argc, argv);
+
+  rclcpp::Node::SharedPtr node;
+
+  std::list<std::string> keys = {"intra", "intraprocess", "intra-process", "intra_process"};
+  bool intra_process = false;
+
+  if (argc > 1) {
+    for (auto & key : keys) {
+      if (std::string(argv[1]) == key) {
+        intra_process = true;
+        break;
+      }
+    }
+  }
+
+  if (intra_process) {
+    printf("Intra-process pipeline is ON.\n");
+    auto context = rclcpp::contexts::default_context::get_global_default_context();
+    auto ipm_state =
+      std::make_shared<rclcpp::intra_process_manager::IntraProcessManagerImpl<MyAllocator<>>>();
+    // Constructs the intra-process manager with a custom allocator.
+    context->get_sub_context<rclcpp::intra_process_manager::IntraProcessManager>(ipm_state);
+    node = rclcpp::Node::make_shared("allocator_tutorial", true);
+  } else {
+    printf("Intra-process pipeline is OFF.\n");
+    node = rclcpp::Node::make_shared("allocator_tutorial", false);
+  }
+
+  uint32_t counter = 0;
+  auto callback = [&counter](std_msgs::msg::UInt32::SharedPtr msg) -> void
+    {
+      (void)msg;
+      ++counter;
+    };
+
+  // Create a custom allocator and pass the allocator to the publisher and subscriber.
+  auto alloc = std::make_shared<MyAllocator<void>>();
+  auto publisher = node->create_publisher<std_msgs::msg::UInt32>("allocator_tutorial", 10, alloc);
+  auto msg_mem_strat =
+    std::make_shared<rclcpp::message_memory_strategy::MessageMemoryStrategy<std_msgs::msg::UInt32,
+    MyAllocator<>>>(alloc);
+  auto subscriber = node->create_subscription<std_msgs::msg::UInt32>(
+    "allocator_tutorial", 10, callback, nullptr, false, msg_mem_strat, alloc);
+
+  // Create a MemoryStrategy, which handles the allocations made by the Executor during the
+  // execution path, and inject the MemoryStrategy into the Executor.
+  std::shared_ptr<rclcpp::memory_strategy::MemoryStrategy> memory_strategy =
+    std::make_shared<AllocatorMemoryStrategy<MyAllocator<>>>(alloc);
+
+  rclcpp::executor::ExecutorArgs args;
+  args.memory_strategy = memory_strategy;
+  rclcpp::executors::SingleThreadedExecutor executor(args);
+
+  // Add our node to the executor.
+  executor.add_node(node);
+
+  // Create a message with the custom allocator, so that when the Executor deallocates the
+  // message on the execution path, it will use the custom deallocate.
+  auto msg = std::allocate_shared<std_msgs::msg::UInt32>(*alloc.get());
+
+  rclcpp::utilities::sleep_for(std::chrono::milliseconds(1));
+  is_running = true;
+
+  uint32_t i = 0;
+  while (rclcpp::ok()) {
+    msg->data = i;
+    ++i;
+    publisher->publish(msg);
+    rclcpp::utilities::sleep_for(std::chrono::milliseconds(1));
+    executor.spin_some();
+  }
+  is_running = false;
+
+  uint32_t final_global_allocs = global_runtime_allocs;
+  uint32_t final_global_deallocs = global_runtime_deallocs;
+  printf("Global new was called %u times during spin\n", final_global_allocs);
+  printf("Global delete was called %u times during spin\n", final_global_deallocs);
+
+  printf("Allocator new was called %u times during spin\n", num_allocs);
+  printf("Allocator delete was called %u times during spin\n", num_deallocs);
+}

--- a/demo_nodes_cpp/src/topics/allocator_tutorial.cpp
+++ b/demo_nodes_cpp/src/topics/allocator_tutorial.cpp
@@ -100,6 +100,16 @@ void * operator new(std::size_t size)
   return std::malloc(size);
 }
 
+void operator delete(void * ptr, size_t size) noexcept
+{
+  (void)size;
+  if (ptr != nullptr) {
+    if (is_running) {
+      global_runtime_deallocs++;
+    }
+    std::free(ptr);
+  }
+}
 
 void operator delete(void * ptr) noexcept
 {
@@ -108,7 +118,6 @@ void operator delete(void * ptr) noexcept
       global_runtime_deallocs++;
     }
     std::free(ptr);
-    ptr = nullptr;
   }
 }
 

--- a/demo_nodes_cpp/src/topics/imu_listener.cpp
+++ b/demo_nodes_cpp/src/topics/imu_listener.cpp
@@ -1,0 +1,36 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdio>
+
+#include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/imu.hpp"
+
+void imu_cb(const sensor_msgs::msg::Imu::SharedPtr msg)
+{
+  printf(" accel: [%+6.3f %+6.3f %+6.3f]\n",
+    msg->linear_acceleration.x,
+    msg->linear_acceleration.y,
+    msg->linear_acceleration.z);
+}
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  auto node = rclcpp::Node::make_shared("imu_listener");
+  auto sub = node->create_subscription<sensor_msgs::msg::Imu>(
+    "imu", imu_cb, rmw_qos_profile_sensor_data);
+  rclcpp::spin(node);
+  return 0;
+}

--- a/demo_nodes_cpp/src/topics/listener.cpp
+++ b/demo_nodes_cpp/src/topics/listener.cpp
@@ -1,0 +1,38 @@
+// Copyright 2014 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "std_msgs/msg/string.hpp"
+
+void chatterCallback(const std_msgs::msg::String::SharedPtr msg)
+{
+  std::cout << "I heard: [" << msg->data << "]" << std::endl;
+}
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  auto node = rclcpp::Node::make_shared("listener");
+
+  auto sub = node->create_subscription<std_msgs::msg::String>(
+    "chatter", chatterCallback, rmw_qos_profile_default);
+
+  rclcpp::spin(node);
+
+  return 0;
+}

--- a/demo_nodes_cpp/src/topics/listener_best_effort.cpp
+++ b/demo_nodes_cpp/src/topics/listener_best_effort.cpp
@@ -1,0 +1,31 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/string.hpp"
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  auto node = rclcpp::Node::make_shared("listener");
+  auto sub = node->create_subscription<std_msgs::msg::String>(
+    "chatter", [](const std_msgs::msg::String::SharedPtr msg) -> void {
+    printf("I heard: [%s]\n", msg->data.c_str());
+  }, rmw_qos_profile_sensor_data);
+  rclcpp::spin(node);
+  return 0;
+}

--- a/demo_nodes_cpp/src/topics/talker.cpp
+++ b/demo_nodes_cpp/src/topics/talker.cpp
@@ -1,0 +1,47 @@
+// Copyright 2014 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "std_msgs/msg/string.hpp"
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+
+  auto node = rclcpp::node::Node::make_shared("talker");
+
+  rmw_qos_profile_t custom_qos_profile = rmw_qos_profile_default;
+  custom_qos_profile.depth = 7;
+
+  auto chatter_pub = node->create_publisher<std_msgs::msg::String>("chatter", custom_qos_profile);
+
+  rclcpp::WallRate loop_rate(2);
+
+  auto msg = std::make_shared<std_msgs::msg::String>();
+  auto i = 1;
+
+  while (rclcpp::ok()) {
+    msg->data = "Hello World: " + std::to_string(i++);
+    std::cout << "Publishing: '" << msg->data << "'" << std::endl;
+    chatter_pub->publish(msg);
+    rclcpp::spin_some(node);
+    loop_rate.sleep();
+  }
+
+  return 0;
+}

--- a/demo_nodes_cpp/test/add_two_ints_client.txt
+++ b/demo_nodes_cpp/test/add_two_ints_client.txt
@@ -1,0 +1,1 @@
+Result of add_two_ints: 5

--- a/demo_nodes_cpp/test/add_two_ints_client_async.txt
+++ b/demo_nodes_cpp/test/add_two_ints_client_async.txt
@@ -1,0 +1,1 @@
+Result of add_two_ints: 5

--- a/demo_nodes_cpp/test/add_two_ints_server.txt
+++ b/demo_nodes_cpp/test/add_two_ints_server.txt
@@ -1,0 +1,2 @@
+Incoming request
+a: 2 b: 3

--- a/demo_nodes_cpp/test/list_parameters.txt
+++ b/demo_nodes_cpp/test/list_parameters.txt
@@ -1,0 +1,5 @@
+Parameter name: bar
+Parameter name: foo
+Parameter name: foo.first
+Parameter name: foo.second
+Parameter prefix: foo

--- a/demo_nodes_cpp/test/list_parameters_async.txt
+++ b/demo_nodes_cpp/test/list_parameters_async.txt
@@ -1,0 +1,5 @@
+Parameter name: bar
+Parameter name: foo
+Parameter name: foo.first
+Parameter name: foo.second
+Parameter prefix: foo

--- a/demo_nodes_cpp/test/listener.regex
+++ b/demo_nodes_cpp/test/listener.regex
@@ -1,0 +1,1 @@
+I heard: \[Hello World: \d+\]

--- a/demo_nodes_cpp/test/parameter_events.txt
+++ b/demo_nodes_cpp/test/parameter_events.txt
@@ -1,0 +1,30 @@
+Parameter event:
+ new parameters:
+  foo
+ changed parameters:
+ deleted parameters:
+Parameter event:
+ new parameters:
+  bar
+ changed parameters:
+ deleted parameters:
+Parameter event:
+ new parameters:
+  baz
+ changed parameters:
+ deleted parameters:
+Parameter event:
+ new parameters:
+  foobar
+ changed parameters:
+ deleted parameters:
+Parameter event:
+ new parameters:
+ changed parameters:
+  foo
+ deleted parameters:
+Parameter event:
+ new parameters:
+ changed parameters:
+  bar
+ deleted parameters:

--- a/demo_nodes_cpp/test/parameter_events_async.txt
+++ b/demo_nodes_cpp/test/parameter_events_async.txt
@@ -1,0 +1,30 @@
+Parameter event:
+ new parameters:
+  foo
+ changed parameters:
+ deleted parameters:
+Parameter event:
+ new parameters:
+  bar
+ changed parameters:
+ deleted parameters:
+Parameter event:
+ new parameters:
+  baz
+ changed parameters:
+ deleted parameters:
+Parameter event:
+ new parameters:
+  foobar
+ changed parameters:
+ deleted parameters:
+Parameter event:
+ new parameters:
+ changed parameters:
+  foo
+ deleted parameters:
+Parameter event:
+ new parameters:
+ changed parameters:
+  bar
+ deleted parameters:

--- a/demo_nodes_cpp/test/set_and_get_parameters.txt
+++ b/demo_nodes_cpp/test/set_and_get_parameters.txt
@@ -1,0 +1,4 @@
+Parameter name: foo
+Parameter value (integer): 2
+Parameter name: baz
+Parameter value (double): 1.450000

--- a/demo_nodes_cpp/test/set_and_get_parameters_async.txt
+++ b/demo_nodes_cpp/test/set_and_get_parameters_async.txt
@@ -1,0 +1,4 @@
+Parameter name: foo
+Parameter value (integer): 2
+Parameter name: baz
+Parameter value (double): 1.450000

--- a/demo_nodes_cpp/test/talker.txt
+++ b/demo_nodes_cpp/test/talker.txt
@@ -1,0 +1,1 @@
+Publishing: 'Hello World: 1'

--- a/demo_nodes_cpp/test/test_executables_tutorial.py.in
+++ b/demo_nodes_cpp/test/test_executables_tutorial.py.in
@@ -21,8 +21,8 @@ def test_executable():
     launch_descriptor = LaunchDescriptor()
 
     rmw_implementation = '@rmw_implementation@'
-    executables = '@RCLCPP_EXAMPLES_EXECUTABLE@'.split(';')
-    output_files = '@RCLCPP_EXAMPLES_EXPECTED_OUTPUT@'.split(';')
+    executables = '@DEMO_NODES_CPP_EXECUTABLE@'.split(';')
+    output_files = '@DEMO_NODES_CPP_EXPECTED_OUTPUT@'.split(';')
     for i, (exe, output_file) in enumerate(zip(executables, output_files)):
         name = 'test_executable_' + str(i)
         # The last executable is taken to be the test program (the one whose

--- a/demo_nodes_cpp/test/test_executables_tutorial.py.in
+++ b/demo_nodes_cpp/test/test_executables_tutorial.py.in
@@ -1,0 +1,62 @@
+# generated from rclcpp_tutorials/test/test_executables_tutorial.py.in
+# generated code does not contain a copyright notice
+
+import os
+from launch import LaunchDescriptor
+from launch.exit_handler import ignore_exit_handler
+from launch.exit_handler import primary_ignore_returncode_exit_handler
+from launch.launcher import DefaultLauncher
+from launch.output_handler import ConsoleOutput
+from launch_testing import create_handler
+from launch_testing import get_default_filtered_prefixes
+
+
+def setup():
+    os.environ['OSPL_VERBOSITY'] = '8'  # 8 = OS_NONE
+
+
+def test_executable():
+    output_handlers = []
+
+    launch_descriptor = LaunchDescriptor()
+
+    rmw_implementation = '@rmw_implementation@'
+    executables = '@RCLCPP_EXAMPLES_EXECUTABLE@'.split(';')
+    output_files = '@RCLCPP_EXAMPLES_EXPECTED_OUTPUT@'.split(';')
+    for i, (exe, output_file) in enumerate(zip(executables, output_files)):
+        name = 'test_executable_' + str(i)
+        # The last executable is taken to be the test program (the one whose
+        # output check can make the decision to shut everything down)
+        if i == (len(executables) - 1):
+            exit_handler = primary_ignore_returncode_exit_handler
+            exit_on_match = True
+        else:
+            exit_handler = ignore_exit_handler
+            exit_on_match = False
+
+        filtered = get_default_filtered_prefixes() + [b'service not available, waiting again...']
+        handler = create_handler(
+            name, launch_descriptor, output_file, filtered_prefixes=filtered,
+            exit_on_match=exit_on_match, filtered_rmw_implementation=rmw_implementation)
+        assert handler, 'Cannot find appropriate handler for %s' % output_file
+        output_handlers.append(handler)
+        launch_descriptor.add_process(
+            cmd=[exe, 'test_executable'],
+            name=name,
+            exit_handler=exit_handler,
+            output_handlers=[ConsoleOutput(), handler],
+        )
+
+    launcher = DefaultLauncher()
+    launcher.add_launch_descriptor(launch_descriptor)
+    rc = launcher.launch()
+
+    assert rc == 0, \
+        "The launch file failed with exit code '" + str(rc) + "'. " \
+        'Maybe the client did not receive any messages?'
+
+    for handler in output_handlers:
+        handler.check()
+
+if __name__ == '__main__':
+    test_executable()

--- a/demo_nodes_cpp/test/test_executables_tutorial.py.in
+++ b/demo_nodes_cpp/test/test_executables_tutorial.py.in
@@ -1,4 +1,4 @@
-# generated from rclcpp_tutorials/test/test_executables_tutorial.py.in
+# generated from demo_nodes_cpp/test/test_executables_tutorial.py.in
 # generated code does not contain a copyright notice
 
 import os

--- a/demo_nodes_py/package.xml
+++ b/demo_nodes_py/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>demo_nodes_py</name>
+  <version>0.0.0</version>
+  <description>
+    Python nodes which were previously in the ros2/examples repository but are now just used for demo purposes.
+  </description>
+  <author email="esteve@osrfoundation.org">Esteve Fernandez</author>
+  <maintainer email="mikael@osrfoundation.org">Mikael Arguedas</maintainer>
+  <license>Apache License 2.0</license>
+
+  <exec_depend>example_interfaces</exec_depend>
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>ament_pep8</test_depend>
+  <test_depend>ament_pyflakes</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/demo_nodes_py/services/add_two_ints_client_async_py.py
+++ b/demo_nodes_py/services/add_two_ints_client_async_py.py
@@ -1,0 +1,48 @@
+# Copyright 2016 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+
+import rclpy
+
+from example_interfaces.srv import AddTwoInts
+
+
+def main(args=None):
+
+    rclpy.init(args)
+
+    node = rclpy.create_node('add_two_ints_client')
+
+    cli = node.create_client(AddTwoInts, 'add_two_ints')
+
+    max_iter = 3
+    i = 0
+    req = AddTwoInts.Request()
+    req.a = i
+    req.b = i + 1
+    time.sleep(2)
+    cli.call(req)
+    while rclpy.ok() and i < max_iter:
+        if cli.response is not None:
+            print('Result of add_two_ints: %d' % cli.response.sum)
+            i += 1
+            cli.response = None
+            req.a = i
+            req.b = i + 1
+            cli.call(req)
+        rclpy.spin_once(node)
+
+if __name__ == '__main__':
+    main()

--- a/demo_nodes_py/services/add_two_ints_client_py.py
+++ b/demo_nodes_py/services/add_two_ints_client_py.py
@@ -1,0 +1,38 @@
+# Copyright 2016 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rclpy
+
+from example_interfaces.srv import AddTwoInts
+
+
+def main(args=None):
+    rclpy.init(args)
+
+    node = rclpy.create_node('add_two_ints_client')
+
+    cli = node.create_client(AddTwoInts, 'add_two_ints')
+    max_iter = 3
+    i = 0
+    while rclpy.ok() and i < max_iter:
+        req = AddTwoInts.Request()
+        req.a = i
+        req.b = i + 1
+        cli.call(req)
+        cli.wait_for_future()
+        print('Result of add_two_ints: %d' % cli.response.sum)
+        i += 1
+
+if __name__ == '__main__':
+    main()

--- a/demo_nodes_py/services/add_two_ints_server_py.py
+++ b/demo_nodes_py/services/add_two_ints_server_py.py
@@ -1,0 +1,43 @@
+# Copyright 2016 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rclpy
+
+from example_interfaces.srv import AddTwoInts
+
+
+def add_two_ints_callback(request, response):
+    response.sum = request.a + request.b
+    print('Incoming request\na: %d b:%d' % (request.a, request.b))
+
+    return response
+
+
+def main(args=None):
+    rclpy.init(args)
+
+    node = rclpy.create_node('add_two_ints_server')
+
+    srv = node.create_service(AddTwoInts, 'add_two_ints', add_two_ints_callback)
+    max_iter = 3
+    i = 0
+    while rclpy.ok() and i < max_iter:
+        rclpy.spin_once(node)
+        i += 1
+    # Destroy the service attached to the node explicitly
+    # (optional - otherwise it will be done automatically
+    # when the garbage collector destroys the node object)
+    node.destroy_service(srv)
+if __name__ == '__main__':
+    main()

--- a/demo_nodes_py/setup.py
+++ b/demo_nodes_py/setup.py
@@ -1,0 +1,41 @@
+from setuptools import setup
+
+setup(
+    name='demo_nodes_py',
+    version='0.0.0',
+    packages=[],
+    py_modules=[
+        'topics.listener_py', 'topics.talker_py',
+        'topics.listener_qos_py', 'topics.talker_qos_py',
+        'services.add_two_ints_client_py', 'services.add_two_ints_client_async_py',
+        'services.add_two_ints_server_py'],
+    install_requires=['setuptools'],
+    author='Esteve Fernandez',
+    author_email='esteve@osrfoundation.org',
+    maintainer='Mikael Arguedas',
+    maintainer_email='mikael@osrfoundation.org',
+    keywords=['ROS'],
+    classifiers=[
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: Apache Software License',
+        'Programming Language :: Python',
+        'Topic :: Software Development',
+    ],
+    description=(
+        'Python nodes which were previously in the ros2/examples repository '
+        'but are now just used for demo purposes.'
+    ),
+    license='Apache License, Version 2.0',
+    test_suite='test',
+    entry_points={
+        'console_scripts': [
+            'listener_py = topics.listener_py:main',
+            'talker_py = topics.talker_py:main',
+            'listener_qos_py = topics.listener_qos_py:main',
+            'talker_qos_py = topics.talker_qos_py:main',
+            'add_two_ints_client_py = services.add_two_ints_client_py:main',
+            'add_two_ints_client_async_py = services.add_two_ints_client_async_py:main',
+            'add_two_ints_server_py = services.add_two_ints_server_py:main'
+        ],
+    },
+)

--- a/demo_nodes_py/test/test_copyright.py
+++ b/demo_nodes_py/test/test_copyright.py
@@ -1,0 +1,20 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_copyright.main import main
+
+
+def test_copyright():
+    rc = main(argv=['.', 'test'])
+    assert rc == 0, 'Found errors'

--- a/demo_nodes_py/test/test_pep257.py
+++ b/demo_nodes_py/test/test_pep257.py
@@ -1,0 +1,20 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_pep257.main import main
+
+
+def test_pep257():
+    rc = main(argv=['.', 'test'])
+    assert rc == 0, 'Found code style errors / warnings'

--- a/demo_nodes_py/test/test_pep8.py
+++ b/demo_nodes_py/test/test_pep8.py
@@ -1,0 +1,20 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_pep8.main import main
+
+
+def test_pep8():
+    rc = main(argv=['.', 'test'])
+    assert rc == 0, 'Found code style errors / warnings'

--- a/demo_nodes_py/test/test_pyflakes.py
+++ b/demo_nodes_py/test/test_pyflakes.py
@@ -1,0 +1,20 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_pyflakes.main import main
+
+
+def test_pyflakes():
+    rc = main(argv=['.', 'test'])
+    assert rc == 0, 'Found errors'

--- a/demo_nodes_py/topics/listener_py.py
+++ b/demo_nodes_py/topics/listener_py.py
@@ -1,0 +1,42 @@
+# Copyright 2016 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+import rclpy
+from rclpy.qos import qos_profile_default
+
+from std_msgs.msg import String
+
+
+def chatter_callback(msg):
+    print('I heard: [%s]' % msg.data)
+
+
+def main(args=None):
+    if args is None:
+        args = sys.argv
+
+    rclpy.init(args)
+
+    node = rclpy.create_node('listener')
+
+    sub = node.create_subscription(String, 'chatter', chatter_callback, qos_profile_default)
+    assert sub  # prevent unused warning
+
+    while rclpy.ok():
+        rclpy.spin_once(node)
+
+if __name__ == '__main__':
+    main()

--- a/demo_nodes_py/topics/listener_qos_py.py
+++ b/demo_nodes_py/topics/listener_qos_py.py
@@ -1,0 +1,59 @@
+# Copyright 2016 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import sys
+
+import rclpy
+from rclpy.qos import qos_profile_default, qos_profile_sensor_data
+
+from std_msgs.msg import String
+
+
+def chatter_callback(msg):
+    print('I heard: [%s]' % msg.data)
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        '--reliable', dest='reliable', action='store_true',
+        help='set qos profile to reliable')
+    parser.set_defaults(reliable=False)
+    parser.add_argument(
+        '-n', '--number_of_cycles', type=int, default=20,
+        help='max number of spin_once iterations')
+    args = parser.parse_args(argv)
+    rclpy.init()
+
+    if args.reliable:
+        custom_qos_profile = qos_profile_default
+        print('Reliable listener')
+    else:
+        custom_qos_profile = qos_profile_sensor_data
+        print('Best effort listener')
+
+    node = rclpy.create_node('listener_qos')
+
+    sub = node.create_subscription(String, 'chatter_qos', chatter_callback, custom_qos_profile)
+
+    assert sub  # prevent unused warning
+
+    cycle_count = 0
+    while rclpy.ok() and cycle_count < args.number_of_cycles:
+        rclpy.spin_once(node)
+        cycle_count += 1
+
+if __name__ == '__main__':
+    main()

--- a/demo_nodes_py/topics/talker_py.py
+++ b/demo_nodes_py/topics/talker_py.py
@@ -1,0 +1,47 @@
+# Copyright 2016 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from time import sleep
+
+import rclpy
+
+from rclpy.qos import qos_profile_default
+
+from std_msgs.msg import String
+
+
+def main(args=None):
+    if args is None:
+        args = sys.argv
+
+    rclpy.init(args)
+
+    node = rclpy.create_node('talker')
+
+    chatter_pub = node.create_publisher(String, 'chatter', qos_profile_default)
+
+    msg = String()
+
+    i = 1
+    while True:
+        msg.data = 'Hello World: {0}'.format(i)
+        i += 1
+        print('Publishing: "{0}"'.format(msg.data))
+        chatter_pub.publish(msg)
+        # TODO(wjwwood): need to spin_some or spin_once with timeout
+        sleep(1)
+
+if __name__ == '__main__':
+    main()

--- a/demo_nodes_py/topics/talker_qos_py.py
+++ b/demo_nodes_py/topics/talker_qos_py.py
@@ -1,0 +1,59 @@
+# Copyright 2016 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import sys
+from time import sleep
+
+import rclpy
+from rclpy.qos import qos_profile_default, qos_profile_sensor_data
+
+from std_msgs.msg import String
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        '--reliable', dest='reliable', action='store_true',
+        help='set qos profile to reliable')
+    parser.set_defaults(reliable=False)
+    parser.add_argument(
+        '-n', '--number_of_cycles', type=int, default=20,
+        help='number of sending attempts')
+    args = parser.parse_args(argv)
+    rclpy.init()
+
+    if args.reliable:
+        custom_qos_profile = qos_profile_default
+        print('Reliable publisher')
+    else:
+        custom_qos_profile = qos_profile_sensor_data
+        print('Best effort publisher')
+
+    node = rclpy.create_node('talker_qos')
+
+    chatter_pub = node.create_publisher(String, 'chatter_qos', custom_qos_profile)
+
+    msg = String()
+
+    cycle_count = 0
+    while rclpy.ok() and cycle_count < args.number_of_cycles:
+        msg.data = 'Hello World: {0}'.format(cycle_count)
+        print('Publishing: "{0}"'.format(msg.data))
+        chatter_pub.publish(msg)
+        cycle_count += 1
+        sleep(1)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I basically just copy-paste-renamed `rclcpp_tutorials` (previously `rclcpp_examples`) to `demo_nodes_cpp` as well as renamed `rclpy_tutorials` (previously `rclpy_examples`) to `demo_nodes_py`. I'm doing this to preserve the executables used in many of our demos like `talker`, `talker_py`, `listener`, `listener_best_effort`, etc...

I'm doing this because we'd like to eventually refactor these in the tutorials repository but not break the existing demos and because we're not shipping the tutorials repository for beta1 since it is not ready just yet.

I'm going to open a few more pr's to update documentation in a few places, but otherwise I'm looking for reviews.