### PR TITLE
Various fixes

### DIFF
--- a/demo_nodes_py/topics/listener_qos.py
+++ b/demo_nodes_py/topics/listener_qos.py
@@ -47,7 +47,7 @@ def main(argv=sys.argv[1:]):
     node = rclpy.create_node('listener_qos')
 
     sub = node.create_subscription(
-        String, 'chatter_qos', chatter_callback, qos_profile=custom_qos_profile)
+        String, 'chatter', chatter_callback, qos_profile=custom_qos_profile)
 
     assert sub  # prevent unused warning
 

--- a/demo_nodes_py/topics/talker_qos.py
+++ b/demo_nodes_py/topics/talker_qos.py
@@ -44,7 +44,7 @@ def main(argv=sys.argv[1:]):
     node = rclpy.create_node('talker_qos')
 
     chatter_pub = node.create_publisher(
-        String, 'chatter_qos', qos_profile=custom_qos_profile)
+        String, 'chatter', qos_profile=custom_qos_profile)
 
     msg = String()
 

--- a/dummy_robot/dummy_map_server/CMakeLists.txt
+++ b/dummy_robot/dummy_map_server/CMakeLists.txt
@@ -18,9 +18,11 @@ find_package(rmw REQUIRED)
 add_executable(dummy_map_server src/dummy_map_server.cpp)
 ament_target_dependencies(dummy_map_server
   "rclcpp"
-  "nav_msgs")
+  "nav_msgs"
+)
+
 install(TARGETS dummy_map_server
-  DESTINATION bin)
+  DESTINATION lib/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/dummy_robot/dummy_robot_bringup/launch/dummy_robot_bringup.py
+++ b/dummy_robot/dummy_robot_bringup/launch/dummy_robot_bringup.py
@@ -16,14 +16,12 @@ import os
 
 from ament_index_python.packages import get_package_prefix
 from ament_index_python.packages import get_package_share_directory
-from launch import LaunchDescriptor
-from launch.launcher import DefaultLauncher
 
 file_path = os.path.dirname(os.path.realpath(__file__))
 
 
