### PR TITLE
Fixed incorrect image size in watermark and image view nodes

### DIFF
--- a/intra_process_demo/src/image_pipeline/image_view_node.hpp
+++ b/intra_process_demo/src/image_pipeline/image_view_node.hpp
@@ -36,7 +36,7 @@ public:
       input, [node_name](const sensor_msgs::msg::Image::SharedPtr msg) {
       // Create a cv::Mat from the image message (without copying).
       cv::Mat cv_mat(
-        msg->width, msg->height,
+        msg->height, msg->width,
         encoding2mat_type(msg->encoding),
         msg->data.data());
       // Annotate with the pid and pointer address.

--- a/intra_process_demo/src/image_pipeline/watermark_node.hpp
+++ b/intra_process_demo/src/image_pipeline/watermark_node.hpp
@@ -46,7 +46,7 @@ public:
       }
       // Create a cv::Mat from the image message (without copying).
       cv::Mat cv_mat(
-        msg->width, msg->height,
+        msg->height, msg->width,
         encoding2mat_type(msg->encoding),
         msg->data.data());
       // Annotate the image with the pid, pointer address, and the watermark text.


### PR DESCRIPTION
cv::Mat constructor takes (# of rows, # of cols), which is (height, width) instead of the previously used (width, height).

This fix causes images and watermarks to look right when running demos like image_pipeline_all_in_one.