### PR TITLE
Use logging macros [logger name instead of object]

### DIFF
--- a/composition/src/api_composition.cpp
+++ b/composition/src/api_composition.cpp
@@ -89,7 +89,7 @@ int main(int argc, char * argv[])
       if (
         !ament_index_cpp::get_resource("node_plugin", request->package_name, content, &base_path))
       {
-        RCLCPP_ERROR(node->get_name(), "Could not find requested resource in ament index");
+        RCLCPP_ERROR(node->get_name(), "Could not find requested resource in ament index")
         response->success = false;
         return;
       }
@@ -98,7 +98,7 @@ int main(int argc, char * argv[])
       for (auto line : lines) {
         std::vector<std::string> parts = split(line, ';');
         if (parts.size() != 2) {
-          RCLCPP_ERROR(node->get_name(), "Invalid resource entry");
+          RCLCPP_ERROR(node->get_name(), "Invalid resource entry")
           response->success = false;
           return;
         }
@@ -114,23 +114,23 @@ int main(int argc, char * argv[])
         if (!fs::path(library_path).is_absolute()) {
           library_path = base_path + "/" + library_path;
         }
-        RCLCPP_INFO(node->get_name(), "Load library %s", library_path.c_str());
+        RCLCPP_INFO(node->get_name(), "Load library %s", library_path.c_str())
         class_loader::ClassLoader * loader;
         try {
           loader = new class_loader::ClassLoader(library_path);
         } catch (const std::exception & ex) {
-          RCLCPP_ERROR(node->get_name(), "Failed to load library: %s", ex.what());
+          RCLCPP_ERROR(node->get_name(), "Failed to load library: %s", ex.what())
           response->success = false;
           return;
         } catch (...) {
-          RCLCPP_ERROR(node->get_name(), "Failed to load library");
+          RCLCPP_ERROR(node->get_name(), "Failed to load library")
           response->success = false;
           return;
         }
         auto classes = loader->getAvailableClasses<rclcpp::Node>();
         for (auto clazz : classes) {
           if (clazz == class_name) {
-            RCLCPP_INFO(node->get_name(), "Instantiate class %s", clazz.c_str());
+            RCLCPP_INFO(node->get_name(), "Instantiate class %s", clazz.c_str())
             auto node = loader->createInstance<rclcpp::Node>(clazz);
             exec.add_node(node);
             nodes.push_back(node);
@@ -145,13 +145,13 @@ int main(int argc, char * argv[])
         RCLCPP_ERROR(
           node->get_name(), "Failed to find class with the requested plugin name '%s' in "
           "the loaded library",
-          request->plugin_name.c_str());
+          request->plugin_name.c_str())
         response->success = false;
         return;
       }
       RCLCPP_ERROR(
         node->get_name(), "Failed to find plugin name '%s' in prefix '%s'",
-        request->plugin_name.c_str(), base_path.c_str());
+        request->plugin_name.c_str(), base_path.c_str())
       response->success = false;
     });
 

--- a/composition/src/api_composition_cli.cpp
+++ b/composition/src/api_composition_cli.cpp
@@ -52,23 +52,23 @@ int main(int argc, char * argv[])
     if (!rclcpp::ok()) {
       RCLCPP_ERROR(
         node->get_name(),
-        "Interrupted while waiting for the service. Exiting.");
+        "Interrupted while waiting for the service. Exiting.")
       return 0;
     }
-    RCLCPP_INFO(node->get_name(), "Service not available, waiting again...");
+    RCLCPP_INFO(node->get_name(), "Service not available, waiting again...")
   }
 
   auto request = std::make_shared<composition::srv::LoadNode::Request>();
   request->package_name = argv[1];
   request->plugin_name = argv[2];
 
-  RCLCPP_INFO(node->get_name(), "Sending request...");
+  RCLCPP_INFO(node->get_name(), "Sending request...")
   auto result = client->async_send_request(request);