-def launch():
-    ld = LaunchDescriptor()
+def launch(launch_descriptor, argv):
+    ld = launch_descriptor
 
     package = 'dummy_map_server'
     ld.add_process(
@@ -48,13 +46,3 @@ def launch():
     ld.add_process(
         cmd=[os.path.join(get_package_prefix(package), 'lib', package, 'dummy_joint_states')],
     )
-
-    launcher = DefaultLauncher()
-    launcher.add_launch_descriptor(ld)
-    rc = launcher.launch()
-
-    assert rc == 0, "The launch file failed with exit code '" + str(rc) + "'. "
-
-
-if __name__ == "__main__":
-    launch()

--- a/dummy_robot/dummy_robot_bringup/launch/dummy_robot_bringup.py
+++ b/dummy_robot/dummy_robot_bringup/launch/dummy_robot_bringup.py
@@ -14,8 +14,8 @@
 
 import os
 
-from ament_index_python.packages import get_package_prefix
 from ament_index_python.packages import get_package_share_directory
+from ros2run.api import get_executable_path
 
 file_path = os.path.dirname(os.path.realpath(__file__))
 
@@ -25,14 +25,13 @@ def launch(launch_descriptor, argv):
 
     package = 'dummy_map_server'
     ld.add_process(
-        cmd=[os.path.join(get_package_prefix(package), 'lib', package, 'dummy_map_server')],
+        cmd=[get_executable_path(package_name=package, executable_name='dummy_map_server')],
     )
 
     package = 'robot_state_publisher'
     ld.add_process(
         cmd=[
-            os.path.join(
-                get_package_prefix(package), 'lib', package, 'robot_state_publisher'),
+            get_executable_path(package_name=package, executable_name='robot_state_publisher'),
             os.path.join(
                 get_package_share_directory('dummy_robot_bringup'), 'launch', 'single_rrbot.urdf')
         ],
@@ -40,9 +39,9 @@ def launch(launch_descriptor, argv):
 
     package = 'dummy_sensors'
     ld.add_process(
-        cmd=[os.path.join(get_package_prefix(package), 'lib', package, 'dummy_laser')],
+        cmd=[get_executable_path(package_name=package, executable_name='dummy_laser')],
     )
 
     ld.add_process(
-        cmd=[os.path.join(get_package_prefix(package), 'lib', package, 'dummy_joint_states')],
+        cmd=[get_executable_path(package_name=package, executable_name='dummy_joint_states')],
     )

--- a/dummy_robot/dummy_robot_bringup/launch/dummy_robot_bringup.py
+++ b/dummy_robot/dummy_robot_bringup/launch/dummy_robot_bringup.py
@@ -14,6 +14,8 @@
 
 import os
 
+from ament_index_python.packages import get_package_prefix
+from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescriptor
 from launch.launcher import DefaultLauncher
 
@@ -23,19 +25,28 @@ file_path = os.path.dirname(os.path.realpath(__file__))
 def launch():
     ld = LaunchDescriptor()
 
+    package = 'dummy_map_server'
     ld.add_process(
-        cmd=['dummy_laser'],
+        cmd=[os.path.join(get_package_prefix(package), 'lib', package, 'dummy_map_server')],
     )
+
+    package = 'robot_state_publisher'
     ld.add_process(
-        cmd=['dummy_map_server'],
+        cmd=[
+            os.path.join(
+                get_package_prefix(package), 'lib', package, 'robot_state_publisher'),
+            os.path.join(
+                get_package_share_directory('dummy_robot_bringup'), 'launch', 'single_rrbot.urdf')
+        ],
+    )
+
+    package = 'dummy_sensors'
+    ld.add_process(
+        cmd=[os.path.join(get_package_prefix(package), 'lib', package, 'dummy_laser')],
     )
 
     ld.add_process(
-        cmd=['robot_state_publisher', os.path.join(file_path, 'single_rrbot.urdf')]
-    )
-
-    ld.add_process(
-        cmd=['dummy_joint_states']
+        cmd=[os.path.join(get_package_prefix(package), 'lib', package, 'dummy_joint_states')],
     )
 
     launcher = DefaultLauncher()

--- a/dummy_robot/dummy_robot_bringup/package.xml
+++ b/dummy_robot/dummy_robot_bringup/package.xml
@@ -13,6 +13,7 @@
 
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>launch</exec_depend>
+  <exec_depend>ros2run</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/dummy_robot/dummy_robot_bringup/package.xml
+++ b/dummy_robot/dummy_robot_bringup/package.xml
@@ -11,6 +11,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <exec_depend>ament_index_python</exec_depend>
   <exec_depend>launch</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>

--- a/dummy_robot/dummy_sensors/CMakeLists.txt
+++ b/dummy_robot/dummy_sensors/CMakeLists.txt
@@ -18,16 +18,17 @@ find_package(sensor_msgs REQUIRED)
 add_executable(dummy_laser src/dummy_laser.cpp)
 ament_target_dependencies(dummy_laser
   "rclcpp"
-  "sensor_msgs")
-install(TARGETS dummy_laser
-  DESTINATION bin)
+  "sensor_msgs"
+)
 
 add_executable(dummy_joint_states src/dummy_joint_states.cpp)
 ament_target_dependencies(dummy_joint_states
   "rclcpp"
   "sensor_msgs")
-install(TARGETS dummy_joint_states
-  DESTINATION bin)
+install(TARGETS
+  dummy_joint_states
+  dummy_laser
+  DESTINATION lib/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/lifecycle/CMakeLists.txt
+++ b/lifecycle/CMakeLists.txt
@@ -48,9 +48,7 @@ install(TARGETS
   lifecycle_talker
   lifecycle_listener
   lifecycle_service_client
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin)
+  DESTINATION lib/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -62,6 +60,6 @@ install(
   PROGRAMS
   src/lifecycle_service_client_py.py
   launch/lifecycle_demo_launch.py
-  DESTINATION bin)
+  DESTINATION lib/${PROJECT_NAME})
 
 ament_package()

--- a/lifecycle/CMakeLists.txt
+++ b/lifecycle/CMakeLists.txt
@@ -59,7 +59,11 @@ endif()
 install(
   PROGRAMS
   src/lifecycle_service_client_py.py
-  launch/lifecycle_demo_launch.py
   DESTINATION lib/${PROJECT_NAME})
+
+install(DIRECTORY
+  launch
+  DESTINATION share/${PROJECT_NAME}/
+)
 
 ament_package()

--- a/lifecycle/launch/lifecycle_demo_launch.py
+++ b/lifecycle/launch/lifecycle_demo_launch.py
@@ -12,11 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
-from ament_index_python.packages import get_package_prefix
-
 from launch.exit_handler import primary_exit_handler
+from ros2run.api import get_executable_path
 
 
 def launch(launch_descriptor, argv):
@@ -24,15 +21,15 @@ def launch(launch_descriptor, argv):
 
     package = 'lifecycle'
     ld.add_process(
-        cmd=[os.path.join(get_package_prefix(package), 'lib', package, 'lifecycle_talker')],
+        cmd=[get_executable_path(package_name=package, executable_name='lifecycle_talker')],
     )
 
     ld.add_process(
-        cmd=[os.path.join(get_package_prefix(package), 'lib', package, 'lifecycle_listener')],
+        cmd=[get_executable_path(package_name=package, executable_name='lifecycle_listener')],
     )
 
     ld.add_process(
-        cmd=[os.path.join(
-            get_package_prefix(package), 'lib', package, 'lifecycle_service_client')],
+        cmd=[get_executable_path(
+            package_name=package, executable_name='lifecycle_service_client')],
         exit_handler=primary_exit_handler,
     )

--- a/lifecycle/launch/lifecycle_demo_launch.py
+++ b/lifecycle/launch/lifecycle_demo_launch.py
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
+from ament_index_python.packages import get_package_prefix
+
 from launch import LaunchDescriptor
 from launch.exit_handler import primary_exit_handler
 from launch.launcher import DefaultLauncher
@@ -22,16 +26,18 @@ from launch.launcher import DefaultLauncher
 def lifecycle_demo():
     ld = LaunchDescriptor()
 
+    package = 'lilfecycle'
     ld.add_process(
-        cmd=['lifecycle_talker'],
+        cmd=[os.path.join(get_package_prefix(package), 'lib', package, 'lifecycle_talker')],
     )
 
     ld.add_process(
-        cmd=['lifecycle_listener'],
+        cmd=[os.path.join(get_package_prefix(package), 'lib', package, 'lifecycle_listener')],
     )
 
     ld.add_process(
-        cmd=['lifecycle_service_client'],
+        cmd=[os.path.join(
+            get_package_prefix(package), 'lib', package, 'lifecycle_service_client')],
         exit_handler=primary_exit_handler,
     )
 

--- a/lifecycle/launch/lifecycle_demo_launch.py
+++ b/lifecycle/launch/lifecycle_demo_launch.py
@@ -22,7 +22,7 @@ from launch.exit_handler import primary_exit_handler
 def launch(launch_descriptor, argv):
     ld = launch_descriptor
 
-    package = 'lilfecycle'
+    package = 'lifecycle'
     ld.add_process(
         cmd=[os.path.join(get_package_prefix(package), 'lib', package, 'lifecycle_talker')],
     )

--- a/lifecycle/launch/lifecycle_demo_launch.py
+++ b/lifecycle/launch/lifecycle_demo_launch.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright 2016 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,13 +16,11 @@ import os
 
 from ament_index_python.packages import get_package_prefix
 
-from launch import LaunchDescriptor
 from launch.exit_handler import primary_exit_handler
-from launch.launcher import DefaultLauncher
 
 
-def lifecycle_demo():
-    ld = LaunchDescriptor()
+def launch(launch_descriptor, argv):
+    ld = launch_descriptor
 
     package = 'lilfecycle'
     ld.add_process(
@@ -40,13 +36,3 @@ def lifecycle_demo():
             get_package_prefix(package), 'lib', package, 'lifecycle_service_client')],
         exit_handler=primary_exit_handler,
     )
