### PR TITLE
dependency order

### DIFF
--- a/composition/CMakeLists.txt
+++ b/composition/CMakeLists.txt
@@ -39,9 +39,9 @@ macro(targets)
   target_compile_definitions(talker_component${target_suffix}
     PRIVATE "COMPOSITION_BUILDING_DLL")
   ament_target_dependencies(talker_component${target_suffix}
+    "class_loader"
     "rclcpp${target_suffix}"
-    "std_msgs"
-    "class_loader")
+    "std_msgs")
   rclcpp_register_node_plugins(talker_component${target_suffix} "composition::Talker${target_suffix}")
   set(node_plugins "${node_plugins}composition::Talker${target_suffix};$<TARGET_FILE:talker_component${target_suffix}>\n")
 
@@ -50,9 +50,9 @@ macro(targets)
   target_compile_definitions(listener_component${target_suffix}
     PRIVATE "COMPOSITION_BUILDING_DLL")
   ament_target_dependencies(listener_component${target_suffix}
+    "class_loader"
     "rclcpp${target_suffix}"
-    "std_msgs"
-    "class_loader")
+    "std_msgs")
   rclcpp_register_node_plugins(listener_component${target_suffix} "composition::Listener${target_suffix}")
   set(node_plugins "${node_plugins}composition::Listener${target_suffix};$<TARGET_FILE:listener_component${target_suffix}>\n")
 
@@ -61,9 +61,9 @@ macro(targets)
   target_compile_definitions(server_component${target_suffix}
     PRIVATE "COMPOSITION_BUILDING_DLL")
   ament_target_dependencies(server_component${target_suffix}
-    "rclcpp${target_suffix}"
+    "class_loader"
     "example_interfaces"
-    "class_loader")
+    "rclcpp${target_suffix}")
   rclcpp_register_node_plugins(server_component${target_suffix} "composition::Server${target_suffix}")
   set(node_plugins "${node_plugins}composition::Server${target_suffix};$<TARGET_FILE:server_component${target_suffix}>\n")
 
@@ -72,9 +72,9 @@ macro(targets)
   target_compile_definitions(client_component${target_suffix}
     PRIVATE "COMPOSITION_BUILDING_DLL")
   ament_target_dependencies(client_component${target_suffix}
-    "rclcpp${target_suffix}"
+    "class_loader"
     "example_interfaces"
-    "class_loader")
+    "rclcpp${target_suffix}")
   rclcpp_register_node_plugins(client_component${target_suffix} "composition::Client${target_suffix}")
   set(node_plugins "${node_plugins}composition::Client${target_suffix};$<TARGET_FILE:client_component${target_suffix}>\n")
 
@@ -103,14 +103,14 @@ macro(targets)
   endif()
   target_link_libraries(linktime_composition${target_suffix} ${libs})
   ament_target_dependencies(linktime_composition${target_suffix}
-    "rclcpp${target_suffix}"
-    "class_loader")
+    "class_loader"
+    "rclcpp${target_suffix}")
 
   add_executable(dlopen_composition${target_suffix}
     src/dlopen_composition.cpp)
   ament_target_dependencies(dlopen_composition${target_suffix}
-    "rclcpp${target_suffix}"
-    "class_loader")
+    "class_loader"
+    "rclcpp${target_suffix}")
 
   add_executable(api_composition${target_suffix}
     src/api_composition.cpp)
@@ -122,9 +122,9 @@ macro(targets)
     target_link_libraries(api_composition${target_suffix} "stdc++fs")
   endif()
   ament_target_dependencies(api_composition${target_suffix}
-    "rclcpp${target_suffix}"
     "ament_index_cpp"
-    "class_loader")
+    "class_loader"
+    "rclcpp${target_suffix}")
   get_rmw_typesupport(typesupport_impls "${rmw_implementation}" LANGUAGE "cpp")
   foreach(typesupport_impl ${typesupport_impls})
     rosidl_target_interfaces(api_composition${target_suffix}

--- a/demo_nodes_cpp/CMakeLists.txt
+++ b/demo_nodes_cpp/CMakeLists.txt
@@ -16,12 +16,10 @@ find_package(std_msgs REQUIRED)
 
 function(custom_executable subfolder target)
   add_executable(${target}${target_suffix} src/${subfolder}/${target}.cpp)
-  # TODO(dhood): Allow dependencies to be listed in arbitrary order without affecting the selected
-  # typesupport. See https://github.com/ros2/ros2/issues/253
   ament_target_dependencies(${target}${target_suffix}
+    "example_interfaces"
     "rclcpp${target_suffix}"
-    "std_msgs"
-    "example_interfaces")
+    "std_msgs")
   install(TARGETS ${target}${target_suffix}
     DESTINATION bin)
 endfunction()

--- a/pendulum_control/CMakeLists.txt
+++ b/pendulum_control/CMakeLists.txt
@@ -31,26 +31,24 @@ macro(targets)
 
   add_executable(pendulum_demo${target_suffix}
     src/pendulum_demo.cpp)
-  # TODO(dhood): Allow dependencies to be listed in arbitrary order without affecting the selected
-  # typesupport. Same below. See https://github.com/ros2/ros2/issues/253
   ament_target_dependencies(pendulum_demo${target_suffix}
-    "rclcpp${target_suffix}"
     "pendulum_msgs"
+    "rclcpp${target_suffix}"
     "rttest"
     "tlsf_cpp")
 
   add_executable(pendulum_logger${target_suffix}
     src/pendulum_logger.cpp)
   ament_target_dependencies(pendulum_logger${target_suffix}
-    "rclcpp${target_suffix}"
     "pendulum_msgs"
+    "rclcpp${target_suffix}"
     "rttest")
 
   add_executable(pendulum_teleop${target_suffix}
     src/pendulum_teleop.cpp)
   ament_target_dependencies(pendulum_teleop${target_suffix}
-    "rclcpp${target_suffix}"
     "pendulum_msgs"
+    "rclcpp${target_suffix}"
     "rttest")
 
   install(TARGETS


### PR DESCRIPTION
now that the typesupport refactor is done (https://github.com/ros2/ros2/issues/253#issuecomment-270202324) we can reorder dependencies properly

CI:
Linux: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2195)](http://ci.ros2.org/job/ci_linux/2195)
OSX: TBD
Windows: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2189)](http://ci.ros2.org/job/ci_windows/2189/)