### PR TITLE
Fix import statement and usage for rclpy.node.Node

### DIFF
--- a/demo_nodes_py/demo_nodes_py/services/add_two_ints_server.py
+++ b/demo_nodes_py/demo_nodes_py/services/add_two_ints_server.py
@@ -15,9 +15,10 @@
 from example_interfaces.srv import AddTwoInts
 
 import rclpy
+from rclpy.node import Node
 
 
-class AddTwoIntsServer(rclpy.Node):
+class AddTwoIntsServer(Node):
 
     def __init__(self):
         super().__init__('add_two_ints_server')

--- a/demo_nodes_py/demo_nodes_py/topics/listener.py
+++ b/demo_nodes_py/demo_nodes_py/topics/listener.py
@@ -15,11 +15,12 @@
 import sys
 
 import rclpy
+from rclpy.node import Node
 
 from std_msgs.msg import String
 
 
-class Listener(rclpy.Node):
+class Listener(Node):
 
     def __init__(self):
         super().__init__('listener')

--- a/demo_nodes_py/demo_nodes_py/topics/listener_qos.py
+++ b/demo_nodes_py/demo_nodes_py/topics/listener_qos.py
@@ -16,13 +16,14 @@ import argparse
 import sys
 
 import rclpy
+from rclpy.node import Node
 from rclpy.qos import qos_profile_default, qos_profile_sensor_data
 from rclpy.qos import QoSReliabilityPolicy
 
 from std_msgs.msg import String
 
 
-class ListenerQos(rclpy.Node):
+class ListenerQos(Node):
 
     def __init__(self, qos_profile):
         super().__init__('listener_qos')

--- a/demo_nodes_py/demo_nodes_py/topics/talker.py
+++ b/demo_nodes_py/demo_nodes_py/topics/talker.py
@@ -15,11 +15,12 @@
 import sys
 
 import rclpy
+from rclpy.node import Node
 
 from std_msgs.msg import String
 
 
-class Talker(rclpy.Node):
+class Talker(Node):
 
     def __init__(self):
         super().__init__('talker')

--- a/demo_nodes_py/demo_nodes_py/topics/talker_qos.py
+++ b/demo_nodes_py/demo_nodes_py/topics/talker_qos.py
@@ -16,13 +16,14 @@ import argparse
 import sys
 
 import rclpy
+from rclpy.node import Node
 from rclpy.qos import qos_profile_default, qos_profile_sensor_data
 from rclpy.qos import QoSReliabilityPolicy
 
 from std_msgs.msg import String
 
 
-class TalkerQos(rclpy.Node):
+class TalkerQos(Node):
 
     def __init__(self, qos_profile):
         super().__init__('talker_qos')


### PR DESCRIPTION
node is not imported in `__init__.py` anymore (https://github.com/ros2/rclpy/pull/147)

Without this change the demos raise:
`AttributeError: module 'rclpy' has not attribute 'Node'`

Not sure if https://github.com/ros2/rclpy/pull/147 is a long term fix as this mean that anyone inheriting from Node will need to import it explicitly.