### PR TITLE
Call to rclcpp::shutdown in demos so rclcpp signal handler gets removed

### DIFF
--- a/composition/src/api_composition.cpp
+++ b/composition/src/api_composition.cpp
@@ -159,5 +159,6 @@ int main(int argc, char * argv[])
     exec.remove_node(node);
   }
   nodes.clear();
+  rclcpp::shutdown();
   return 0;
 }

--- a/composition/src/api_composition.cpp
+++ b/composition/src/api_composition.cpp
@@ -159,6 +159,8 @@ int main(int argc, char * argv[])
     exec.remove_node(node);
   }
   nodes.clear();
+
   rclcpp::shutdown();
+
   return 0;
 }

--- a/composition/src/dlopen_composition.cpp
+++ b/composition/src/dlopen_composition.cpp
@@ -53,5 +53,8 @@ int main(int argc, char * argv[])
     exec.remove_node(node);
   }
   nodes.clear();
+
+  rclcpp::shutdown();
+
   return 0;
 }

--- a/composition/src/linktime_composition.cpp
+++ b/composition/src/linktime_composition.cpp
@@ -50,5 +50,8 @@ int main(int argc, char * argv[])
     exec.remove_node(node);
   }
   nodes.clear();
+
+  rclcpp::shutdown();
+
   return 0;
 }

--- a/composition/src/manual_composition.cpp
+++ b/composition/src/manual_composition.cpp
@@ -46,5 +46,8 @@ int main(int argc, char * argv[])
   // spin will block until work comes in, execute work as it becomes available, and keep blocking.
   // It will only be interrupted by Ctrl-C.
   exec.spin();
+
+  rclcpp::shutdown();
+
   return 0;
 }

--- a/demo_nodes_cpp/src/parameters/list_parameters.cpp
+++ b/demo_nodes_cpp/src/parameters/list_parameters.cpp
@@ -47,5 +47,7 @@ int main(int argc, char ** argv)
     std::cout << "Parameter prefix: " << prefix << std::endl;
   }
 
+  rclcpp::shutdown();
+
   return 0;
 }

--- a/demo_nodes_cpp/src/parameters/list_parameters_async.cpp
+++ b/demo_nodes_cpp/src/parameters/list_parameters_async.cpp
@@ -57,5 +57,7 @@ int main(int argc, char ** argv)
     std::cout << "Parameter prefix: " << prefix << std::endl;
   }
 
+  rclcpp::shutdown();
+
   return 0;
 }

--- a/demo_nodes_cpp/src/parameters/parameter_events.cpp
+++ b/demo_nodes_cpp/src/parameters/parameter_events.cpp
@@ -71,5 +71,7 @@ int main(int argc, char ** argv)
 
   rclcpp::spin_some(node);
 
+  rclcpp::shutdown();
+
   return 0;
 }

--- a/demo_nodes_cpp/src/parameters/parameter_events_async.cpp
+++ b/demo_nodes_cpp/src/parameters/parameter_events_async.cpp
@@ -73,5 +73,7 @@ int main(int argc, char ** argv)
 
   rclcpp::spin_some(node);
 
+  rclcpp::shutdown();
+
   return 0;
 }

--- a/demo_nodes_cpp/src/parameters/parameter_node.cpp
+++ b/demo_nodes_cpp/src/parameters/parameter_node.cpp
@@ -53,5 +53,7 @@ int main(int argc, char ** argv)
 
   rclcpp::spin(node);
 
+  rclcpp::shutdown();
+
   return 0;
 }

--- a/demo_nodes_cpp/src/parameters/ros2param.cpp
+++ b/demo_nodes_cpp/src/parameters/ros2param.cpp
@@ -164,5 +164,8 @@ int main(int argc, char ** argv)
     fprintf(stderr, "%s\n", USAGE);
     return 1;
   }
+
+  rclcpp::shutdown();
+
   return 0;
 }

