### PR TITLE
Ignore a connext output from small depth in tests

### DIFF
--- a/pendulum_control/test/test_pendulum_demo.py.in
+++ b/pendulum_control/test/test_pendulum_demo.py.in
@@ -9,6 +9,7 @@ from launch.launcher import DefaultLauncher
 from launch.output_handler import ConsoleOutput
 
 from launch_testing import create_handler
+from launch_testing import get_default_filtered_prefixes
 
 
 def setup():
@@ -23,7 +24,7 @@ def test_executable():
     rmw_implementation = '@rmw_implementation@'
     pendulum_logger_executable = '@RCLCPP_DEMO_PENDULUM_LOGGER_EXECUTABLE@'
     pendulum_logger_output_file = '@RCLCPP_DEMO_PENDULUM_LOGGER_EXPECTED_OUTPUT@'
-    pendulum_logger_name = 'test_executable_0'
+    pendulum_logger_name = 'pendulum_logger'
     pendulum_logger_handler = create_handler(pendulum_logger_name, launch_descriptor, pendulum_logger_output_file)
     assert pendulum_logger_handler, 'Cannot find appropriate handler for %s' % pendulum_logger_output_file
     output_handlers.append(pendulum_logger_handler)
@@ -36,9 +37,19 @@ def test_executable():
 
     pendulum_demo_executable = '@RCLCPP_DEMO_PENDULUM_DEMO_EXECUTABLE@'
     pendulum_demo_output_file = '@RCLCPP_DEMO_PENDULUM_DEMO_EXPECTED_OUTPUT@'
-    pendulum_demo_name = 'test_executable_1'
+    pendulum_demo_name = 'pendulum_demo'
+
+    filtered_prefixes = get_default_filtered_prefixes()
+    if rmw_implementation.startswith('rmw_connext'):
+        # This output can be caused by a small QoS depth leading to samples being discarded.
+        # Since we are optimizing for performance with a depth of 1, we can ignore it.
+        filtered_prefixes.append(
+            b'PRESWriterHistoryDriver_completeBeAsynchPub:!make_sample_reclaimable'
+        )
+
     pendulum_demo_handler = create_handler(
         pendulum_demo_name, launch_descriptor, pendulum_demo_output_file,
+        filtered_prefixes=filtered_prefixes,
         filtered_rmw_implementation=rmw_implementation)
     assert pendulum_demo_handler, 'Cannot find appropriate handler for %s' % pendulum_demo_output_file
     output_handlers.append(pendulum_demo_handler)

--- a/pendulum_control/test/test_pendulum_teleop.py.in
+++ b/pendulum_control/test/test_pendulum_teleop.py.in
@@ -10,6 +10,7 @@ from launch.launcher import DefaultLauncher
 from launch.output_handler import ConsoleOutput
 
 from launch_testing import create_handler
+from launch_testing import get_default_filtered_prefixes
 
 
 def setup():
@@ -24,7 +25,7 @@ def test_executable():
     rmw_implementation = '@rmw_implementation@'
     pendulum_demo_executable = '@RCLCPP_DEMO_PENDULUM_DEMO_EXECUTABLE@'
     pendulum_demo_output_file = '@RCLCPP_DEMO_PENDULUM_DEMO_TELEOP_EXPECTED_OUTPUT@'
-    pendulum_demo_name = 'test_executable_0'
+    pendulum_demo_name = 'pendulum_demo'
     pendulum_demo_handler = create_handler(pendulum_demo_name, launch_descriptor, pendulum_demo_output_file)
     assert pendulum_demo_handler, 'Cannot find appropriate handler for %s' % pendulum_demo_output_file
     output_handlers.append(pendulum_demo_handler)
@@ -37,9 +38,19 @@ def test_executable():
 
     pendulum_teleop_executable = '@RCLCPP_DEMO_PENDULUM_TELEOP_EXECUTABLE@'
     pendulum_teleop_output_file = '@RCLCPP_DEMO_PENDULUM_TELEOP_EXPECTED_OUTPUT@'
-    pendulum_teleop_name = 'test_executable_1'
+    pendulum_teleop_name = 'pendulum_teleop'
+
+    filtered_prefixes = get_default_filtered_prefixes()
+    if rmw_implementation.startswith('rmw_connext'):
+        # This output can be caused by a small QoS depth leading to samples being discarded.
+        # Since we are optimizing for performance with a depth of 1, we can ignore it.
+        filtered_prefixes.append(
+            b'PRESWriterHistoryDriver_completeBeAsynchPub:!make_sample_reclaimable'
+        )
+
     pendulum_teleop_handler = create_handler(
         pendulum_teleop_name, launch_descriptor, pendulum_teleop_output_file,
+        filtered_prefixes=filtered_prefixes,
         filtered_rmw_implementation=rmw_implementation)
     assert pendulum_teleop_handler, 'Cannot find appropriate handler for %s' % pendulum_teleop_output_file
     output_handlers.append(pendulum_teleop_handler)


### PR DESCRIPTION
fixes https://github.com/ros2/demos/issues/126

standard ci (pendulum_control only):
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2937)](http://ci.ros2.org/job/ci_linux/2937/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=404)](http://ci.ros2.org/job/ci_linux-aarch64/404/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2381)](http://ci.ros2.org/job/ci_osx/2381/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3065)](http://ci.ros2.org/job/ci_windows/3065/)

--retest-until-fail 30:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2938)](http://ci.ros2.org/job/ci_linux/2938/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=405)](http://ci.ros2.org/job/ci_linux-aarch64/405/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2382)](http://ci.ros2.org/job/ci_osx/2382/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3066)](http://ci.ros2.org/job/ci_windows/3066/)

there was a test failure in the linux job but it was because the test_pendulum_teleop test is flaky in another way as well. in this job you'll see that the test_pendulum (not teleop) test passed 50 times despite the "PRESWriterHistoryDriver_completeBeAsynchPub:!make_sample_reclaimable" output occurring in two tests: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2939)](http://ci.ros2.org/job/ci_linux/2939/)