### PR TITLE
Demo nodes cpp native

### DIFF
--- a/demo_nodes_cpp_native/CMakeLists.txt
+++ b/demo_nodes_cpp_native/CMakeLists.txt
@@ -1,0 +1,75 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(demo_nodes_cpp_native)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rmw REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(rmw_fastrtps_cpp QUIET)
+
+function(custom_executable target)
+  add_executable(${target} src/${target}.cpp)
+  ament_target_dependencies(${target}
+    "rclcpp"
+    "std_msgs"
+    "rmw_fastrtps_cpp")
+  install(TARGETS ${target}
+    DESTINATION lib/${PROJECT_NAME})
+endfunction()
+
+if(rmw_fastrtps_cpp_FOUND)
+  find_package(rmw_fastrtps_cpp REQUIRED)
+  custom_executable(talker)
+
+  if(BUILD_TESTING)
+    find_package(ament_lint_auto REQUIRED)
+    ament_lint_auto_find_test_dependencies()
+
+    set(tutorial_executables "talker")
+
+    set(DEMO_NODES_CPP_EXPECTED_OUTPUT "")
+    foreach(executable ${tutorial_executables})
+      list(APPEND DEMO_NODES_CPP_EXPECTED_OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/test/${executable}")
+    endforeach()
+
+    set(DEMO_NODES_CPP_EXECUTABLE "")
+    foreach(executable ${tutorial_executables})
+      list(APPEND DEMO_NODES_CPP_EXECUTABLE "$<TARGET_FILE:${executable}>")
+    endforeach()
+
+    string(REPLACE ";" "_" exe_list_underscore "${tutorial_executables}")
+    configure_file(
+      test/test_executables_tutorial.py.in
+      test_${exe_list_underscore}.py.configured
+      @ONLY
+    )
+    file(GENERATE
+      OUTPUT "test_${exe_list_underscore}_$<CONFIG>.py"
+      INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_${exe_list_underscore}.py.configured"
+    )
+
+    ament_add_nose_test(test_tutorial_${exe_list_underscore}
+      "${CMAKE_CURRENT_BINARY_DIR}/test_${exe_list_underscore}_$<CONFIG>.py"
+      TIMEOUT 30
+      ENV
+      RCL_ASSERT_RMW_ID_MATCHES=rmw_fastrtps_cpp
+      RMW_IMPLEMENTATION=rmw_fastrtps_cpp)
+    foreach(executable ${tutorial_executables})
+      set_property(
+        TEST test_tutorial_${exe_list_underscore}
+        APPEND PROPERTY DEPENDS ${executable})
+    endforeach()
+  endif()
+endif()
+
+ament_package()

--- a/demo_nodes_cpp_native/package.xml
+++ b/demo_nodes_cpp_native/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>demo_nodes_cpp_native</name>
+  <version>0.0.2</version>
+  <description>
+    C++ nodes which access the native handles of the rmw implemenation.
+  </description>
+  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rmw_fastrtps_cpp</depend>
+  <depend>std_msgs</depend>
+
+  <test_depend>ament_cmake_nose</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>launch</test_depend>
+  <test_depend>launch_testing</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/demo_nodes_cpp_native/src/talker.cpp
+++ b/demo_nodes_cpp_native/src/talker.cpp
@@ -1,0 +1,64 @@
+// Copyright 2014 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "std_msgs/msg/string.hpp"
+
+#include "rmw_fastrtps_cpp/get_participant.hpp"
+#include "rmw_fastrtps_cpp/get_publisher.hpp"
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+
+  auto node = rclcpp::node::Node::make_shared("talker_native");
+
+  {
+    rcl_node_t * rcl_node = node->get_node_base_interface()->get_rcl_node_handle();
+    rmw_node_t * rmw_node = rcl_node_get_rmw_handle(rcl_node);
+    eprosima::fastrtps::Participant * p = rmw_fastrtps_cpp::get_participant(rmw_node);
+    printf("eprosima::fastrtps::Participant * %zu\n", reinterpret_cast<size_t>(p));
+  }
+
+  auto pub = node->create_publisher<std_msgs::msg::String>("chatter");
+
+  {
+    rcl_publisher_t * rcl_pub = pub->get_publisher_handle();
+    rmw_publisher_t * rmw_pub = rcl_publisher_get_rmw_handle(rcl_pub);
+    eprosima::fastrtps::Publisher * p = rmw_fastrtps_cpp::get_publisher(rmw_pub);
+    printf("eprosima::fastrtps::Publisher * %zu\n", reinterpret_cast<size_t>(p));
+  }
+
+  rclcpp::WallRate loop_rate(2);
+
+  auto msg = std::make_shared<std_msgs::msg::String>();
+  auto i = 1;
+
+  while (rclcpp::ok()) {
+    msg->data = "Hello World: " + std::to_string(i++);
+    std::cout << "Publishing: '" << msg->data << "'" << std::endl;
+    pub->publish(msg);
+    rclcpp::spin_some(node);
+    loop_rate.sleep();
+  }
+
+  rclcpp::shutdown();
+
+  return 0;
+}