-
-    launcher = DefaultLauncher()
-    launcher.add_launch_descriptor(ld)
-    rc = launcher.launch()
-
-    assert rc == 0, "The launch file failed with exit code '" + str(rc) + "'. "
-
-
-if __name__ == '__main__':
-    lifecycle_demo()

--- a/lifecycle/package.xml
+++ b/lifecycle/package.xml
@@ -13,6 +13,7 @@
   <build_depend>rclcpp_lifecycle</build_depend>
   <build_depend>std_msgs</build_depend>
 
+  <exec_depend>ament_index_python</exec_depend>
   <exec_depend>rclcpp_lifecycle</exec_depend>
   <exec_depend>lifecycle_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>

--- a/lifecycle/package.xml
+++ b/lifecycle/package.xml
@@ -13,9 +13,9 @@
   <build_depend>rclcpp_lifecycle</build_depend>
   <build_depend>std_msgs</build_depend>
 
-  <exec_depend>ament_index_python</exec_depend>
   <exec_depend>rclcpp_lifecycle</exec_depend>
   <exec_depend>lifecycle_msgs</exec_depend>
+  <exec_depend>ros2run</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/topic_monitor/README.md
+++ b/topic_monitor/README.md
@@ -10,7 +10,7 @@ To visualize the reception rate, we will use a “topic monitor” that periodic
 
 If you have the Python3 `matplotlib` package installed, you can use the `--display` option to plot the reception rate of topics:
 ```
-topic_monitor --display
+ros2 run topic_monitor topic_monitor --display
 ```
 
 Alternatively, if you have ROS 1 installed, you can use the ROS 1 - ROS 2 bridge to plot the reception rate using ROS 1 tools such as `rqt`, or log it using `rosbag`.