--- a/demo_nodes_cpp/src/parameters/set_and_get_parameters.cpp
+++ b/demo_nodes_cpp/src/parameters/set_and_get_parameters.cpp
@@ -49,5 +49,7 @@ int main(int argc, char ** argv)
       parameter.value_to_string() << std::endl;
   }
 
+  rclcpp::shutdown();
+
   return 0;
 }

--- a/demo_nodes_cpp/src/parameters/set_and_get_parameters_async.cpp
+++ b/demo_nodes_cpp/src/parameters/set_and_get_parameters_async.cpp
@@ -63,5 +63,7 @@ int main(int argc, char ** argv)
       parameter.value_to_string() << std::endl;
   }
 
+  rclcpp::shutdown();
+
   return 0;
 }

--- a/dummy_robot/dummy_map_server/src/dummy_map_server.cpp
+++ b/dummy_robot/dummy_map_server/src/dummy_map_server.cpp
@@ -70,5 +70,8 @@ int main(int argc, char * argv[])
     rclcpp::spin_some(node);
     loop_rate.sleep();
   }
+
+  rclcpp::shutdown();
+
   return 0;
 }

--- a/dummy_robot/dummy_sensors/src/dummy_joint_states.cpp
+++ b/dummy_robot/dummy_sensors/src/dummy_joint_states.cpp
@@ -54,5 +54,8 @@ int main(int argc, char * argv[])
     rclcpp::spin_some(node);
     loop_rate.sleep();
   }
+
+  rclcpp::shutdown();
+
   return 0;
 }

--- a/dummy_robot/dummy_sensors/src/dummy_laser.cpp
+++ b/dummy_robot/dummy_sensors/src/dummy_laser.cpp
@@ -87,5 +87,8 @@ int main(int argc, char * argv[])
     rclcpp::spin_some(node);
     loop_rate.sleep();
   }
+
+  rclcpp::shutdown();
+
   return 0;
 }

--- a/image_tools/src/cam2image.cpp
+++ b/image_tools/src/cam2image.cpp
@@ -210,5 +210,7 @@ int main(int argc, char * argv[])
     loop_rate.sleep();
   }
 
+  rclcpp::shutdown();
+
   return 0;
 }

--- a/image_tools/src/showimage.cpp
+++ b/image_tools/src/showimage.cpp
@@ -143,5 +143,7 @@ int main(int argc, char * argv[])
 
   rclcpp::spin(node);
 
+  rclcpp::shutdown();
+
   return 0;
 }

--- a/intra_process_demo/src/cyclic_pipeline/cyclic_pipeline.cpp
+++ b/intra_process_demo/src/cyclic_pipeline/cyclic_pipeline.cpp
@@ -81,5 +81,8 @@ int main(int argc, char * argv[])
   executor.add_node(pipe1);
   executor.add_node(pipe2);
   executor.spin();
+
+  rclcpp::shutdown();
+
   return 0;
 }

--- a/intra_process_demo/src/image_pipeline/camera_node.cpp
+++ b/intra_process_demo/src/image_pipeline/camera_node.cpp
@@ -31,5 +31,8 @@ int main(int argc, char ** argv)
   }
 
   rclcpp::spin(camera_node);
+
+  rclcpp::shutdown();
+
   return 0;
 }

--- a/intra_process_demo/src/image_pipeline/image_pipeline_all_in_one.cpp
+++ b/intra_process_demo/src/image_pipeline/image_pipeline_all_in_one.cpp
@@ -42,5 +42,8 @@ int main(int argc, char * argv[])
   executor.add_node(image_view_node);
 
   executor.spin();
+
+  rclcpp::shutdown();
+
   return 0;
 }

--- a/intra_process_demo/src/image_pipeline/image_pipeline_with_two_image_view.cpp
+++ b/intra_process_demo/src/image_pipeline/image_pipeline_with_two_image_view.cpp
@@ -45,5 +45,8 @@ int main(int argc, char * argv[])
   executor.add_node(image_view_node2);
 
   executor.spin();
+
+  rclcpp::shutdown();
+
   return 0;
 }

