### PR TITLE
add missing include of thread

### DIFF
--- a/lifecycle/src/lifecycle_service_client.cpp
+++ b/lifecycle/src/lifecycle_service_client.cpp
@@ -15,6 +15,7 @@
 #include <chrono>
 #include <memory>
 #include <string>
+#include <thread>
 
 #include "lifecycle_msgs/msg/state.hpp"
 #include "lifecycle_msgs/msg/transition.hpp"

--- a/lifecycle/src/lifecycle_talker.cpp
+++ b/lifecycle/src/lifecycle_talker.cpp
@@ -16,6 +16,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <thread>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/publisher.hpp"


### PR DESCRIPTION
My local linter is more picky and wants this header since both files use `std::this_thread::sleep_for`.