@@ -22,10 +22,10 @@ Be sure to run the bridge with `--bridge-all-2to1-topics` so that all topics wil
 ### Comparing reliability QoS settings
 You will need two machines with ROS 2: one mobile and one stationary.
 
-1. Run the `topic_monitor_launch_reliability_demo` executable on the stationary machine.
+1. Run the `ros2 run topic_monitor topic_monitor_launch_reliability_demo` executable on the stationary machine.
 This will start two nodes: one publishing in “reliable” mode, and one in “best effort”.
 1. Start the monitor on a mobile machine such as a laptop.
-Use `topic_monitor --display --allowed-latency 5` to account for any latency that may occur re-sending the reliable messages.
+Use `ros2 run topic_monitor topic_monitor --display --allowed-latency 5` to account for any latency that may occur re-sending the reliable messages.
 1. Take the mobile machine out of range of the monitor, and observe how the reception rates differ for the different topics.
 
 You should see that the "reliable" topic has a reception rate that is almost always either 0 or 100%, while the "best effort" topic has a reception rate that fluctuates based on the strength of the connection.
@@ -44,7 +44,7 @@ See [[ROS 2 Cleint Libraries]] for more information.
 
 ### Comparing the latency of reliability QoS settings
 Repeat the previous demo with a lower allowed latency on the topic monitor.
-That is, in step 2, run `topic_monitor --display --allowed-latency 1`.
+That is, in step 2, run `ros2 run topic_monitor topic_monitor --display --allowed-latency 1`.
 
 You should see that the “best effort” reception rate is unaffected, while the “reliable” reception rate drops sooner when the machines are going out of range of each other.
 This is because a “reliable” message may be re-sent multiple times in order to be delivered.
@@ -57,9 +57,9 @@ If the 10th latest message has not been successfully acknowledged by the time th
 
 You will need two machines with ROS 2: one mobile and one stationary.
 
-1. Run the `topic_monitor_launch_depth_demo` executable on the stationary machine.
+1. Run the `ros2 run topic_monitor topic_monitor_launch_depth_demo` executable on the stationary machine.
 This will start some nodes publishing both small (payload of 1-character string) and large data (payload of 100,000-character string) with different depths: a pair publishing with a depth of 1, and a pair with a larger depth (50).
-1. Start the monitor on a mobile machine such as a laptop with `topic_monitor --display`.
+1. Start the monitor on a mobile machine such as a laptop with `ros2 run topic_monitor topic_monitor --display`.
 1. Take the mobile machine out of range of the monitor, and observe how the reception rates differ for the different topics.
 
 You should see that the reception rate of the publishers with the higher depth is better than those with the depth of 1, because messages are less likely to get overwritten when data is taking longer to be acknowledged.
@@ -77,8 +77,8 @@ You will need two machines running ROS 2: one stationary and one mobile.
 You should not use the Fast RTPS ROS middleware implementation for this part.
 See [[DDS and ROS Middleware Implementations]] for instructions on how to change the vendor.
 
-1. Run the `topic_monitor_launch_fragmentation_demo` executable on the stationary machine.
-1. Run `topic_monitor --display --expected-period 4` on the mobile machine.
+1. Run the `ros2 run topic_monitor topic_monitor_launch_fragmentation_demo` executable on the stationary machine.
+1. Run `ros2 run topic_monitor topic_monitor --display --expected-period 4` on the mobile machine.
 This will launch four publishers publishing messages of strings of different lengths: small (1), medium (50000), large (100000) and xlarge (150000).
 1. Take the mobile machine out of range of the monitor, and observe how the reception rates differ for the different topics.
 