--- a/intra_process_demo/src/image_pipeline/image_view_node.cpp
+++ b/intra_process_demo/src/image_pipeline/image_view_node.cpp
@@ -23,5 +23,8 @@ int main(int argc, char ** argv)
   rclcpp::init(argc, argv);
   auto image_view_node = std::make_shared<ImageViewNode>("watermarked_image");
   rclcpp::spin(image_view_node);
+
+  rclcpp::shutdown();
+
   return 0;
 }

--- a/intra_process_demo/src/image_pipeline/watermark_node.cpp
+++ b/intra_process_demo/src/image_pipeline/watermark_node.cpp
@@ -24,5 +24,8 @@ int main(int argc, char ** argv)
   auto watermark_node =
     std::make_shared<WatermarkNode>("image", "watermarked_image", "Hello world!");
   rclcpp::spin(watermark_node);
+
+  rclcpp::shutdown();
+
   return 0;
 }

--- a/intra_process_demo/src/two_node_pipeline/two_node_pipeline.cpp
+++ b/intra_process_demo/src/two_node_pipeline/two_node_pipeline.cpp
@@ -83,5 +83,8 @@ int main(int argc, char * argv[])
   executor.add_node(producer);
   executor.add_node(consumer);
   executor.spin();
+
+  rclcpp::shutdown();
+
   return 0;
 }

--- a/lifecycle/src/lifecycle_listener.cpp
+++ b/lifecycle/src/lifecycle_listener.cpp
@@ -78,5 +78,7 @@ int main(int argc, char ** argv)
   auto lc_listener = std::make_shared<LifecycleListener>("lc_listener");
   rclcpp::spin(lc_listener);
 
+  rclcpp::shutdown();
+
   return 0;
 }

--- a/lifecycle/src/lifecycle_service_client.cpp
+++ b/lifecycle/src/lifecycle_service_client.cpp
@@ -295,5 +295,7 @@ int main(int argc, char ** argv)
       std::bind(callee_script, lc_client));
   exe.spin_until_future_complete(script);
 
+  rclcpp::shutdown();
+
   return 0;
 }

--- a/lifecycle/src/lifecycle_talker.cpp
+++ b/lifecycle/src/lifecycle_talker.cpp
@@ -266,5 +266,7 @@ int main(int argc, char * argv[])
 
   exe.spin();
 
+  rclcpp::shutdown();
+
   return 0;
 }

--- a/pendulum_control/src/pendulum_demo.cpp
+++ b/pendulum_control/src/pendulum_demo.cpp
@@ -298,4 +298,6 @@ int main(int argc, char * argv[])
 
   printf("PendulumMotor received %lu messages\n", pendulum_motor->messages_received);
   printf("PendulumController received %lu messages\n", pendulum_controller->messages_received);
+
+  rclcpp::shutdown();
 }

--- a/pendulum_control/src/pendulum_logger.cpp
+++ b/pendulum_control/src/pendulum_logger.cpp
@@ -83,4 +83,6 @@ int main(int argc, char * argv[])
   printf("Logger node initialized.\n");
   rclcpp::spin(logger_node);
   fstream.close();
+
+  rclcpp::shutdown();
 }

--- a/pendulum_control/src/pendulum_teleop.cpp
+++ b/pendulum_control/src/pendulum_teleop.cpp
@@ -55,4 +55,6 @@ int main(int argc, char * argv[])
   pub->publish(msg);
   rclcpp::spin_some(teleop_node);
   std::cout << "Teleop node exited." << std::endl;
+
+  rclcpp::shutdown();
 }


### PR DESCRIPTION
connects to ros2/rmw_implementation#25

combined with https://github.com/ros2/rclcpp/pull/353 this fixes https://github.com/ros2/rmw_implementation/issues/25 (also listed in https://github.com/ros2/build_cop/issues/41)

Calling to shutdown is required because otherwise if launch_testing triggers an interrupt while the process is exiting the process deadlocks when multiple rmw implementions are supported (and therefore poco is in use). see https://github.com/ros2/rmw_implementation/issues/25