### PR TITLE
Stop client component from hogging executor

### DIFF
--- a/composition/CMakeLists.txt
+++ b/composition/CMakeLists.txt
@@ -184,7 +184,7 @@ if(BUILD_TESTING)
       ENV RMW_IMPLEMENTATION=${rmw_implementation}
       APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/test_ament_index/$<CONFIG>
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
-      TIMEOUT 90)
+      TIMEOUT 100)
     list(
       APPEND generated_python_files
       "${CMAKE_CURRENT_BINARY_DIR}/test_composition${target_suffix}_$<CONFIG>.py")

--- a/composition/CMakeLists.txt
+++ b/composition/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(ament_index_cpp REQUIRED)
 find_package(class_loader REQUIRED)
 find_package(example_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rcutils REQUIRED)
 find_package(rosidl_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(std_msgs REQUIRED)
@@ -115,7 +116,8 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 endif()
 ament_target_dependencies(api_composition
   "class_loader"
-  "rclcpp")
+  "rclcpp"
+  "rcutils")
 rosidl_target_interfaces(api_composition
   ${PROJECT_NAME} "rosidl_typesupport_cpp")
 

--- a/composition/include/composition/client_component.hpp
+++ b/composition/include/composition/client_component.hpp
@@ -29,7 +29,7 @@ public:
   Client();
 
 protected:
-  bool on_timer();
+  void on_timer();
 
 private:
   rclcpp::client::Client<example_interfaces::srv::AddTwoInts>::SharedPtr client_;

--- a/composition/package.xml
+++ b/composition/package.xml
@@ -13,6 +13,7 @@
   <build_depend>class_loader</build_depend>
   <build_depend>example_interfaces</build_depend>
   <build_depend>rclcpp</build_depend>
+  <build_depend>rcutils</build_depend>
   <build_depend>rosidl_cmake</build_depend>
   <build_depend>std_msgs</build_depend>
 
@@ -20,6 +21,7 @@
   <exec_depend>class_loader</exec_depend>
   <exec_depend>example_interfaces</exec_depend>
   <exec_depend>rclcpp</exec_depend>
+  <exec_depend>rcutils</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 

--- a/composition/src/api_composition_cli.cpp
+++ b/composition/src/api_composition_cli.cpp
@@ -18,14 +18,30 @@
 
 #include "composition/srv/load_node.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "rcutils/cmdline_parser.h"
 
 using namespace std::chrono_literals;
 
