### PR TITLE
Add support for RGB8

### DIFF
--- a/image_tools/src/showimage.cpp
+++ b/image_tools/src/showimage.cpp
@@ -34,15 +34,20 @@ encoding2mat_type(const std::string & encoding)
 {
   if (encoding == "mono8") {
     return CV_8UC1;
-  } else if (encoding == "bgr8") {
+  }
+  else if (encoding == "bgr8") {
     return CV_8UC3;
-  } else if (encoding == "mono16") {
+  }
+  else if (encoding == "mono16") {
     return CV_16SC1;
-  } else if (encoding == "rgba8") {
+  }
+  else if (encoding == "rgba8") {
     return CV_8UC4;
-  } else if (encoding == "32FC1") {
+  }
+  else if (encoding == "32FC1") {
     return CV_32FC1;
-  } else {
+  }
+  else {
     throw std::runtime_error("Unsupported encoding type");
   }
 }
@@ -81,9 +86,8 @@ int main(int argc, char * argv[])
   bool show_camera = true;
 
   // Configure demo parameters with command line options.
-  if (!parse_command_options(argc, argv, &depth, &reliability_policy, &history_policy,
-    &show_camera))
-  {
+  if (!parse_command_options(argc, argv, &depth, &reliability_policy,
+                             &history_policy, &show_camera)) {
     return 0;
   }
 

--- a/image_tools/src/showimage.cpp
+++ b/image_tools/src/showimage.cpp
@@ -35,23 +35,17 @@ encoding2mat_type(const std::string & encoding)
 {
   if (encoding == "mono8") {
     return CV_8UC1;
-  }
-  else if (encoding == "bgr8") {
+  } else if (encoding == "bgr8") {
     return CV_8UC3;
-  }
-  else if (encoding == "mono16") {
+  } else if (encoding == "mono16") {
     return CV_16SC1;
-  }
-  else if (encoding == "rgba8") {
+  } else if (encoding == "rgba8") {
     return CV_8UC4;
-  }
-  else if (encoding == "32FC1") {
+  } else if (encoding == "32FC1") {
     return CV_32FC1;
-  }
-  else if (encoding == "rgb8") {
+  } else if (encoding == "rgb8") {
     return CV_8UC3;
-  }
-  else {
+  } else {
     throw std::runtime_error("Unsupported encoding type");
   }
 }
@@ -73,8 +67,7 @@ void show_image(const sensor_msgs::msg::Image::SharedPtr msg, bool show_camera)
       cv::Mat frame2;
       cv::cvtColor(frame, frame2, cv::COLOR_RGB2BGR);
       cvframe = frame2;
-    }
-    else {
+    } else {
       cvframe = frame;
     }
 
@@ -99,8 +92,9 @@ int main(int argc, char * argv[])
   bool show_camera = true;
 
   // Configure demo parameters with command line options.
-  if (!parse_command_options(argc, argv, &depth, &reliability_policy,
-                             &history_policy, &show_camera)) {
+  if (!parse_command_options(
+      argc, argv, &depth, &reliability_policy, &history_policy, &show_camera))
+  {
     return 0;
   }
 

--- a/image_tools/src/showimage.cpp
+++ b/image_tools/src/showimage.cpp
@@ -17,6 +17,7 @@
 #include <string>
 
 #include "opencv2/highgui/highgui.hpp"
+#include "opencv2/imgproc/imgproc.hpp"
 
 #include "rclcpp/rclcpp.hpp"
 
@@ -47,6 +48,9 @@ encoding2mat_type(const std::string & encoding)
   else if (encoding == "32FC1") {
     return CV_32FC1;
   }
+  else if (encoding == "rgb8") {
+    return CV_8UC3;
+  }
   else {
     throw std::runtime_error("Unsupported encoding type");
   }
@@ -64,10 +68,19 @@ void show_image(const sensor_msgs::msg::Image::SharedPtr msg, bool show_camera)
       msg->height, msg->width, encoding2mat_type(msg->encoding),
       const_cast<unsigned char *>(msg->data.data()), msg->step);
 
+    CvMat cvframe;
+    if (msg->encoding == "rgb8") {
+      cv::Mat frame2;
+      cv::cvtColor(frame, frame2, cv::COLOR_RGB2BGR);
+      cvframe = frame2;
+    }
+    else {
+      cvframe = frame;
+    }
+
     // NOTE(esteve): Use C version of cvShowImage to avoid this on Windows:
     // http://stackoverflow.com/q/20854682
     // Show the image in a window called "showimage".
-    CvMat cvframe = frame;
     cvShowImage("showimage", &cvframe);
     // Draw the screen and wait for 1 millisecond.
     cv::waitKey(1);


### PR DESCRIPTION
The showimage viewer is a useful program to have for viewing data other than that from cam2image.  Here we expand it so that it supports rgb8 as well as bgr8.