### PR TITLE
Rename data types

### DIFF
--- a/lifecycle/src/lifecycle_listener.cpp
+++ b/lifecycle/src/lifecycle_listener.cpp
@@ -16,7 +16,11 @@
 #include <string>
 
 #include "lifecycle_msgs/msg/transition_event.hpp"
+
 #include "rclcpp/rclcpp.hpp"
+
+#include "rcutils/logging_macros.h"
+
 #include "std_msgs/msg/string.hpp"
 
 /// LifecycleListener class as a simple listener node
@@ -47,13 +51,13 @@ public:
 
   void data_callback(const std_msgs::msg::String::SharedPtr msg)
   {
-    printf("[%s] data_callback: %s\n", get_name(), msg->data.c_str());
+    RCUTILS_LOG_INFO_NAMED(get_name(), "data_callback: %s", msg->data.c_str())
   }
 
   void notification_callback(const lifecycle_msgs::msg::TransitionEvent::SharedPtr msg)
   {
-    printf("[%s] notify callback: Transition from state %s to %s\n", get_name(),
-      msg->start_state.label.c_str(), msg->goal_state.label.c_str());
+    RCUTILS_LOG_INFO_NAMED(get_name(), "notify callback: Transition from state %s to %s",
+      msg->start_state.label.c_str(), msg->goal_state.label.c_str())
   }
 
 private:

--- a/lifecycle/src/lifecycle_talker.cpp
+++ b/lifecycle/src/lifecycle_talker.cpp
@@ -26,6 +26,8 @@
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "rclcpp_lifecycle/lifecycle_publisher.hpp"
 
+#include "rcutils/logging_macros.h"
+
 #include "std_msgs/msg/string.hpp"
 
 using namespace std::chrono_literals;
@@ -68,18 +70,19 @@ public:
    * lifecycle publisher is not activate, we still invoke publish, but
    * the communication is blocked so that no messages is actually transferred.
    */