--- a/topic_monitor/README.md
+++ b/topic_monitor/README.md
@@ -10,7 +10,7 @@ To visualize the reception rate, we will use a “topic monitor” that periodic
 
 If you have the Python3 `matplotlib` package installed, you can use the `--display` option to plot the reception rate of topics:
 ```
-ros2 run topic_monitor topic_monitor --display
+ros2 run topic_monitor topic_monitor -- --display
 ```
 
 Alternatively, if you have ROS 1 installed, you can use the ROS 1 - ROS 2 bridge to plot the reception rate using ROS 1 tools such as `rqt`, or log it using `rosbag`.
@@ -25,7 +25,7 @@ You will need two machines with ROS 2: one mobile and one stationary.
 1. Run the `ros2 run topic_monitor topic_monitor_launch_reliability_demo` executable on the stationary machine.
 This will start two nodes: one publishing in “reliable” mode, and one in “best effort”.
 1. Start the monitor on a mobile machine such as a laptop.
-Use `ros2 run topic_monitor topic_monitor --display --allowed-latency 5` to account for any latency that may occur re-sending the reliable messages.
+Use `ros2 run topic_monitor topic_monitor -- --display --allowed-latency 5` to account for any latency that may occur re-sending the reliable messages.
 1. Take the mobile machine out of range of the monitor, and observe how the reception rates differ for the different topics.
 
 You should see that the "reliable" topic has a reception rate that is almost always either 0 or 100%, while the "best effort" topic has a reception rate that fluctuates based on the strength of the connection.
@@ -44,7 +44,7 @@ See [[ROS 2 Cleint Libraries]] for more information.
 
 ### Comparing the latency of reliability QoS settings
 Repeat the previous demo with a lower allowed latency on the topic monitor.
-That is, in step 2, run `ros2 run topic_monitor topic_monitor --display --allowed-latency 1`.
+That is, in step 2, run `ros2 run topic_monitor topic_monitor -- --display --allowed-latency 1`.
 
 You should see that the “best effort” reception rate is unaffected, while the “reliable” reception rate drops sooner when the machines are going out of range of each other.
 This is because a “reliable” message may be re-sent multiple times in order to be delivered.
@@ -59,7 +59,7 @@ You will need two machines with ROS 2: one mobile and one stationary.
 
 1. Run the `ros2 run topic_monitor topic_monitor_launch_depth_demo` executable on the stationary machine.
 This will start some nodes publishing both small (payload of 1-character string) and large data (payload of 100,000-character string) with different depths: a pair publishing with a depth of 1, and a pair with a larger depth (50).
-1. Start the monitor on a mobile machine such as a laptop with `ros2 run topic_monitor topic_monitor --display`.
+1. Start the monitor on a mobile machine such as a laptop with `ros2 run topic_monitor topic_monitor -- --display`.
 1. Take the mobile machine out of range of the monitor, and observe how the reception rates differ for the different topics.
 
 You should see that the reception rate of the publishers with the higher depth is better than those with the depth of 1, because messages are less likely to get overwritten when data is taking longer to be acknowledged.
@@ -78,7 +78,7 @@ You should not use the Fast RTPS ROS middleware implementation for this part.
 See [[DDS and ROS Middleware Implementations]] for instructions on how to change the vendor.
 
 1. Run the `ros2 run topic_monitor topic_monitor_launch_fragmentation_demo` executable on the stationary machine.
-1. Run `ros2 run topic_monitor topic_monitor --display --expected-period 4` on the mobile machine.
+1. Run `ros2 run topic_monitor topic_monitor -- --display --expected-period 4` on the mobile machine.
 This will launch four publishers publishing messages of strings of different lengths: small (1), medium (50000), large (100000) and xlarge (150000).
 1. Take the mobile machine out of range of the monitor, and observe how the reception rates differ for the different topics.
 

--- a/topic_monitor/README.md
+++ b/topic_monitor/README.md
@@ -22,7 +22,7 @@ Be sure to run the bridge with `--bridge-all-2to1-topics` so that all topics wil
 ### Comparing reliability QoS settings
 You will need two machines with ROS 2: one mobile and one stationary.
 
-1. Run the `ros2 run topic_monitor topic_monitor_launch_reliability_demo` executable on the stationary machine.
+1. Run the `ros2 run topic_monitor launch_reliability_demo` executable on the stationary machine.
 This will start two nodes: one publishing in “reliable” mode, and one in “best effort”.
 1. Start the monitor on a mobile machine such as a laptop.
 Use `ros2 run topic_monitor topic_monitor -- --display --allowed-latency 5` to account for any latency that may occur re-sending the reliable messages.