-  RCLCPP_INFO(node->get_name(), "Waiting for response...");
+  RCLCPP_INFO(node->get_name(), "Waiting for response...")
   if (rclcpp::spin_until_future_complete(node, result) !=
     rclcpp::executor::FutureReturnCode::SUCCESS)
   {
-    RCLCPP_ERROR(node->get_name(), "Interrupted while waiting for response. Exiting.");
+    RCLCPP_ERROR(node->get_name(), "Interrupted while waiting for response. Exiting.")
     if (!rclcpp::ok()) {
       return 0;
     }
@@ -76,7 +76,7 @@ int main(int argc, char * argv[])
   }
   RCLCPP_INFO(
     node->get_name(), "Result of load_node: success = %s",
-    result.get()->success ? "true" : "false");
+    result.get()->success ? "true" : "false")
 
   rclcpp::shutdown();
 

--- a/composition/src/api_composition_cli.cpp
+++ b/composition/src/api_composition_cli.cpp
@@ -50,29 +50,33 @@ int main(int argc, char * argv[])
 
   while (!client->wait_for_service(1s)) {
     if (!rclcpp::ok()) {
-      printf("api_composition_cli was interrupted while waiting for the service. Exiting.\n");
+      RCLCPP_ERROR(
+        node->get_name(),
+        "Interrupted while waiting for the service. Exiting.");
       return 0;
     }
-    printf("service not available, waiting again...\n");
+    RCLCPP_INFO(node->get_name(), "Service not available, waiting again...");
   }
 
   auto request = std::make_shared<composition::srv::LoadNode::Request>();
   request->package_name = argv[1];
   request->plugin_name = argv[2];
 
-  printf("Sending request...\n");
+  RCLCPP_INFO(node->get_name(), "Sending request...");
   auto result = client->async_send_request(request);
-  printf("Waiting for response...\n");
+  RCLCPP_INFO(node->get_name(), "Waiting for response...");
   if (rclcpp::spin_until_future_complete(node, result) !=
     rclcpp::executor::FutureReturnCode::SUCCESS)
   {
-    fprintf(stderr, "api_composition_cli was interrupted. Exiting.\n");
+    RCLCPP_ERROR(node->get_name(), "Interrupted while waiting for response. Exiting.");
     if (!rclcpp::ok()) {
       return 0;
     }
     return 1;
   }
-  printf("Result of load_node: success = %s\n", result.get()->success ? "true" : "false");
+  RCLCPP_INFO(
+    node->get_name(), "Result of load_node: success = %s",
+    result.get()->success ? "true" : "false");
 
   rclcpp::shutdown();
 

--- a/composition/src/client_component.cpp
+++ b/composition/src/client_component.cpp
@@ -58,11 +58,12 @@ void Client::on_timer()
 {
   if (!client_->wait_for_service(1s)) {
     if (!rclcpp::ok()) {
-      fprintf(stderr,
-        "add_two_ints_client was interrupted while waiting for the service. Exiting.\n");
+      RCLCPP_ERROR(
+        this->get_name(),
+        "Interrupted while waiting for the service. Exiting.");
       return;
     }
-    fprintf(stderr, "service not available after waiting.\n");
+    RCLCPP_INFO(this->get_name(), "Service not available after waiting");
     return;
   }
 
@@ -82,8 +83,8 @@ void Client::on_timer()
   // continue and our callback will get called once the response is received.
   using ServiceResponseFuture =
       rclcpp::client::Client<example_interfaces::srv::AddTwoInts>::SharedFuture;
-  auto response_received_callback = [](ServiceResponseFuture future) {
-      printf("Got result: [%" PRIu64 "]\n", future.get()->sum);
+  auto response_received_callback = [this](ServiceResponseFuture future) {
+      RCLCPP_INFO(this->get_name(), "Got result: [%" PRIu64 "]", future.get()->sum);
     };
   auto future_result = client_->async_send_request(request, response_received_callback);
 }

--- a/composition/src/client_component.cpp
+++ b/composition/src/client_component.cpp
@@ -60,10 +60,10 @@ void Client::on_timer()
     if (!rclcpp::ok()) {
       RCLCPP_ERROR(
         this->get_name(),
-        "Interrupted while waiting for the service. Exiting.");
+        "Interrupted while waiting for the service. Exiting.")
       return;
     }