-  void publish()
+  void
+  publish()
   {
     static size_t count = 0;
     msg_->data = "Lifecycle HelloWorld #" + std::to_string(++count);
 
     // Print the current state for demo purposes
     if (!pub_->is_activated()) {
-      printf("[%s] Lifecycle publisher is currently inactive. Messages are not published.\n",
-        get_name());
+      RCUTILS_LOG_INFO_NAMED(
+        get_name(), "Lifecycle publisher is currently inactive. Messages are not published.")
     } else {
-      printf("[%s] Lifecycle publisher is active. Publishing: [%s]\n",
-        get_name(), msg_->data.c_str());
+      RCUTILS_LOG_INFO_NAMED(
+        get_name(), "Lifecycle publisher is active. Publishing: [%s]", msg_->data.c_str())
     }
 
     // We independently from the current state call publish on the lifecycle
@@ -116,7 +119,7 @@ public:
     timer_ = this->create_wall_timer(
       1s, std::bind(&LifecycleTalker::publish, this));
 
-    printf("[%s] on_configure() is called.\n", get_name());
+    RCUTILS_LOG_INFO_NAMED(get_name(), "on_configure() is called.")
 
     // We return a success and hence invoke the transition to the next
     // step: "inactive".
@@ -146,7 +149,7 @@ public:
     // ignored but sent into the network.
     pub_->on_activate();
 
-    printf("[%s] on_activate() is called.\n", get_name());
+    RCUTILS_LOG_INFO_NAMED(get_name(), "on_activate() is called.")
 
     // Let's sleep for 2 seconds.
     // We emulate we are doing important
@@ -181,7 +184,7 @@ public:
     // sent into the network.
     pub_->on_deactivate();
 
-    printf("[%s] on_deactivate() is called.\n", get_name());
+    RCUTILS_LOG_INFO_NAMED(get_name(), "on_deactivate() is called.")
 
     // We return a success and hence invoke the transition to the next
     // step: "inactive".
@@ -212,7 +215,7 @@ public:
     timer_.reset();
     pub_.reset();
 
-    printf("[%s] on cleanup is called.\n", get_name());
+    RCUTILS_LOG_INFO_NAMED(get_name(), "on cleanup is called.")
 
     // We return a success and hence invoke the transition to the next
     // step: "unconfigured".

--- a/lifecycle/src/lifecycle_talker.cpp
+++ b/lifecycle/src/lifecycle_talker.cpp
@@ -18,6 +18,8 @@
 #include <string>
 #include <thread>
 
+#include "lifecycle_msgs/msg/transition.hpp"
+
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/publisher.hpp"
 
@@ -94,11 +96,12 @@ public:
    * Depending on the return value of this function, the state machine
    * either invokes a transition to the "inactive" state or stays
    * in "unconfigured".
-   * RCL_LIFECYCLE_RET_OK transitions to "inactive"
-   * RCL_LIFECYCLE_RET_FAILURE transitions to "unconfigured"
-   * RCL_LIFECYCLE_RET_ERROR or any uncaught exceptions to "errorprocessing"
+   * TRANSITION_CALLBACK_SUCCESS transitions to "inactive"
+   * TRANSITION_CALLBACK_FAILURE transitions to "unconfigured"
+   * TRANSITION_CALLBACK_ERROR or any uncaught exceptions to "errorprocessing"
    */
-  rcl_lifecycle_ret_t on_configure(const rclcpp_lifecycle::State &)
+  rcl_lifecycle_transition_key_t
+  on_configure(const rclcpp_lifecycle::State &)
   {
     // This callback is supposed to be used for initialization and
     // configuring purposes.
@@ -117,11 +120,11 @@ public:
 
     // We return a success and hence invoke the transition to the next
     // step: "inactive".
-    // If we returned RCL_LIFECYCLE_RET_FAILURE instead, the state machine
+    // If we returned TRANSITION_CALLBACK_FAILURE instead, the state machine
     // would stay in the "unconfigured" state.
-    // In case of RCL_LIFECYCLE_RET_ERROR or any thrown exception within
+    // In case of TRANSITION_CALLBACK_ERROR or any thrown exception within
     // this callback, the state machine transitions to state "errorprocessing".
-    return RCL_LIFECYCLE_RET_OK;
+    return lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS;
   }
 
   /// Transition callback for state activating
@@ -131,11 +134,12 @@ public:
    * Depending on the return value of this function, the state machine
    * either invokes a transition to the "active" state or stays
    * in "inactive".
-   * RCL_LIFECYCLE_RET_OK transitions to "active"
-   * RCL_LIFECYCLE_RET_FAILURE transitions to "inactive"
-   * RCL_LIFECYCLE_RET_ERROR or any uncaught exceptions to "errorprocessing"
+   * TRANSITION_CALLBACK_SUCCESS transitions to "active"
+   * TRANSITION_CALLBACK_FAILURE transitions to "inactive"
+   * TRANSITION_CALLBACK_ERROR or any uncaught exceptions to "errorprocessing"
    */
-  rcl_lifecycle_ret_t on_activate(const rclcpp_lifecycle::State &)
+  rcl_lifecycle_transition_key_t
+  on_activate(const rclcpp_lifecycle::State &)
   {
     // We explicitly activate the lifecycle publisher.
     // Starting from this point, all messages are no longer
@@ -151,11 +155,11 @@ public:
 
     // We return a success and hence invoke the transition to the next
     // step: "active".
-    // If we returned RCL_LIFECYCLE_RET_FAILURE instead, the state machine
+    // If we returned TRANSITION_CALLBACK_FAILURE instead, the state machine
     // would stay in the "inactive" state.
-    // In case of RCL_LIFECYCLE_RET_ERROR or any thrown exception within
+    // In case of TRANSITION_CALLBACK_ERROR or any thrown exception within
     // this callback, the state machine transitions to state "errorprocessing".
-    return RCL_LIFECYCLE_RET_OK;
+    return lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS;
   }
 
   /// Transition callback for state activating
@@ -165,11 +169,12 @@ public:
    * Depending on the return value of this function, the state machine
    * either invokes a transition to the "inactive" state or stays
    * in "active".
-   * RCL_LIFECYCLE_RET_OK transitions to "inactive"
-   * RCL_LIFECYCLE_RET_FAILURE transitions to "active"
-   * RCL_LIFECYCLE_RET_ERROR or any uncaught exceptions to "errorprocessing"
+   * TRANSITION_CALLBACK_SUCCESS transitions to "inactive"
+   * TRANSITION_CALLBACK_FAILURE transitions to "active"
+   * TRANSITION_CALLBACK_ERROR or any uncaught exceptions to "errorprocessing"
    */
-  rcl_lifecycle_ret_t on_deactivate(const rclcpp_lifecycle::State &)
+  rcl_lifecycle_transition_key_t
+  on_deactivate(const rclcpp_lifecycle::State &)
   {
     // We explicitly deactivate the lifecycle publisher.
     // Starting from this point, all messages are no longer
@@ -180,11 +185,11 @@ public:
 
     // We return a success and hence invoke the transition to the next
     // step: "inactive".
-    // If we returned RCL_LIFECYCLE_RET_FAILURE instead, the state machine
+    // If we returned TRANSITION_CALLBACK_FAILURE instead, the state machine
     // would stay in the "active" state.
-    // In case of RCL_LIFECYCLE_RET_ERROR or any thrown exception within
+    // In case of TRANSITION_CALLBACK_ERROR or any thrown exception within
     // this callback, the state machine transitions to state "errorprocessing".
-    return RCL_LIFECYCLE_RET_OK;
+    return lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS;
   }
 
   /// Transition callback for state deactivating
@@ -194,11 +199,12 @@ public:
    * Depending on the return value of this function, the state machine
    * either invokes a transition to the "uncofigured" state or stays
    * in "inactive".
-   * RCL_LIFECYCLE_RET_OK transitions to "unconfigured"
-   * RCL_LIFECYCLE_RET_FAILURE transitions to "inactive"
-   * RCL_LIFECYCLE_RET_ERROR or any uncaught exceptions to "errorprocessing"
+   * TRANSITION_CALLBACK_SUCCESS transitions to "unconfigured"
+   * TRANSITION_CALLBACK_FAILURE transitions to "inactive"
+   * TRANSITION_CALLBACK_ERROR or any uncaught exceptions to "errorprocessing"
    */
-  rcl_lifecycle_ret_t on_cleanup(const rclcpp_lifecycle::State &)
+  rcl_lifecycle_transition_key_t
+  on_cleanup(const rclcpp_lifecycle::State &)
   {
     // In our cleanup phase, we release the shared pointers to the
     // timer and publisher. These entities are no longer available
@@ -210,11 +216,11 @@ public:
 
     // We return a success and hence invoke the transition to the next
     // step: "unconfigured".
-    // If we returned RCL_LIFECYCLE_RET_FAILURE instead, the state machine
+    // If we returned TRANSITION_CALLBACK_FAILURE instead, the state machine
     // would stay in the "inactive" state.
-    // In case of RCL_LIFECYCLE_RET_ERROR or any thrown exception within
+    // In case of TRANSITION_CALLBACK_ERROR or any thrown exception within
     // this callback, the state machine transitions to state "errorprocessing".
-    return RCL_LIFECYCLE_RET_OK;
+    return lifecycle_msgs::msg::Transition::TRANSITION_CALLBACK_SUCCESS;
   }
 
 private:


### PR DESCRIPTION
Top Level PR for renaming `rcl_lifecycle_ret_t` to `rcl_lifecycle_transition_key_t` which corresponds to the lifecycle_msgs predefined transitions.

For this package, I also included the change from `fprintf` to `RCUTILS_LOG*`.

CI:
linux: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2921)](http://ci.ros2.org/job/ci_linux/2921/)
win: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3047)](http://ci.ros2.org/job/ci_windows/3047/)
osx: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2371)](http://ci.ros2.org/job/ci_osx/2371/)