@@ -57,7 +57,7 @@ If the 10th latest message has not been successfully acknowledged by the time th
 
 You will need two machines with ROS 2: one mobile and one stationary.
 
-1. Run the `ros2 run topic_monitor topic_monitor_launch_depth_demo` executable on the stationary machine.
+1. Run the `ros2 run topic_monitor launch_depth_demo` executable on the stationary machine.
 This will start some nodes publishing both small (payload of 1-character string) and large data (payload of 100,000-character string) with different depths: a pair publishing with a depth of 1, and a pair with a larger depth (50).
 1. Start the monitor on a mobile machine such as a laptop with `ros2 run topic_monitor topic_monitor -- --display`.
 1. Take the mobile machine out of range of the monitor, and observe how the reception rates differ for the different topics.
@@ -77,7 +77,7 @@ You will need two machines running ROS 2: one stationary and one mobile.
 You should not use the Fast RTPS ROS middleware implementation for this part.
 See [[DDS and ROS Middleware Implementations]] for instructions on how to change the vendor.
 
-1. Run the `ros2 run topic_monitor topic_monitor_launch_fragmentation_demo` executable on the stationary machine.
+1. Run the `ros2 run topic_monitor launch_fragmentation_demo` executable on the stationary machine.
 1. Run `ros2 run topic_monitor topic_monitor -- --display --expected-period 4` on the mobile machine.
 This will launch four publishers publishing messages of strings of different lengths: small (1), medium (50000), large (100000) and xlarge (150000).
 1. Take the mobile machine out of range of the monitor, and observe how the reception rates differ for the different topics.

--- a/topic_monitor/package.xml
+++ b/topic_monitor/package.xml
@@ -7,8 +7,10 @@
   <maintainer email="dhood@osrfoundation.org">D. Hood</maintainer>
   <license>Apache License 2.0</license>
 
+  <build_depend>ament_python</build_depend>
   <build_depend>rclpy</build_depend>
 
+  <exec_depend>ament_index_python</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 

--- a/topic_monitor/package.xml
+++ b/topic_monitor/package.xml
@@ -12,6 +12,7 @@
 
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>rclpy</exec_depend>
+  <exec_depend>ros2run</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
   <export>

--- a/topic_monitor/package.xml
+++ b/topic_monitor/package.xml
@@ -10,7 +10,6 @@
   <build_depend>ament_python</build_depend>
   <build_depend>rclpy</build_depend>
 
-  <exec_depend>ament_index_python</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>ros2run</exec_depend>
   <exec_depend>std_msgs</exec_depend>

--- a/topic_monitor/setup.py
+++ b/topic_monitor/setup.py
@@ -1,4 +1,8 @@
+from ament_python.script_dir import install_scripts_to_libexec
 from setuptools import setup