-    RCLCPP_INFO(this->get_name(), "Service not available after waiting");
+    RCLCPP_INFO(this->get_name(), "Service not available after waiting")
     return;
   }
 
@@ -84,7 +84,7 @@ void Client::on_timer()
   using ServiceResponseFuture =
       rclcpp::client::Client<example_interfaces::srv::AddTwoInts>::SharedFuture;
   auto response_received_callback = [this](ServiceResponseFuture future) {
-      RCLCPP_INFO(this->get_name(), "Got result: [%" PRIu64 "]", future.get()->sum);
+      RCLCPP_INFO(this->get_name(), "Got result: [%" PRIu64 "]", future.get()->sum)
     };
   auto future_result = client_->async_send_request(request, response_received_callback);
 }

--- a/composition/src/dlopen_composition.cpp
+++ b/composition/src/dlopen_composition.cpp
@@ -19,6 +19,8 @@
 #include "class_loader/class_loader.h"
 #include "rclcpp/rclcpp.hpp"
 
+#define DLOPEN_COMPOSITION_LOGGER_NAME "dlopen_composition"
+
 int main(int argc, char * argv[])
 {
   if (argc < 2) {
@@ -35,11 +37,11 @@ int main(int argc, char * argv[])
     libraries.push_back(argv[i]);
   }
   for (auto library : libraries) {
-    printf("Load library %s\n", library.c_str());
+    RCLCPP_INFO(DLOPEN_COMPOSITION_LOGGER_NAME, "Load library %s", library.c_str());
     auto loader = new class_loader::ClassLoader(library);
     auto classes = loader->getAvailableClasses<rclcpp::Node>();
     for (auto clazz : classes) {
-      printf("Instantiate class %s\n", clazz.c_str());
+      RCLCPP_INFO(DLOPEN_COMPOSITION_LOGGER_NAME, "Instantiate class %s", clazz.c_str());
       auto node = loader->createInstance<rclcpp::Node>(clazz);
       exec.add_node(node);
       nodes.push_back(node);

--- a/composition/src/dlopen_composition.cpp
+++ b/composition/src/dlopen_composition.cpp
@@ -24,7 +24,7 @@
 int main(int argc, char * argv[])
 {
   if (argc < 2) {
-    fprintf(stderr, "Requires at least one argument to be passed with the library to load\n")
+    fprintf(stderr, "Requires at least one argument to be passed with the library to load\n");
     return 1;
   }
   rclcpp::init(argc, argv);

--- a/composition/src/dlopen_composition.cpp
+++ b/composition/src/dlopen_composition.cpp
@@ -24,7 +24,7 @@
 int main(int argc, char * argv[])
 {
   if (argc < 2) {
-    fprintf(stderr, "Requires at least one argument to be passed with the library to load\n");
+    fprintf(stderr, "Requires at least one argument to be passed with the library to load\n")
     return 1;
   }
   rclcpp::init(argc, argv);
@@ -37,11 +37,11 @@ int main(int argc, char * argv[])
     libraries.push_back(argv[i]);
   }
   for (auto library : libraries) {
-    RCLCPP_INFO(DLOPEN_COMPOSITION_LOGGER_NAME, "Load library %s", library.c_str());
+    RCLCPP_INFO(DLOPEN_COMPOSITION_LOGGER_NAME, "Load library %s", library.c_str())
     auto loader = new class_loader::ClassLoader(library);
     auto classes = loader->getAvailableClasses<rclcpp::Node>();
     for (auto clazz : classes) {
-      RCLCPP_INFO(DLOPEN_COMPOSITION_LOGGER_NAME, "Instantiate class %s", clazz.c_str());
+      RCLCPP_INFO(DLOPEN_COMPOSITION_LOGGER_NAME, "Instantiate class %s", clazz.c_str())
       auto node = loader->createInstance<rclcpp::Node>(clazz);
       exec.add_node(node);
       nodes.push_back(node);

--- a/demo_nodes_cpp/src/topics/listener.cpp
+++ b/demo_nodes_cpp/src/topics/listener.cpp
@@ -21,6 +21,8 @@
 
 #include "std_msgs/msg/string.hpp"
 
+const char * g_logger_name = nullptr;
+
 void print_usage()
 {
   printf("Usage for listener app:\n");
@@ -32,13 +34,14 @@ void print_usage()
 
 void chatterCallback(const std_msgs::msg::String::SharedPtr msg)
 {
-  std::cout << "I heard: [" << msg->data << "]" << std::endl;
+  RCLCPP_INFO(g_logger_name, "I heard: [%s]", msg->data.c_str());
 }
 
 int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
   auto node = rclcpp::Node::make_shared("listener");
+  g_logger_name = node->get_name();
 
   if (rcutils_cli_option_exist(argv, argv + argc, "-h")) {
     print_usage();

--- a/demo_nodes_cpp/src/topics/listener.cpp
+++ b/demo_nodes_cpp/src/topics/listener.cpp
@@ -21,8 +21,6 @@
 
 #include "std_msgs/msg/string.hpp"
 
-const char * g_logger_name = nullptr;
-
 void print_usage()
 {
   printf("Usage for listener app:\n");
@@ -34,14 +32,13 @@ void print_usage()
 
 void chatterCallback(const std_msgs::msg::String::SharedPtr msg)
 {
-  RCLCPP_INFO(g_logger_name, "I heard: [%s]", msg->data.c_str());
+  std::cout << "I heard: [" << msg->data << "]" << std::endl;
 }
 
 int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
   auto node = rclcpp::Node::make_shared("listener");
-  g_logger_name = node->get_name();
 
   if (rcutils_cli_option_exist(argv, argv + argc, "-h")) {
     print_usage();

--- a/image_tools/src/showimage.cpp
+++ b/image_tools/src/showimage.cpp
@@ -56,7 +56,7 @@ encoding2mat_type(const std::string & encoding)
 void show_image(
   const sensor_msgs::msg::Image::SharedPtr msg, bool show_camera, std::string logger_name)
 {
-  RCLCPP_INFO(logger_name, "Received image #%s", msg->header.frame_id.c_str());
+  RCLCPP_INFO(logger_name, "Received image #%s", msg->header.frame_id.c_str())
 
   if (show_camera) {
     // Convert to an OpenCV matrix by assigning the data.

--- a/image_tools/src/showimage.cpp
+++ b/image_tools/src/showimage.cpp
@@ -53,9 +53,10 @@ encoding2mat_type(const std::string & encoding)
 
 /// Convert the ROS Image message to an OpenCV matrix and display it to the user.
 // \param[in] msg The image message to show.
-void show_image(const sensor_msgs::msg::Image::SharedPtr msg, bool show_camera)
+void show_image(
+  const sensor_msgs::msg::Image::SharedPtr msg, bool show_camera, std::string logger_name)
 {
-  printf("Received image #%s\n", msg->header.frame_id.c_str());
+  RCLCPP_INFO(logger_name, "Received image #%s", msg->header.frame_id.c_str());
 
   if (show_camera) {
     // Convert to an OpenCV matrix by assigning the data.
@@ -131,9 +132,9 @@ int main(int argc, char * argv[])
   // makes no guarantees about the order or reliability of delivery.
   custom_qos_profile.reliability = reliability_policy;
 
-  auto callback = [show_camera](const sensor_msgs::msg::Image::SharedPtr msg)
+  auto callback = [show_camera, &node](const sensor_msgs::msg::Image::SharedPtr msg)
     {
-      show_image(msg, show_camera);
+      show_image(msg, show_camera, node->get_name());
     };
 
   printf("Subscribing to topic '%s'\n", topic.c_str());


### PR DESCRIPTION
This currently has a few files converted: 4 commits for 4 different "types" of conversion.

Please give feedback on this and then I'll do the rest of them matching the conventions.

Remember that the macros are taking a name instead of a logger object at the moment: `node->get_name()` will one day be replaced by `node->get_logger()`.