### PR TITLE
Added ability to disable pid/ptr on images

### DIFF
--- a/intra_process_demo/src/image_pipeline/camera_node.hpp
+++ b/intra_process_demo/src/image_pipeline/camera_node.hpp
@@ -32,8 +32,8 @@ class CameraNode : public rclcpp::Node
 {
 public:
   CameraNode(const std::string & output, const std::string & node_name = "camera_node",
-    int device = 0, int width = 320, int height = 240)
-  : Node(node_name, "", true), canceled_(false)
+    bool watermark = true, int device = 0, int width = 320, int height = 240)
+  : Node(node_name, "", true), canceled_(false), watermark_(watermark)
   {
     // Initialize OpenCV
     cap_.open(device);
@@ -68,10 +68,13 @@ public:
       }
       // Create a new unique_ptr to an Image message for storage.
       sensor_msgs::msg::Image::UniquePtr msg(new sensor_msgs::msg::Image());
-      std::stringstream ss;
-      // Put this process's id and the msg's pointer address on the image.
-      ss << "pid: " << GETPID() << ", ptr: " << msg.get();
-      draw_on_image(frame_, ss.str(), 20);
+
+      if(watermark_.load()) {
+        std::stringstream ss;
+        // Put this process's id and the msg's pointer address on the image.
+        ss << "pid: " << GETPID() << ", ptr: " << msg.get();
+        draw_on_image(frame_, ss.str(), 20);
+      }
       // Pack the OpenCV image into the ROS image.
       set_now(msg->header.stamp);
       msg->header.frame_id = "camera_frame";
@@ -89,6 +92,10 @@ private:
   rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr pub_;
   std::thread thread_;
   std::atomic<bool> canceled_;
+
+  /// whether or not to add a watermark to the image showing process id and
+  /// pointer location
+  std::atomic<bool> watermark_;
 
   cv::VideoCapture cap_;
   cv::Mat frame_;

--- a/intra_process_demo/src/image_pipeline/camera_node.hpp
+++ b/intra_process_demo/src/image_pipeline/camera_node.hpp
@@ -69,7 +69,7 @@ public:
       // Create a new unique_ptr to an Image message for storage.
       sensor_msgs::msg::Image::UniquePtr msg(new sensor_msgs::msg::Image());
 
-      if(watermark_) {
+      if (watermark_) {
         std::stringstream ss;
         // Put this process's id and the msg's pointer address on the image.
         ss << "pid: " << GETPID() << ", ptr: " << msg.get();

--- a/intra_process_demo/src/image_pipeline/camera_node.hpp
+++ b/intra_process_demo/src/image_pipeline/camera_node.hpp
@@ -69,7 +69,7 @@ public:
       // Create a new unique_ptr to an Image message for storage.
       sensor_msgs::msg::Image::UniquePtr msg(new sensor_msgs::msg::Image());
 
-      if(watermark_.load()) {
+      if(watermark_) {
         std::stringstream ss;
         // Put this process's id and the msg's pointer address on the image.
         ss << "pid: " << GETPID() << ", ptr: " << msg.get();
@@ -95,7 +95,7 @@ private:
 
   /// whether or not to add a watermark to the image showing process id and
   /// pointer location
-  std::atomic<bool> watermark_;
+  bool watermark_;
 
   cv::VideoCapture cap_;
   cv::Mat frame_;

--- a/intra_process_demo/src/image_pipeline/image_view_node.hpp
+++ b/intra_process_demo/src/image_pipeline/image_view_node.hpp
@@ -29,7 +29,7 @@ class ImageViewNode : public rclcpp::Node
 public:
   explicit ImageViewNode(
     const std::string & input, const std::string & node_name = "image_view_node",
-    bool watermark=true)
+    bool watermark = true)
   : Node(node_name, "", true)
   {
     // Create a subscription on the input topic.
@@ -40,7 +40,7 @@ public:
         msg->width, msg->height,
         encoding2mat_type(msg->encoding),
         msg->data.data());
-      if(watermark) {
+      if (watermark) {
         // Annotate with the pid and pointer address.
         std::stringstream ss;
         ss << "pid: " << GETPID() << ", ptr: " << msg.get();

--- a/intra_process_demo/src/image_pipeline/image_view_node.hpp
+++ b/intra_process_demo/src/image_pipeline/image_view_node.hpp
@@ -28,21 +28,24 @@ class ImageViewNode : public rclcpp::Node
 {
 public:
   explicit ImageViewNode(
-    const std::string & input, const std::string & node_name = "image_view_node")
+    const std::string & input, const std::string & node_name = "image_view_node",
+    bool watermark=true)
   : Node(node_name, "", true)
   {
     // Create a subscription on the input topic.
     sub_ = this->create_subscription<sensor_msgs::msg::Image>(
-      input, [node_name](const sensor_msgs::msg::Image::SharedPtr msg) {
+      input, [node_name, watermark](const sensor_msgs::msg::Image::SharedPtr msg) {
       // Create a cv::Mat from the image message (without copying).
       cv::Mat cv_mat(
         msg->width, msg->height,
         encoding2mat_type(msg->encoding),
         msg->data.data());
-      // Annotate with the pid and pointer address.
-      std::stringstream ss;
-      ss << "pid: " << GETPID() << ", ptr: " << msg.get();
-      draw_on_image(cv_mat, ss.str(), 60);
+      if(watermark) {
+        // Annotate with the pid and pointer address.
+        std::stringstream ss;
+        ss << "pid: " << GETPID() << ", ptr: " << msg.get();
+        draw_on_image(cv_mat, ss.str(), 60);
+      }
       // Show the image.
       CvMat c_mat = cv_mat;
       cvShowImage(node_name.c_str(), &c_mat);


### PR DESCRIPTION
For image_view_node and camera_node, added flag that turns off the "watermark" with the pid and image
data pointer. The default behavior remains unchanged.