### PR TITLE
Remove 'node' namespace from rclcpp::Node

### DIFF
--- a/demo_nodes_cpp/src/timers/one_off_timer.cpp
+++ b/demo_nodes_cpp/src/timers/one_off_timer.cpp
@@ -24,7 +24,7 @@ class OneOffTimerNode : public rclcpp::Node
 {
 public:
   OneOffTimerNode()
-  : rclcpp::Node("one_off_timer"), count(0)
+  : Node("one_off_timer"), count(0)
   {
     periodic_timer = this->create_wall_timer(
       2s,

--- a/demo_nodes_cpp/src/timers/reuse_timer.cpp
+++ b/demo_nodes_cpp/src/timers/reuse_timer.cpp
@@ -24,7 +24,7 @@ class OneOffTimerNode : public rclcpp::Node
 {
 public:
   OneOffTimerNode()
-  : rclcpp::Node("reuse_timer"), count(0)
+  : Node("reuse_timer"), count(0)
   {
     one_off_timer = this->create_wall_timer(
       1s,

--- a/dummy_robot/dummy_map_server/src/dummy_map_server.cpp
+++ b/dummy_robot/dummy_map_server/src/dummy_map_server.cpp
@@ -27,7 +27,7 @@ int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
 
-  auto node = rclcpp::node::Node::make_shared("dummy_map_server");
+  auto node = rclcpp::Node::make_shared("dummy_map_server");
 
   rmw_qos_profile_t latched_qos = rmw_qos_profile_default;
   latched_qos.depth = 1;

--- a/dummy_robot/dummy_sensors/src/dummy_joint_states.cpp
+++ b/dummy_robot/dummy_sensors/src/dummy_joint_states.cpp
@@ -27,7 +27,7 @@ int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
 
-  auto node = rclcpp::node::Node::make_shared("dummy_joint_states");
+  auto node = rclcpp::Node::make_shared("dummy_joint_states");
 
   auto joint_state_pub = node->create_publisher<sensor_msgs::msg::JointState>(
     "joint_states");

--- a/dummy_robot/dummy_sensors/src/dummy_laser.cpp
+++ b/dummy_robot/dummy_sensors/src/dummy_laser.cpp
@@ -36,7 +36,7 @@ int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
 
-  auto node = rclcpp::node::Node::make_shared("dummy_laser");
+  auto node = rclcpp::Node::make_shared("dummy_laser");
 
   auto laser_pub = node->create_publisher<sensor_msgs::msg::LaserScan>(
     "scan");

--- a/image_tools/src/cam2image.cpp
+++ b/image_tools/src/cam2image.cpp
@@ -100,7 +100,7 @@ int main(int argc, char * argv[])
   }
 
   // Initialize a ROS 2 node to publish images read from the OpenCV interface to the camera.
-  auto node = rclcpp::node::Node::make_shared("cam2image");
+  auto node = rclcpp::Node::make_shared("cam2image");
 
   // Set the parameters of the quality of service profile. Initialize as the default profile
   // and set the QoS parameters specified on the command line.

--- a/image_tools/src/showimage.cpp
+++ b/image_tools/src/showimage.cpp
@@ -113,7 +113,7 @@ int main(int argc, char * argv[])
   }
 
   // Initialize a ROS node.
-  auto node = rclcpp::node::Node::make_shared("showimage");
+  auto node = rclcpp::Node::make_shared("showimage");
 
   // Set quality of service profile based on command line options.
   rmw_qos_profile_t custom_qos_profile = rmw_qos_profile_default;

--- a/lifecycle/src/lifecycle_listener.cpp
+++ b/lifecycle/src/lifecycle_listener.cpp
@@ -31,11 +31,11 @@
  *   notifications about state changes of the node
  *   lc_talker
  */
-class LifecycleListener : public rclcpp::node::Node
+class LifecycleListener : public rclcpp::Node
 {
 public:
   explicit LifecycleListener(const std::string & node_name)
-  : rclcpp::node::Node(node_name)
+  : Node(node_name)
   {
     // Data topic from the lc_talker node
     sub_data_ = this->create_subscription<std_msgs::msg::String>("lifecycle_chatter",

--- a/lifecycle/src/lifecycle_service_client.cpp
+++ b/lifecycle/src/lifecycle_service_client.cpp
@@ -59,11 +59,11 @@ wait_for_result(
   return status;
 }
 
-class LifecycleServiceClient : public rclcpp::node::Node
+class LifecycleServiceClient : public rclcpp::Node
 {
 public:
   explicit LifecycleServiceClient(const std::string & node_name)
-  : rclcpp::node::Node(node_name)
+  : Node(node_name)
   {}
 
   void

--- a/pendulum_control/src/pendulum_demo.cpp
+++ b/pendulum_control/src/pendulum_demo.cpp
@@ -135,11 +135,11 @@ int main(int argc, char * argv[])
     std::make_shared<MessagePoolMemoryStrategy<pendulum_msgs::msg::JointCommand, 1>>();
 
   // The controller node represents user code. This example implements a simple PID controller.
-  auto controller_node = rclcpp::node::Node::make_shared("pendulum_controller");
+  auto controller_node = rclcpp::Node::make_shared("pendulum_controller");
 
   // The "motor" node simulates motors and sensors.
   // It provides sensor data and changes the physical model based on the command.
-  auto motor_node = rclcpp::node::Node::make_shared("pendulum_motor");
+  auto motor_node = rclcpp::Node::make_shared("pendulum_motor");
 
   // The quality of service profile is tuned for real-time performance.
   // More QoS settings may be exposed by the rmw interface in the future to fulfill real-time

--- a/pendulum_control/src/pendulum_logger.cpp
+++ b/pendulum_control/src/pendulum_logger.cpp
@@ -30,7 +30,7 @@ int main(int argc, char * argv[])
   setbuf(stdout, NULL);
   rclcpp::init(argc, argv);
 
-  auto logger_node = rclcpp::node::Node::make_shared("pendulum_logger");
+  auto logger_node = rclcpp::Node::make_shared("pendulum_logger");
   std::string filename = "pendulum_logger_results.csv";
   std::ofstream fstream;
   {

--- a/pendulum_control/src/pendulum_teleop.cpp
+++ b/pendulum_control/src/pendulum_teleop.cpp
@@ -39,7 +39,7 @@ int main(int argc, char * argv[])
     command = atof(argv[1]);
   }
 
-  auto teleop_node = rclcpp::node::Node::make_shared("pendulum_teleop");
+  auto teleop_node = rclcpp::Node::make_shared("pendulum_teleop");
 
   rmw_qos_profile_t qos_profile = rmw_qos_profile_default;
   qos_profile.durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;


### PR DESCRIPTION
Based off https://github.com/ros2/demos/pull/196#issuecomment-347325825:
> what we want to do with the C++ API, i.e. we want rclcpp::Node rather than rclcpp::node::Node.

---

The style I chose is to match https://github.com/ros2/demos/blob/5ba0e66d31374815fb6f0bfb279b4d982459d940/intra_process_demo/src/cyclic_pipeline/cyclic_pipeline.cpp#L30

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3618)](http://ci.ros2.org/job/ci_linux/3618/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=801)](http://ci.ros2.org/job/ci_linux-aarch64/801/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2948)](http://ci.ros2.org/job/ci_osx/2948/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3705)](http://ci.ros2.org/job/ci_windows/3705/)