### PR TITLE
remove dependency on ament_python and perform customizations in setup.py

### DIFF
--- a/demo_nodes_py/package.xml
+++ b/demo_nodes_py/package.xml
@@ -10,8 +10,6 @@
   <maintainer email="mikael@osrfoundation.org">Mikael Arguedas</maintainer>
   <license>Apache License 2.0</license>
 
-  <build_depend>ament_python</build_depend>
-
   <exec_depend>example_interfaces</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>

--- a/demo_nodes_py/setup.cfg
+++ b/demo_nodes_py/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script-dir=$base/lib/demo_nodes_py
+[install]
+install-scripts=$base/lib/demo_nodes_py

--- a/demo_nodes_py/setup.py
+++ b/demo_nodes_py/setup.py
@@ -1,17 +1,17 @@
-from ament_python.data_files import get_data_files
-from ament_python.script_dir import install_scripts_to_libexec
 from setuptools import find_packages
 from setuptools import setup
 
 package_name = 'demo_nodes_py'
-data_files = get_data_files(package_name)
-install_scripts_to_libexec(package_name)
 
 setup(
     name=package_name,
     version='0.0.0',
     packages=find_packages(exclude=['test']),
-    data_files=data_files,
+    data_files=[
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+    ],
     install_requires=['setuptools'],
     author='Esteve Fernandez',
     author_email='esteve@osrfoundation.org',

--- a/topic_monitor/package.xml
+++ b/topic_monitor/package.xml
@@ -7,7 +7,6 @@
   <maintainer email="dhood@osrfoundation.org">D. Hood</maintainer>
   <license>Apache License 2.0</license>
 
-  <build_depend>ament_python</build_depend>
   <build_depend>rclpy</build_depend>
 
   <exec_depend>launch</exec_depend>

--- a/topic_monitor/setup.cfg
+++ b/topic_monitor/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script-dir=$base/lib/topic_monitor
+[install]
+install-scripts=$base/lib/topic_monitor

--- a/topic_monitor/setup.py
+++ b/topic_monitor/setup.py
@@ -1,17 +1,17 @@
-from ament_python.data_files import get_data_files
-from ament_python.script_dir import install_scripts_to_libexec
 from setuptools import find_packages
 from setuptools import setup
 
 package_name = 'topic_monitor'
-data_files = get_data_files(package_name)
-install_scripts_to_libexec(package_name)
 
 setup(
-    name='topic_monitor',
+    name=package_name,
     version='0.0.0',
     packages=find_packages(exclude=['test']),
-    data_files=data_files,
+    data_files=[
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+    ],
     install_requires=[
         'launch',
         'setuptools',


### PR DESCRIPTION
Connect to ament/ament_python#3.

The same changes are necessary for the `example_rclpy_*` packages. Once we agree this is the right way to move forward I will create a PR for those.

**Update:** ros2/examples#178