### PR TITLE
Support bgra8 in showimage

### DIFF
--- a/image_tools/src/showimage.cpp
+++ b/image_tools/src/showimage.cpp
@@ -42,6 +42,8 @@ encoding2mat_type(const std::string & encoding)
     return CV_16SC1;
   } else if (encoding == "rgba8") {
     return CV_8UC4;
+  } else if (encoding == "bgra8") {
+    return CV_8UC4;
   } else if (encoding == "32FC1") {
     return CV_32FC1;
   } else if (encoding == "rgb8") {


### PR DESCRIPTION
I'm working on a ros2 screen grab node https://github.com/lucasw/screen_grab/tree/master/screen_grab_ros2 and it defaults to bgra8.