### PR TITLE
Composition printing signed fields fixup + remove unused function

### DIFF
--- a/composition/src/client_component.cpp
+++ b/composition/src/client_component.cpp
@@ -26,24 +26,6 @@ using namespace std::chrono_literals;
 namespace composition
 {
 
-template<typename FutureT, typename WaitTimeT>
-std::future_status
-wait_for_result(
-  FutureT & future,
-  WaitTimeT time_to_wait)
-{
-  auto end = std::chrono::steady_clock::now() + time_to_wait;
-  std::chrono::milliseconds wait_period(100);
-  std::future_status status = std::future_status::timeout;
-  do {
-    auto now = std::chrono::steady_clock::now();
-    auto time_left = end - now;
-    if (time_left <= std::chrono::seconds(0)) {break;}
-    status = future.wait_for((time_left < wait_period) ? time_left : wait_period);
-  } while (rclcpp::ok() && status != std::future_status::ready);
-  return status;
-}
-
 Client::Client()
 : Node("Client")
 {

--- a/composition/src/client_component.cpp
+++ b/composition/src/client_component.cpp
@@ -84,7 +84,7 @@ void Client::on_timer()
   using ServiceResponseFuture =
       rclcpp::client::Client<example_interfaces::srv::AddTwoInts>::SharedFuture;
   auto response_received_callback = [this](ServiceResponseFuture future) {
-      RCLCPP_INFO(this->get_name(), "Got result: [%" PRIu64 "]", future.get()->sum)
+      RCLCPP_INFO(this->get_name(), "Got result: [%" PRId64 "]", future.get()->sum)
     };
   auto future_result = client_->async_send_request(request, response_received_callback);
 }

--- a/composition/src/server_component.cpp
+++ b/composition/src/server_component.cpp
@@ -33,7 +33,7 @@ Server::Server()
     std::shared_ptr<example_interfaces::srv::AddTwoInts::Response> response
     ) -> void
     {
-      printf("Incoming request: [a: %" PRIu64 ", b: %" PRIu64 "]\n",
+      printf("Incoming request: [a: %" PRId64 ", b: %" PRId64 "]\n",
         request->a, request->b);
       std::flush(std::cout);
       response->sum = request->a + request->b;


### PR DESCRIPTION
I think the client_component must have been copied from [lifecycle_service_client]( https://github.com/ros2/demos/blob/8354081d55c627b60b8e1229bdcd84d6ec036068/lifecycle/src/lifecycle_service_client.cpp#L111) initially, but the `wait_for_result` function isn't used in the end.

---

The AddTwoInts service can have negative fields so should use `PRId64`, otherwise:

```
$ ros2 service call /add_two_ints example_interfaces/AddTwoInts "{a: -1, b: -2}"

$ ros2 run composition dlopen_composition -- `ros2 pkg prefix composition`/lib/libserver_component.so
[INFO] [dlopen_composition]: Load library /home/dhood/ros2_ws/install_isolated/composition/lib/libserver_component.so
[INFO] [dlopen_composition]: Instantiate class composition::Server
Incoming request: [a: 18446744073709551615, b: 18446744073709551614]
```


Windows CI [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3585)](http://ci.ros2.org/job/ci_linux/3585/)