+void print_usage()
+{
+  printf("Usage for api_composition_cli:\n");
+  printf("api_composition_cli package_name plugin_name [--delay delay_ms] [-h]\n");
+  printf("options:\n");
+  printf("-h : Print this help function.\n");
+  printf("--delay delay_ms: Delay in ms before attempting request. Defaults to 0.\n");
+}
+
 int main(int argc, char * argv[])
 {
-  if (argc != 3) {
-    fprintf(stderr, "Requires exactly two arguments to be passed: package name and plugin name\n");
-    return 1;
+  if (argc < 3 || rcutils_cli_option_exist(argv, argv + argc, "-h")) {
+    print_usage();
+    return 0;
+  }
+
+  if (rcutils_cli_option_exist(argv, argv + argc, "--delay")) {
+    std::chrono::milliseconds delay = std::chrono::milliseconds(
+      std::stoul(rcutils_cli_get_option(argv, argv + argc, "--delay")));
+    std::this_thread::sleep_for(delay);
   }
 
   rclcpp::init(argc, argv);

--- a/composition/src/client_component.cpp
+++ b/composition/src/client_component.cpp
@@ -48,7 +48,7 @@ Client::Client()
 : Node("Client")
 {
   client_ = create_client<example_interfaces::srv::AddTwoInts>("add_two_ints");
-  timer_ = create_wall_timer(1s, std::bind(&Client::on_timer, this));
+  timer_ = create_wall_timer(2s, std::bind(&Client::on_timer, this));
 }
 
 bool Client::on_timer()

--- a/composition/src/client_component.cpp
+++ b/composition/src/client_component.cpp
@@ -56,10 +56,6 @@ Client::Client()
 
 void Client::on_timer()
 {
-  auto request = std::make_shared<example_interfaces::srv::AddTwoInts::Request>();
-  request->a = 2;
-  request->b = 3;
-
   if (!client_->wait_for_service(1s)) {
     if (!rclcpp::ok()) {
       fprintf(stderr,
@@ -69,6 +65,10 @@ void Client::on_timer()
     fprintf(stderr, "service not available after waiting.\n");
     return;
   }
+
+  auto request = std::make_shared<example_interfaces::srv::AddTwoInts::Request>();
+  request->a = 2;
+  request->b = 3;
 
   // In order to wait for a response to arrive, we need to spin().
   // However, this function is already being called from within another spin().

--- a/composition/src/client_component.cpp
+++ b/composition/src/client_component.cpp
@@ -51,7 +51,7 @@ Client::Client()
   timer_ = create_wall_timer(2s, std::bind(&Client::on_timer, this));
 }
 
-bool Client::on_timer()
+void Client::on_timer()
 {
   auto request = std::make_shared<example_interfaces::srv::AddTwoInts::Request>();
   request->a = 2;
@@ -61,10 +61,10 @@ bool Client::on_timer()
     if (!rclcpp::ok()) {
       fprintf(stderr,
         "add_two_ints_client was interrupted while waiting for the service. Exiting.\n");
-      return false;
+      return;
     }
     fprintf(stderr, "service not available after waiting.\n");
-    return false;
+    return;
   }
 
   // In order to wait for a response to arrive, we need to spin().
@@ -83,8 +83,6 @@ bool Client::on_timer()
       printf("Got result: [%" PRIu64 "]\n", future.get()->sum);
     };
   auto future_result = client_->async_send_request(request, response_received_callback);
-
-  return true;
 }
 
 }  // namespace composition

--- a/composition/src/client_component.cpp
+++ b/composition/src/client_component.cpp
@@ -57,13 +57,14 @@ bool Client::on_timer()
   request->a = 2;
   request->b = 3;
 
-  while (!client_->wait_for_service(1s)) {
+  if (!client_->wait_for_service(1s)) {
     if (!rclcpp::ok()) {
       fprintf(stderr,
         "add_two_ints_client was interrupted while waiting for the service. Exiting.\n");
       return false;
     }
-    fprintf(stderr, "service not available, waiting again...\n");
+    fprintf(stderr, "service not available after waiting.\n");
+    return false;
   }
 
   // In order to wait for a response to arrive, we need to spin().

--- a/composition/src/client_component.cpp
+++ b/composition/src/client_component.cpp
@@ -48,6 +48,9 @@ Client::Client()
 : Node("Client")
 {
   client_ = create_client<example_interfaces::srv::AddTwoInts>("add_two_ints");
+  // Note(dhood): The timer period must be greater than the duration of the timer callback.
+  // Otherwise, the timer can starve a single-threaded executor.
+  // See https://github.com/ros2/rclcpp/issues/392 for updates.
   timer_ = create_wall_timer(2s, std::bind(&Client::on_timer, this));
 }
 

--- a/composition/test/test_composition.py.in
+++ b/composition/test/test_composition.py.in
@@ -116,7 +116,7 @@ def test_api_srv_composition_client_first():
         {
             'cmd': [
                 '@API_COMPOSITION_CLI_EXECUTABLE@',
-                'composition', 'composition::Server'],
+                'composition', 'composition::Server', '--delay', '5000'],
             'name': 'load_server_component',
             'exit_handler': exit_on_error_exit_handler,
         },

--- a/composition/test/test_composition.py.in
+++ b/composition/test/test_composition.py.in
@@ -100,6 +100,31 @@ def test_api_srv_composition():
     launch(name, [executable], output_file, additional_processes=additional_processes)
 
 
+def test_api_srv_composition_client_first():
+    # This is a regression test to ensure that the client starting first and waiting for a service
+    # does not block the executor from processing requests to load other components.
+    name = 'test_api_composition'
+    executable = '@API_COMPOSITION_EXECUTABLE@'
+    additional_processes = [
+        {
+            'cmd': [
+                '@API_COMPOSITION_CLI_EXECUTABLE@',
+                'composition', 'composition::Client'],
+            'name': 'load_client_component',
+            'exit_handler': exit_on_error_exit_handler,
+        },
+        {
+            'cmd': [
+                '@API_COMPOSITION_CLI_EXECUTABLE@',
+                'composition', 'composition::Server'],
+            'name': 'load_server_component',
+            'exit_handler': exit_on_error_exit_handler,
+        },
+    ]
+    output_file = '@EXPECTED_OUTPUT_SRV@'
+    launch(name, [executable], output_file, additional_processes=additional_processes)
+
+
 def launch(name, cmd, output_file, additional_processes=None):
     launch_descriptor = LaunchDescriptor()
 


### PR DESCRIPTION
Using the API composition demo, if the client component is started before the server, then a request to load the server component cannot be processed because the client is hogging the executor waiting for the service.

To reproduce:
```
ros2 run composition api_composition
```

In another terminal:
```
ros2 run composition api_composition_cli -- composition composition::Client
Sending request...
Waiting for response...
Result of load_node: success = true
```
```
ros2 run composition api_composition_cli -- composition composition::Server
Sending request...
Waiting for response...
<never loads>
```
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3436)](http://ci.ros2.org/job/ci_linux/3436/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=682)](http://ci.ros2.org/job/ci_linux-aarch64/682/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2764)](http://ci.ros2.org/job/ci_osx/2764/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3481)](http://ci.ros2.org/job/ci_windows/3481/)

An alternative fix is to make the API composition demo use a multithreaded executor. That change may independently make sense, but I think the client component should be more co-operative regardless.

Rather than change the existing test I added a new regression test with the client being started first. However, this PR should also address flakiness of the existing test if the client waiitng was the cause of the server not being loaded sometimes e.g. http://ci.ros2.org/view/nightly/job/nightly_osx_repeated/883/testReport/junit/(root)/projectroot/test_composition__rmw_connext_cpp/