### PR TITLE
Prototype for using logging macros

### DIFF
--- a/demo_nodes_cpp/src/services/add_two_ints_client.cpp
+++ b/demo_nodes_cpp/src/services/add_two_ints_client.cpp
@@ -73,19 +73,21 @@ int main(int argc, char ** argv)
 
   while (!client->wait_for_service(1s)) {
     if (!rclcpp::ok()) {
-      printf("add_two_ints_client was interrupted while waiting for the service. Exiting.\n");
+      // This will have <package_name>.<node_name> as the logger name.
+      ROS_INFO_NAMED(node->get_name(),
+        "add_two_ints_client was interrupted while waiting for the service. Exiting.\n");
       return 0;
     }
-    printf("service not available, waiting again...\n");
+    ROS_INFO_NAMED(node->get_name(), "service not available, waiting again...\n");
   }
 
   // TODO(wjwwood): make it like `client->send_request(node, request)->sum`
   // TODO(wjwwood): consider error condition
   auto result = send_request(node, client, request);
   if (result) {
-    printf("Result of add_two_ints: %zd\n", result->sum);
+    ROS_INFO_NAMED(node->get_name(), "Result of add_two_ints: %zd\n", result->sum);
   } else {
-    printf("add_two_ints_client was interrupted. Exiting.\n");
+    ROS_INFO_NAMED(node->get_name(), "add_two_ints_client was interrupted. Exiting.\n");
   }
 
   rclcpp::shutdown();

--- a/demo_nodes_cpp/src/services/add_two_ints_server.cpp
+++ b/demo_nodes_cpp/src/services/add_two_ints_server.cpp
@@ -17,6 +17,7 @@
 #include <string>
 
 #include "rclcpp/rclcpp.hpp"
+#include "rcutils/logging_macros.h"
 #include "rcutils/cmdline_parser.h"
 
 #include "example_interfaces/srv/add_two_ints.hpp"
@@ -36,8 +37,11 @@ void handle_add_two_ints(
   std::shared_ptr<example_interfaces::srv::AddTwoInts::Response> response)
 {
   (void)request_header;
-  std::cout << "Incoming request" << std::endl;
-  std::cout << "a: " << request->a << " b: " << request->b << std::endl;
+  std::stringstream ss;
+  ss << "Incoming request" << std::endl;
+  ss << "a: " << request->a << " b: " << request->b << std::endl;
+  // No stream log macro yet. This will get <package_name> as the logger name.
+  ROS_INFO("%s", ss.str().c_str())
   response->sum = request->a + request->b;
 }
 

--- a/demo_nodes_cpp/src/topics/talker.cpp
+++ b/demo_nodes_cpp/src/topics/talker.cpp
@@ -56,8 +56,11 @@ int main(int argc, char * argv[])
   auto i = 1;
 
   while (rclcpp::ok()) {
-    msg->data = "Hello World: " + std::to_string(i++);
-    std::cout << "Publishing: '" << msg->data << "'" << std::endl;
+    msg->data = "Hello World: " + std::to_string(i);
+    // Pretend that the topic is how we want to separate our loggers for some reason
+    ROS_INFO_FULLNAMED(topic + "." + RCLCPP_CONSOLE_DEFAULT_NAME + "." + node->get_name(),
+      "Publishing: '%d'", i);
+    i++;
     chatter_pub->publish(msg);
     rclcpp::spin_some(node);
     loop_rate.sleep();


### PR DESCRIPTION
Proposed usage for logging macro wrappers provided by rclcpp (not considering logger objects at the moment)

The purpose for wrapping the rcutils macros in the first place is to inject default names and/or name suffixes to log calls.

For comparison, ROS 1's [rosconsole does the following](https://github.com/ros/ros_comm/blob/4383f8fad9550836137077ed1a7120e5d3e745de/tools/rosconsole/include/ros/console.h#L298..L299):
1. uses "ros.<package_name>" as the name for unnamed log calls (a default name of sorts, to allow for some automatic grouping of logging messages even if users just call ROS_INFO)
1. prepends "ros.<package_name>" to all named log calls e.g. ROS_INFO_NAMED, presumably to distinguish them from other non-ros loggers, e.g. `rqt_gui_py_node` exposes loggers like `PyQt5.uic.properties`
1. doesn't provide a way to avoid the suffix when using the macros from what I can tell (you don't have to use the macros though)

The proposal for ROS 2 is to do something similar by setting a default name/prefix, but also provide ROS_INFO_FULLNAMED that allows users to provide the full logger name if they want to.

Concrete proposals:
1. Default name of just "<package_name>" for nameless log calls (when using ROS_INFO)
1. Default name is prepended as a prefix for named calls (when using ROS_INFO_NAMED)
1. No prefix added for fully-named calls (when using ROS_INFO_FULLNAMED)

Reasoning:
Speaking with a couple of people it seems that we don't feel that having the "ros" prefix for the default name/prefix is that necessary, but that a default of some sort is still needed, so we can just go with "<package_name>". IMO if a user calls ROS_INFO_NAMED in the same file as ROS_INFO they should go to the same parent logger (different child for the named one), suggesting that whatever the default name is it should continue to be prepended even in the case of ROS_INFO_NAMED.

However, most people I spoke to were surprised that the package name was always being prepended without a way to override it, so we can also add ROS_INFO_FULLNAMED, which doesn't do any name modification, it just passes it through to rcutils.
Examples when you might want to use ROS_INFO_FULLNAMED:
1. someone wants to group all of their packages relating to robotX under a common root logger
1. someone has 2 instances of robotX and wants them to publish under separate root loggers based on their robot name.

This PR has some usage examples.