+
+package_name = 'topic_monitor'
+install_scripts_to_libexec(package_name)
 
 setup(
     name='topic_monitor',
@@ -26,12 +30,12 @@ setup(
     license='Apache License, Version 2.0',
     entry_points={
         'console_scripts': [
-            'topic_monitor_data_publisher = topic_monitor.scripts.data_publisher:main',
+            'data_publisher = topic_monitor.scripts.data_publisher:main',
             'topic_monitor = topic_monitor.scripts.topic_monitor:main',
-            'topic_monitor_launch_depth_demo = topic_monitor.launch_files.launch_depth_demo:main',
-            'topic_monitor_launch_fragmentation_demo ='
+            'launch_depth_demo = topic_monitor.launch_files.launch_depth_demo:main',
+            'launch_fragmentation_demo ='
                 'topic_monitor.launch_files.launch_fragmentation_demo:main',
-            'topic_monitor_launch_reliability_demo ='
+            'launch_reliability_demo ='
                 'topic_monitor.launch_files.launch_reliability_demo:main',
         ],
     },

--- a/topic_monitor/topic_monitor/README.md
+++ b/topic_monitor/topic_monitor/README.md
@@ -9,7 +9,7 @@ Some launch files are provided for comparing different QoS policies.
 
 To start one such publisher, assuming you have already installed ROS 2 and sourced your setup file, run:
 ```
-ros2 run topic_monitor topic_monitor_data_publisher -- critical
+ros2 run topic_monitor data_publisher -- critical
 ```
 This will start a ROS 2 publisher on the topic `critical_data` that will use the default QoS profile, which includes “reliable” reliability settings.
 A message will be sent periodically, with incrementing values that act as sequence numbers.
@@ -18,7 +18,7 @@ This enables the “reception rate” of the topic to be calculated based on how
 
 To start a publisher with “best effort” reliability settings, run:
 ```
-ros2 run topic_monitor topic_monitor_data_publisher -- sensor --best-effort
+ros2 run topic_monitor data_publisher -- sensor --best-effort
 ```
 This will start a ROS 2 publisher on the topic `sensor_data_best_effort` that will use the “best effort” setting for the QoS reliability policy.
 This publisher will not check if sent data is acknowledged by any subscriptions, and therefore the reception rate may drop below 100% if the network is congested or there is a poor connection between the monitor and the publisher.
@@ -26,7 +26,7 @@ This publisher will not check if sent data is acknowledged by any subscriptions,
 When the data publisher script is terminated with `Ctrl + C`, the publisher will attempt to send `-1` as a “last breath” message that signals the topic monitor that it is going offline gracefully.
 Otherwise, if the topic monitor doesn't receive a message from a publisher for a pre-determined amount of time, it will consider the topic "stale".
 
-For a full list of options for the data publisher, type `ros2 run topic_monitor topic_monitor_data_publisher -- --help`.
+For a full list of options for the data publisher, type `ros2 run topic_monitor data_publisher -- --help`.
 
 ### How to start the topic monitor
 

--- a/topic_monitor/topic_monitor/README.md
+++ b/topic_monitor/topic_monitor/README.md
@@ -9,7 +9,7 @@ Some launch files are provided for comparing different QoS policies.
 
 To start one such publisher, assuming you have already installed ROS 2 and sourced your setup file, run:
 ```
-topic_monitor_data_publisher critical
+ros2 run topic_monitor topic_monitor_data_publisher -- critical
 ```
 This will start a ROS 2 publisher on the topic `critical_data` that will use the default QoS profile, which includes “reliable” reliability settings.
 A message will be sent periodically, with incrementing values that act as sequence numbers.
@@ -18,7 +18,7 @@ This enables the “reception rate” of the topic to be calculated based on how
 
 To start a publisher with “best effort” reliability settings, run:
 ```
-topic_monitor_data_publisher sensor --best-effort
+ros2 run topic_monitor topic_monitor_data_publisher -- sensor --best-effort
 ```
 This will start a ROS 2 publisher on the topic `sensor_data_best_effort` that will use the “best effort” setting for the QoS reliability policy.
 This publisher will not check if sent data is acknowledged by any subscriptions, and therefore the reception rate may drop below 100% if the network is congested or there is a poor connection between the monitor and the publisher.
@@ -26,13 +26,13 @@ This publisher will not check if sent data is acknowledged by any subscriptions,
 When the data publisher script is terminated with `Ctrl + C`, the publisher will attempt to send `-1` as a “last breath” message that signals the topic monitor that it is going offline gracefully.
 Otherwise, if the topic monitor doesn't receive a message from a publisher for a pre-determined amount of time, it will consider the topic "stale".
 
-For a full list of options for the data publisher, type `topic_monitor_data_publisher --help`.
+For a full list of options for the data publisher, type `ros2 run topic_monitor topic_monitor_data_publisher -- --help`.
 
 ### How to start the topic monitor
 
 To start the topic monitor, run:
 ```
-topic_monitor
+ros2 run topic_monitor topic_monitor
 ```
 
 This will start a topic monitor that will subscribe to any ROS 2 topics that match the structure “<name>_data” or “<name>_data_best_effort”, where <name> can be something such as “topic1”.

--- a/topic_monitor/topic_monitor/launch_files/launch_depth_demo.py
+++ b/topic_monitor/topic_monitor/launch_files/launch_depth_demo.py
@@ -12,19 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import sys
 
-from ament_index_python.packages import get_package_prefix
 from launch import LaunchDescriptor
 from launch.launcher import DefaultLauncher
+from ros2run.api import get_executable_path
 
 
 def add_process_to_descriptor(launch_descriptor, size, depth):
     name = '{0}_depth_{1}'.format(size, depth)
     payload = 0 if size == 'small' else 100000
     package = 'topic_monitor'
-    executable = os.path.join(get_package_prefix(package), 'lib', package, 'data_publisher')
+    executable = get_executable_path(package_name=package, executable_name='data_publisher')
     launch_descriptor.add_process(
         cmd=[executable, name, '--depth', str(depth), '--payload-size', str(payload)],
         name=name,

--- a/topic_monitor/topic_monitor/launch_files/launch_depth_demo.py
+++ b/topic_monitor/topic_monitor/launch_files/launch_depth_demo.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import sys
 
+from ament_index_python.packages import get_package_prefix
 from launch import LaunchDescriptor
 from launch.launcher import DefaultLauncher
 
@@ -21,7 +23,8 @@ from launch.launcher import DefaultLauncher
 def add_process_to_descriptor(launch_descriptor, size, depth):
     name = '{0}_depth_{1}'.format(size, depth)
     payload = 0 if size == 'small' else 100000
-    executable = 'topic_monitor_data_publisher'
+    package = 'topic_monitor'
+    executable = os.path.join(get_package_prefix(package), 'lib', package, 'data_publisher')
     launch_descriptor.add_process(
         cmd=[executable, name, '--depth', str(depth), '--payload-size', str(payload)],
         name=name,

--- a/topic_monitor/topic_monitor/launch_files/launch_fragmentation_demo.py
+++ b/topic_monitor/topic_monitor/launch_files/launch_fragmentation_demo.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import sys
 
+from ament_index_python.packages import get_package_prefix
 from launch import LaunchDescriptor
 from launch.launcher import DefaultLauncher
 
@@ -21,7 +23,9 @@ from launch.launcher import DefaultLauncher
 def main():
     launcher = DefaultLauncher()
     launch_descriptor = LaunchDescriptor()
-    executable = 'topic_monitor_data_publisher'
+
+    package = 'topic_monitor'
+    executable = os.path.join(get_package_prefix(package), 'lib', package, 'data_publisher')
 
     name = 'small'
     launch_descriptor.add_process(

--- a/topic_monitor/topic_monitor/launch_files/launch_fragmentation_demo.py
+++ b/topic_monitor/topic_monitor/launch_files/launch_fragmentation_demo.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import sys
 
-from ament_index_python.packages import get_package_prefix
 from launch import LaunchDescriptor
 from launch.launcher import DefaultLauncher
+from ros2run.api import get_executable_path
 
 
 def main():
@@ -25,7 +24,7 @@ def main():
     launch_descriptor = LaunchDescriptor()
 
     package = 'topic_monitor'
-    executable = os.path.join(get_package_prefix(package), 'lib', package, 'data_publisher')
+    executable = get_executable_path(package_name=package, executable_name='data_publisher')
 
     name = 'small'
     launch_descriptor.add_process(

--- a/topic_monitor/topic_monitor/launch_files/launch_reliability_demo.py
+++ b/topic_monitor/topic_monitor/launch_files/launch_reliability_demo.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import sys
 
+from ament_index_python.packages import get_package_prefix
 from launch import LaunchDescriptor
 from launch.launcher import DefaultLauncher
 
@@ -21,7 +23,8 @@ from launch.launcher import DefaultLauncher
 def main():
     launcher = DefaultLauncher()
     launch_descriptor = LaunchDescriptor()
-    executable = 'topic_monitor_data_publisher'
+    package = 'topic_monitor'
+    executable = os.path.join(get_package_prefix(package), 'lib', package, 'data_publisher')
 
     launch_descriptor.add_process(
         cmd=[executable, 'sensor', '--best-effort'],

--- a/topic_monitor/topic_monitor/launch_files/launch_reliability_demo.py
+++ b/topic_monitor/topic_monitor/launch_files/launch_reliability_demo.py
@@ -12,19 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import sys
 
-from ament_index_python.packages import get_package_prefix
 from launch import LaunchDescriptor
 from launch.launcher import DefaultLauncher
+from ros2run.api import get_executable_path
 
 
 def main():
     launcher = DefaultLauncher()
     launch_descriptor = LaunchDescriptor()
     package = 'topic_monitor'
-    executable = os.path.join(get_package_prefix(package), 'lib', package, 'data_publisher')
+    executable = get_executable_path(package_name=package, executable_name='data_publisher')
 
     launch_descriptor.add_process(
         cmd=[executable, 'sensor', '--best-effort'],


### PR DESCRIPTION
- Install lifecycle demo executables to libexec (fixes #137 )
- install dummy robot/* executables to libexec
- make launchfiles runnable with `launch` (fixes #140 )
- install topic monitor executables to libexec (fixes #138 )
- switch talker/listener_qos to use the chatter topic (fixes #144 )

Not in this PR: 
 - move the pendulum demo executables (because they need to be on the path given the current launch logic)

Depends on https://github.com/ros2/robot_state_publisher/pull/8
Depends on https://github.com/ros2/ros2cli/pull/23