### PR TITLE
 Strip formatting from console output for output matching

### DIFF
--- a/composition/src/listener_component.cpp
+++ b/composition/src/listener_component.cpp
@@ -17,6 +17,7 @@
 #include <iostream>
 #include <memory>
 
+#include "rcutils/logging_macros.h"
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/string.hpp"
 
@@ -34,7 +35,7 @@ Listener::Listener()
   auto callback =
     [](const typename std_msgs::msg::String::SharedPtr msg) -> void
     {
-      printf("I heard: [%s]\n", msg->data.c_str());
+      RCUTILS_LOG_INFO_NAMED("composition", "I heard: [%s]", msg->data.c_str());
       std::flush(std::cout);
     };
 

--- a/composition/src/listener_component.cpp
+++ b/composition/src/listener_component.cpp
@@ -17,7 +17,6 @@
 #include <iostream>
 #include <memory>
 
-#include "rcutils/logging_macros.h"
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/string.hpp"
 
@@ -35,7 +34,7 @@ Listener::Listener()
   auto callback =
     [](const typename std_msgs::msg::String::SharedPtr msg) -> void
     {
-      RCUTILS_LOG_INFO_NAMED("composition", "I heard: [%s]", msg->data.c_str());
+      printf("I heard: [%s]\n", msg->data.c_str());
       std::flush(std::cout);
     };
 

--- a/composition/test/test_composition.py.in
+++ b/composition/test/test_composition.py.in
@@ -23,6 +23,11 @@ from launch.output_handler import ConsoleOutput
 from launch_testing import create_handler
 
 
+def setup():
+    # bare minimum formatting for console output matching
+    os.environ['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '{message}'
+
+
 def test_manual_composition():
     name = 'test_manual_composition'
     executable = '@MANUAL_COMPOSITION_EXECUTABLE@'

--- a/demo_nodes_cpp/test/test_executables_tutorial.py.in
+++ b/demo_nodes_cpp/test/test_executables_tutorial.py.in
@@ -14,6 +14,8 @@ from launch_testing import get_default_filtered_prefixes
 
 def setup():
     os.environ['OSPL_VERBOSITY'] = '8'  # 8 = OS_NONE
+    # bare minimum formatting for console output matching
+    os.environ['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '{message}'
 
 
 def test_executable():

--- a/demo_nodes_cpp_native/test/test_executables_tutorial.py.in
+++ b/demo_nodes_cpp_native/test/test_executables_tutorial.py.in
@@ -12,6 +12,11 @@ from launch_testing import create_handler
 from launch_testing import get_default_filtered_prefixes
 
 
+def setup():
+    # bare minimum formatting for console output matching
+    os.environ['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '{message}'
+
+
 def test_executable():
     output_handlers = []
 

--- a/image_tools/test/test_executables_demo.py.in
+++ b/image_tools/test/test_executables_demo.py.in
@@ -24,6 +24,8 @@ from launch_testing import create_handler
 
 def setup():
     os.environ['OSPL_VERBOSITY'] = '8'  # 8 = OS_NONE
+    # bare minimum formatting for console output matching
+    os.environ['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '{message}'
 
 
 def test_reliable_qos():

--- a/intra_process_demo/test/test_executables_demo.py.in
+++ b/intra_process_demo/test/test_executables_demo.py.in
@@ -12,6 +12,8 @@ from launch_testing import create_handler
 
 def setup():
     os.environ['OSPL_VERBOSITY'] = '8'  # 8 = OS_NONE
+    # bare minimum formatting for console output matching
+    os.environ['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '{message}'
 
 
 def test_executable():

--- a/pendulum_control/test/test_pendulum_demo.py.in
+++ b/pendulum_control/test/test_pendulum_demo.py.in
@@ -14,6 +14,8 @@ from launch_testing import get_default_filtered_prefixes
 
 def setup():
     os.environ['OSPL_VERBOSITY'] = '8'  # 8 = OS_NONE
+    # bare minimum formatting for console output matching
+    os.environ['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '{message}'
 
 
 def test_executable():

--- a/pendulum_control/test/test_pendulum_teleop.py.in
+++ b/pendulum_control/test/test_pendulum_teleop.py.in
@@ -15,6 +15,8 @@ from launch_testing import get_default_filtered_prefixes
 
 def setup():
     os.environ['OSPL_VERBOSITY'] = '8'  # 8 = OS_NONE
+    # bare minimum formatting for console output matching
+    os.environ['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '{message}'
 
 
 def test_executable():


### PR DESCRIPTION
This is preparation for swapping demos to logging macros. I don't mind if we merge this now or later but I want to kick off the review process in case there are any hiccups.

29e3716eb1d6c363f70bbfbc9994a7ca91ae2c56 is included to show that the change does what's expected, it's not being proposed for merge and will be removed before merge.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3511)](http://ci.ros2.org/job/ci_linux/3511/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=731)](http://ci.ros2.org/job/ci_linux-aarch64/731/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2847)](http://ci.ros2.org/job/ci_osx/2847/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3574)](http://ci.ros2.org/job/ci_windows/3574/)