--- a/demo_nodes_cpp_native/test/talker.regex
+++ b/demo_nodes_cpp_native/test/talker.regex
@@ -1,0 +1,3 @@
+eprosima::fastrtps::Participant \* [0-9]{2,}
+eprosima::fastrtps::Publisher \* [0-9]{2,}
+Publishing: 'Hello World: 1'

--- a/demo_nodes_cpp_native/test/test_executables_tutorial.py.in
+++ b/demo_nodes_cpp_native/test/test_executables_tutorial.py.in
@@ -1,0 +1,59 @@
+# generated from demo_nodes_cpp/test/test_executables_tutorial.py.in
+# generated code does not contain a copyright notice
+
+import os
+
+from launch import LaunchDescriptor
+from launch.exit_handler import ignore_exit_handler
+from launch.exit_handler import primary_ignore_returncode_exit_handler
+from launch.launcher import DefaultLauncher
+from launch.output_handler import ConsoleOutput
+from launch_testing import create_handler
+from launch_testing import get_default_filtered_prefixes
+
+
+def test_executable():
+    output_handlers = []
+
+    launch_descriptor = LaunchDescriptor()
+
+    rmw_implementation = 'rmw_fastrtps_cpp'
+    executables = '@DEMO_NODES_CPP_EXECUTABLE@'.split(';')
+    output_files = '@DEMO_NODES_CPP_EXPECTED_OUTPUT@'.split(';')
+    for i, (exe, output_file) in enumerate(zip(executables, output_files)):
+        name = 'test_executable_' + str(i)
+        # The last executable is taken to be the test program (the one whose
+        # output check can make the decision to shut everything down)
+        if i == (len(executables) - 1):
+            exit_handler = primary_ignore_returncode_exit_handler
+            exit_on_match = True
+        else:
+            exit_handler = ignore_exit_handler
+            exit_on_match = False
+
+        handler = create_handler(
+            name, launch_descriptor, output_file,
+            exit_on_match=exit_on_match, filtered_rmw_implementation=rmw_implementation)
+        assert handler, 'Cannot find appropriate handler for %s' % output_file
+        output_handlers.append(handler)
+        launch_descriptor.add_process(
+            cmd=[exe],
+            name=name,
+            exit_handler=exit_handler,
+            output_handlers=[ConsoleOutput(), handler],
+        )
+
+    launcher = DefaultLauncher()
+    launcher.add_launch_descriptor(launch_descriptor)
+    rc = launcher.launch()
+
+    assert rc == 0, \
+        "The launch file failed with exit code '" + str(rc) + "'. " \
+        'Maybe the client did not receive any messages?'
+
+    for handler in output_handlers:
+        handler.check()
+
+
+if __name__ == '__main__':
+    test_executable()


### PR DESCRIPTION
Demonstrate how to access the RMW specific native handles exposed in ros2/rmw_fastrtps#145 and ros2/rmw_fastrtps#146.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3069)](http://ci.ros2.org/job/ci_linux/3069/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=460)](http://ci.ros2.org/job/ci_linux-aarch64/460/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2466)](http://ci.ros2.org/job/ci_osx/2466/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3137)](http://ci.ros2.org/job/ci_windows/3137/)
  * The Windows linker fails to find `libfastrtps-1.5.lib`. According to the linked `rmw_fastrtps_cpp_LIBRARIES` it is supposed to link against `C:/J/workspace/ci_windows/ws/install/fastrtps/lib/fastrtps-1.5.lib`. I don't see where the additional `lib` prefix is coming from (the file itself exists but the linker probably doesn't know where to find it). Any ideas what is going wrong here would be appreciated.