### PR TITLE
add server and client

### DIFF
--- a/composition/CMakeLists.txt
+++ b/composition/CMakeLists.txt
@@ -92,7 +92,9 @@ macro(targets)
     src/linktime_composition.cpp)
   set(libs
     talker_component${target_suffix}
-    listener_component${target_suffix})
+    listener_component${target_suffix}
+    server_component${target_suffix}
+    client_component${target_suffix})
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set(libs
       "-Wl,--no-as-needed"
@@ -171,6 +173,8 @@ if(BUILD_TESTING)
     set(DLOPEN_COMPOSITION_EXECUTABLE $<TARGET_FILE:dlopen_composition${target_suffix}>)
     set(TALKER_LIBRARY $<TARGET_FILE:talker_component${target_suffix}>)
     set(LISTENER_LIBRARY $<TARGET_FILE:listener_component${target_suffix}>)
+    set(SERVER_LIBRARY $<TARGET_FILE:server_component${target_suffix}>)
+    set(CLIENT_LIBRARY $<TARGET_FILE:client_component${target_suffix}>)
     set(API_COMPOSITION_EXECUTABLE $<TARGET_FILE:api_composition${target_suffix}>)
     set(API_COMPOSITION_CLI_EXECUTABLE $<TARGET_FILE:api_composition_cli${target_suffix}>)
     set(EXPECTED_OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/test/composition")

--- a/composition/CMakeLists.txt
+++ b/composition/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(ament_index_cpp REQUIRED)
 find_package(class_loader REQUIRED)
+find_package(example_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rmw_implementation_cmake REQUIRED)
 find_package(rosidl_cmake REQUIRED)
@@ -55,11 +56,35 @@ macro(targets)
   rclcpp_register_node_plugins(listener_component${target_suffix} "composition::Listener${target_suffix}")
   set(node_plugins "${node_plugins}composition::Listener${target_suffix};$<TARGET_FILE:listener_component${target_suffix}>\n")
 
+  add_library(server_component${target_suffix} SHARED
+    src/server_component.cpp)
+  target_compile_definitions(server_component${target_suffix}
+    PRIVATE "COMPOSITION_BUILDING_DLL")
+  ament_target_dependencies(server_component${target_suffix}
+    "rclcpp${target_suffix}"
+    "example_interfaces"
+    "class_loader")
+  rclcpp_register_node_plugins(server_component${target_suffix} "composition::Server${target_suffix}")
+  set(node_plugins "${node_plugins}composition::Server${target_suffix};$<TARGET_FILE:server_component${target_suffix}>\n")
+
+  add_library(client_component${target_suffix} SHARED
+    src/client_component.cpp)
+  target_compile_definitions(client_component${target_suffix}
+    PRIVATE "COMPOSITION_BUILDING_DLL")
+  ament_target_dependencies(client_component${target_suffix}
+    "rclcpp${target_suffix}"
+    "example_interfaces"
+    "class_loader")
+  rclcpp_register_node_plugins(client_component${target_suffix} "composition::Client${target_suffix}")
+  set(node_plugins "${node_plugins}composition::Client${target_suffix};$<TARGET_FILE:client_component${target_suffix}>\n")
+
   add_executable(manual_composition${target_suffix}
     src/manual_composition.cpp)
   target_link_libraries(manual_composition${target_suffix}
     talker_component${target_suffix}
-    listener_component${target_suffix})
+    listener_component${target_suffix}
+    server_component${target_suffix}
+    client_component${target_suffix})
   ament_target_dependencies(manual_composition${target_suffix}
     "rclcpp${target_suffix}")
 
@@ -117,6 +142,8 @@ macro(targets)
   install(TARGETS
     talker_component${target_suffix}
     listener_component${target_suffix}
+    server_component${target_suffix}
+    client_component${target_suffix}
     manual_composition${target_suffix}
     linktime_composition${target_suffix}
     dlopen_composition${target_suffix}

--- a/composition/include/composition/client_component.hpp
+++ b/composition/include/composition/client_component.hpp
@@ -1,0 +1,41 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COMPOSITION__CLIENT_COMPONENT_HPP_
+#define COMPOSITION__CLIENT_COMPONENT_HPP_
+
+#include "composition/visibility_control.h"
+#include "example_interfaces/srv/add_two_ints.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+namespace composition
+{
+
+class Client : public rclcpp::Node
+{
+public:
+  COMPOSITION_PUBLIC
+  Client();
+
+protected:
+  bool on_timer();
+
+private:
+  rclcpp::client::Client<example_interfaces::srv::AddTwoInts>::SharedPtr client_;
+  rclcpp::timer::TimerBase::SharedPtr timer_;
+};
+
+}  // namespace composition
+
+#endif  // COMPOSITION__CLIENT_COMPONENT_HPP_

--- a/composition/include/composition/server_component.hpp
+++ b/composition/include/composition/server_component.hpp
@@ -1,0 +1,37 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COMPOSITION__SERVER_COMPONENT_HPP_
+#define COMPOSITION__SERVER_COMPONENT_HPP_
+
+#include "composition/visibility_control.h"
+#include "example_interfaces/srv/add_two_ints.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+namespace composition
+{
+
+class Server : public rclcpp::Node
+{
+public:
+  COMPOSITION_PUBLIC
+  Server();
+
+private:
+  rclcpp::service::Service<example_interfaces::srv::AddTwoInts>::SharedPtr srv_;
+};
+
+}  // namespace composition
+
+#endif  // COMPOSITION__SERVER_COMPONENT_HPP_

--- a/composition/package.xml
+++ b/composition/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>ament_index_cpp</build_depend>
   <build_depend>class_loader</build_depend>
+  <build_depend>example_interfaces</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>rmw_implementation_cmake</build_depend>
   <build_depend>rosidl_cmake</build_depend>
@@ -17,6 +18,7 @@
 
   <exec_depend>ament_index_cpp</exec_depend>
   <exec_depend>class_loader</exec_depend>
+  <exec_depend>example_interfaces</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 

--- a/composition/src/client_component.cpp
+++ b/composition/src/client_component.cpp
@@ -47,7 +47,7 @@ Client::Client()
 : Node("Client")
 {
   client_ = create_client<example_interfaces::srv::AddTwoInts>("add_two_ints");
-  timer_ = create_wall_timer(1_s, std::bind(&Client::on_timer, this));
+  timer_ = create_wall_timer(1s, std::bind(&Client::on_timer, this));
 }
 
 bool Client::on_timer()

--- a/composition/src/client_component.cpp
+++ b/composition/src/client_component.cpp
@@ -1,0 +1,88 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "composition/client_component.hpp"
+
+#include <iostream>
+#include <memory>
+
+#include "example_interfaces/srv/add_two_ints.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+using namespace std::chrono_literals;
+
+namespace composition
+{
+
+template<typename FutureT, typename WaitTimeT>
+std::future_status
+wait_for_result(
+  FutureT & future,
+  WaitTimeT time_to_wait)
+{
+  auto end = std::chrono::steady_clock::now() + time_to_wait;
+  std::chrono::milliseconds wait_period(100);
+  std::future_status status = std::future_status::timeout;
+  do {
+    auto now = std::chrono::steady_clock::now();
+    auto time_left = end - now;
+    if (time_left <= std::chrono::seconds(0)) {break;}
+    status = future.wait_for((time_left < wait_period) ? time_left : wait_period);
+  } while (rclcpp::ok() && status != std::future_status::ready);
+  return status;
+}
+
+Client::Client()
+: Node("Client")
+{
+  client_ = create_client<example_interfaces::srv::AddTwoInts>("add_two_ints");
+  timer_ = create_wall_timer(1_s, std::bind(&Client::on_timer, this));
+}
+
+bool Client::on_timer()
+{
+  auto request = std::make_shared<example_interfaces::srv::AddTwoInts::Request>();
+  request->a = 2;
+  request->b = 3;
+
+  while (!client_->wait_for_service(1s)) {
+    if (!rclcpp::ok()) {
+      fprintf(stderr,
+        "add_two_ints_client was interrupted while waiting for the service. Exiting.\n");
+      return false;
+    }
+    fprintf(stderr, "service not available, waiting again...\n");
+  }
+
+  // We currently cannot call spin in a spin.
+  // That results in the fact that we cannot trigger and wait for
+  // a service call within the timer callback.
+  // The workaround for this is to give the async request another
+  // callback which gets executed once the future is ready.
+  // decltype(client_)::element_type::SharedFuture
+  // = rclcpp::client::Client<example_interfaces::srv::AddTwoInts>::SharedFuture
+  auto return_callback = [](decltype(client_)::element_type::SharedFuture future) {
+      printf("Got result: [%s]\n",
+        std::to_string(future.get()->sum).c_str());
+    };
+  auto future_result = client_->async_send_request(request, return_callback);
+
+  return true;
+}
+
+}  // namespace composition
+
+#include "class_loader/class_loader_register_macro.h"
+
+CLASS_LOADER_REGISTER_CLASS(composition::Client, rclcpp::Node)

--- a/composition/src/client_component.cpp
+++ b/composition/src/client_component.cpp
@@ -76,7 +76,7 @@ bool Client::on_timer()
   // We then return from this callback so that the existing spin() function can
   // continue and our callback will get called once the response is received.
   using ServiceResponseFuture =
-    rclcpp::client::Client<example_interfaces::srv::AddTwoInts>::SharedFuture;
+      rclcpp::client::Client<example_interfaces::srv::AddTwoInts>::SharedFuture;
   auto response_received_callback = [](ServiceResponseFuture future) {
       printf("Got result: [%s]\n",
         std::to_string(future.get()->sum).c_str());

--- a/composition/src/manual_composition.cpp
+++ b/composition/src/manual_composition.cpp
@@ -14,8 +14,10 @@
 
 #include <memory>
 
+#include "composition/client_component.hpp"
 #include "composition/listener_component.hpp"
 #include "composition/talker_component.hpp"
+#include "composition/server_component.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 int main(int argc, char * argv[])
@@ -27,6 +29,10 @@ int main(int argc, char * argv[])
   exec.add_node(talker);
   auto listener = std::make_shared<composition::Listener>();
   exec.add_node(listener);
+  auto server = std::make_shared<composition::Server>();
+  exec.add_node(server);
+  auto client = std::make_shared<composition::Client>();
+  exec.add_node(client);
 
   exec.spin();
   return 0;

--- a/composition/src/server_component.cpp
+++ b/composition/src/server_component.cpp
@@ -1,0 +1,49 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "composition/server_component.hpp"
+
+#include <iostream>
+#include <memory>
+
+#include "example_interfaces/srv/add_two_ints.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+namespace composition
+{
+
+Server::Server()
+: Node("Server")
+{
+  auto handle_add_two_ints =
+    [](
+    const std::shared_ptr<example_interfaces::srv::AddTwoInts::Request> request,
+    std::shared_ptr<example_interfaces::srv::AddTwoInts::Response> response
+    ) -> void
+    {
+      printf("Incoming request: [a: %s, b: %s]\n",
+        std::to_string(request->a).c_str(),
+        std::to_string(request->b).c_str());
+      std::flush(std::cout);
+      response->sum = request->a + request->b;
+    };
+
+  srv_ = create_service<example_interfaces::srv::AddTwoInts>("add_two_ints", handle_add_two_ints);
+}
+
+}  // namespace composition
+
+#include "class_loader/class_loader_register_macro.h"
+
+CLASS_LOADER_REGISTER_CLASS(composition::Server, rclcpp::Node)

--- a/composition/test/composition.regex
+++ b/composition/test/composition.regex
@@ -1,1 +1,2 @@
 I heard: \[Hello World: \d+\]
+Incoming request: \[a: \d+, b: \d+\]

--- a/composition/test/test_composition.py.in
+++ b/composition/test/test_composition.py.in
@@ -43,7 +43,9 @@ def test_dlopen_composition():
     executable = '@DLOPEN_COMPOSITION_EXECUTABLE@'
     talker_library = '@TALKER_LIBRARY@'
     listener_library = '@LISTENER_LIBRARY@'
-    launch(name, [executable, talker_library, listener_library])
+    server_library = '@SERVER_LIBRARY@'
+    client_library = '@CLIENT_LIBRARY@'
+    launch(name, [executable, talker_library, listener_library, server_library, client_library])
 
 
 def test_api_composition():
@@ -63,6 +65,20 @@ def test_api_composition():
                 '@API_COMPOSITION_CLI_EXECUTABLE@',
                 'composition', 'composition::Listener'],
             'name': 'load_listener_component',
+            'exit_handler': exit_on_error_exit_handler,
+        },
+        {
+            'cmd': [
+                '@API_COMPOSITION_CLI_EXECUTABLE@',
+                'composition', 'composition::Server'],
+            'name': 'load_server_component',
+            'exit_handler': exit_on_error_exit_handler,
+        },
+        {
+            'cmd': [
+                '@API_COMPOSITION_CLI_EXECUTABLE@',
+                'composition', 'composition::Client'],
+            'name': 'load_client_component',
             'exit_handler': exit_on_error_exit_handler,
         },
     ]


### PR DESCRIPTION
Adding server and clients to the composition demo.

I had to do some non-obvious things in the `on_timer` callback for the client. The reason is because we can't trigger AND wait for a service client within a walltimer callback. This effectively results in a spin-within-a-spin which is currently not provided.
The workaround for this is to send the async client request and give it a callback to execute once this request returns true.

@dirk-thomas What is missing here is the test for the two added elements.