### PR TITLE
use ros2run api to handle KeyboardInterrupt

### DIFF
--- a/pendulum_control/package.xml
+++ b/pendulum_control/package.xml
@@ -25,6 +25,7 @@
   <test_depend>launch</test_depend>
   <test_depend>launch_testing</test_depend>
   <test_depend>rmw_implementation_cmake</test_depend>
+  <test_depend>ros2run</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/pendulum_control/test/execute_with_delay.py
+++ b/pendulum_control/test/execute_with_delay.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import argparse
-import subprocess
 import sys
 import time
+
+from ros2run.api import run_executable
 
 
 def main():
@@ -27,7 +28,8 @@ def main():
 
     delay_time = args.delay * 0.001
     time.sleep(delay_time)
-    return subprocess.call(args.executable)
+    # use ros2run api to handle KeyboardInterrupt
+    return run_executable(path=args.executable[0], argv=args.executable[1:])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Without the patch the surrounding launch file sends a `SIGINT` to this script which will raise during the `subprocess.call` and return non-zero.

This seems to have failed a few tests in the past:
* http://ci.ros2.org/view/nightly/job/nightly_linux_repeated/779/testReport/(root)/projectroot/test_pendulum_teleop__rmw_connext_cpp/
* http://ci.ros2.org/view/nightly/job/nightly_linux_repeated/773/testReport/(root)/projectroot/test_pendulum_teleop__rmw_connext_cpp/
* http://ci.ros2.org/view/nightly/job/nightly_linux_repeated/769/testReport/(root)/projectroot/test_pendulum_teleop__rmw_connext_cpp/
* ...

The patch uses the `ros2run` API to handle the raised `KeyboardInterrupt` nicely and let the subprocess finish. The hope is that this makes the test not flaky anymore / less flaky.

It retried 30 times without failing due to a `KeyboardInterrupt` (which of course doesn't proof anything :wink:): [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3243)](http://ci.ros2.org/job/ci_linux/3243/)

The later failure was a timeout - `pendulum_demo` was hanging without ever printing the Connext license message. More on this in #177.