### PR TITLE
Use escalated namespaces for more entities

### DIFF
--- a/composition/include/composition/client_component.hpp
+++ b/composition/include/composition/client_component.hpp
@@ -32,8 +32,8 @@ protected:
   void on_timer();
 
 private:
-  rclcpp::client::Client<example_interfaces::srv::AddTwoInts>::SharedPtr client_;
-  rclcpp::timer::TimerBase::SharedPtr timer_;
+  rclcpp::Client<example_interfaces::srv::AddTwoInts>::SharedPtr client_;
+  rclcpp::TimerBase::SharedPtr timer_;
 };
 
 }  // namespace composition

--- a/composition/include/composition/listener_component.hpp
+++ b/composition/include/composition/listener_component.hpp
@@ -29,7 +29,7 @@ public:
   Listener();
 
 private:
-  rclcpp::subscription::Subscription<std_msgs::msg::String>::SharedPtr sub_;
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr sub_;
 };
 
 }  // namespace composition

--- a/composition/include/composition/server_component.hpp
+++ b/composition/include/composition/server_component.hpp
@@ -29,7 +29,7 @@ public:
   Server();
 
 private:
-  rclcpp::service::Service<example_interfaces::srv::AddTwoInts>::SharedPtr srv_;
+  rclcpp::Service<example_interfaces::srv::AddTwoInts>::SharedPtr srv_;
 };
 
 }  // namespace composition

--- a/composition/include/composition/talker_component.hpp
+++ b/composition/include/composition/talker_component.hpp
@@ -34,7 +34,7 @@ protected:
 private:
   size_t count_;
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr pub_;
-  rclcpp::timer::TimerBase::SharedPtr timer_;
+  rclcpp::TimerBase::SharedPtr timer_;
 };
 
 }  // namespace composition

--- a/composition/src/client_component.cpp
+++ b/composition/src/client_component.cpp
@@ -64,7 +64,7 @@ void Client::on_timer()
   // We then return from this callback so that the existing spin() function can
   // continue and our callback will get called once the response is received.
   using ServiceResponseFuture =
-      rclcpp::client::Client<example_interfaces::srv::AddTwoInts>::SharedFuture;
+      rclcpp::Client<example_interfaces::srv::AddTwoInts>::SharedFuture;
   auto response_received_callback = [this](ServiceResponseFuture future) {
       RCLCPP_INFO(this->get_name(), "Got result: [%" PRId64 "]", future.get()->sum)
     };

--- a/demo_nodes_cpp/src/parameters/list_parameters.cpp
+++ b/demo_nodes_cpp/src/parameters/list_parameters.cpp
@@ -26,9 +26,9 @@ int main(int argc, char ** argv)
   auto node = rclcpp::Node::make_shared("list_parameters");
 
   // TODO(esteve): Make the parameter service automatically start with the node.
-  auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
+  auto parameter_service = std::make_shared<rclcpp::ParameterService>(node);
 
-  auto parameters_client = std::make_shared<rclcpp::parameter_client::SyncParametersClient>(node);
+  auto parameters_client = std::make_shared<rclcpp::SyncParametersClient>(node);
   while (!parameters_client->wait_for_service(1s)) {
     if (!rclcpp::ok()) {
       printf("Interrupted while waiting for the service. Exiting.\n");

--- a/demo_nodes_cpp/src/parameters/list_parameters_async.cpp
+++ b/demo_nodes_cpp/src/parameters/list_parameters_async.cpp
@@ -26,9 +26,9 @@ int main(int argc, char ** argv)
   auto node = rclcpp::Node::make_shared("list_parameters_async");
 
   // TODO(esteve): Make the parameter service automatically start with the node.
-  auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
+  auto parameter_service = std::make_shared<rclcpp::ParameterService>(node);
 
-  auto parameters_client = std::make_shared<rclcpp::parameter_client::AsyncParametersClient>(node);
+  auto parameters_client = std::make_shared<rclcpp::AsyncParametersClient>(node);
   while (!parameters_client->wait_for_service(1s)) {
     if (!rclcpp::ok()) {
       printf("Interrupted while waiting for the service. Exiting.\n");

--- a/demo_nodes_cpp/src/parameters/parameter_events.cpp
+++ b/demo_nodes_cpp/src/parameters/parameter_events.cpp
@@ -44,9 +44,9 @@ int main(int argc, char ** argv)
   auto node = rclcpp::Node::make_shared("parameter_events");
 
   // TODO(esteve): Make the parameter service automatically start with the node.
-  auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
+  auto parameter_service = std::make_shared<rclcpp::ParameterService>(node);
 
-  auto parameters_client = std::make_shared<rclcpp::parameter_client::SyncParametersClient>(node);
+  auto parameters_client = std::make_shared<rclcpp::SyncParametersClient>(node);
   while (!parameters_client->wait_for_service(1s)) {
     if (!rclcpp::ok()) {
       printf("Interrupted while waiting for the service. Exiting.\n");

--- a/demo_nodes_cpp/src/parameters/parameter_events_async.cpp
+++ b/demo_nodes_cpp/src/parameters/parameter_events_async.cpp
@@ -44,9 +44,9 @@ int main(int argc, char ** argv)
   auto node = rclcpp::Node::make_shared("parameter_events");
 
   // TODO(esteve): Make the parameter service automatically start with the node.
-  auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
+  auto parameter_service = std::make_shared<rclcpp::ParameterService>(node);
 
-  auto parameters_client = std::make_shared<rclcpp::parameter_client::AsyncParametersClient>(node);
+  auto parameters_client = std::make_shared<rclcpp::AsyncParametersClient>(node);
   while (!parameters_client->wait_for_service(1s)) {
     if (!rclcpp::ok()) {
       printf("Interrupted while waiting for the service. Exiting.\n");

--- a/demo_nodes_cpp/src/parameters/parameter_node.cpp
+++ b/demo_nodes_cpp/src/parameters/parameter_node.cpp
@@ -44,9 +44,9 @@ int main(int argc, char ** argv)
   auto node = rclcpp::Node::make_shared("parameter_node");
 
   // TODO(esteve): Make the parameter service automatically start with the node.
-  auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
+  auto parameter_service = std::make_shared<rclcpp::ParameterService>(node);
 
-  auto parameters_client = std::make_shared<rclcpp::parameter_client::SyncParametersClient>(node);
+  auto parameters_client = std::make_shared<rclcpp::SyncParametersClient>(node);
   while (!parameters_client->wait_for_service(1s)) {
     if (!rclcpp::ok()) {
       printf("Interrupted while waiting for the service. Exiting.\n");

--- a/demo_nodes_cpp/src/parameters/ros2param.cpp
+++ b/demo_nodes_cpp/src/parameters/ros2param.cpp
@@ -104,8 +104,8 @@ int main(int argc, char ** argv)
 
   auto node = rclcpp::Node::make_shared("ros2param");
   auto parameters_client =
-    std::make_shared<rclcpp::parameter_client::AsyncParametersClient>(node, remote_node);
-  auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
+    std::make_shared<rclcpp::AsyncParametersClient>(node, remote_node);
+  auto parameter_service = std::make_shared<rclcpp::ParameterService>(node);
   while (!parameters_client->wait_for_service(1s)) {
     if (!rclcpp::ok()) {
       printf("Interrupted while waiting for the service. Exiting.\n");

--- a/demo_nodes_cpp/src/parameters/set_and_get_parameters.cpp
+++ b/demo_nodes_cpp/src/parameters/set_and_get_parameters.cpp
@@ -26,9 +26,9 @@ int main(int argc, char ** argv)
   auto node = rclcpp::Node::make_shared("set_and_get_parameters");
 
   // TODO(wjwwood): Make the parameter service automatically start with the node.
-  auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
+  auto parameter_service = std::make_shared<rclcpp::ParameterService>(node);
 
-  auto parameters_client = std::make_shared<rclcpp::parameter_client::SyncParametersClient>(node);
+  auto parameters_client = std::make_shared<rclcpp::SyncParametersClient>(node);
   while (!parameters_client->wait_for_service(1s)) {
     if (!rclcpp::ok()) {
       printf("Interrupted while waiting for the service. Exiting.\n");

--- a/demo_nodes_cpp/src/parameters/set_and_get_parameters_async.cpp
+++ b/demo_nodes_cpp/src/parameters/set_and_get_parameters_async.cpp
@@ -26,9 +26,9 @@ int main(int argc, char ** argv)
   auto node = rclcpp::Node::make_shared("set_and_get_parameters_async");
 
   // TODO(wjwwood): Make the parameter service automatically start with the node.
-  auto parameter_service = std::make_shared<rclcpp::parameter_service::ParameterService>(node);
+  auto parameter_service = std::make_shared<rclcpp::ParameterService>(node);
 
-  auto parameters_client = std::make_shared<rclcpp::parameter_client::AsyncParametersClient>(node);
+  auto parameters_client = std::make_shared<rclcpp::AsyncParametersClient>(node);
   while (!parameters_client->wait_for_service(1s)) {
     if (!rclcpp::ok()) {
       printf("Interrupted while waiting for the service. Exiting.\n");

--- a/demo_nodes_cpp/src/services/add_two_ints_client.cpp
+++ b/demo_nodes_cpp/src/services/add_two_ints_client.cpp
@@ -33,10 +33,10 @@ void print_usage()
   printf("-s service_name : Specify the service name for this client. Defaults to add_two_ints.\n");
 }
 
-// TODO(wjwwood): make this into a method of rclcpp::client::Client.
+// TODO(wjwwood): make this into a method of rclcpp::Client.
 example_interfaces::srv::AddTwoInts_Response::SharedPtr send_request(
   rclcpp::Node::SharedPtr node,
-  rclcpp::client::Client<example_interfaces::srv::AddTwoInts>::SharedPtr client,
+  rclcpp::Client<example_interfaces::srv::AddTwoInts>::SharedPtr client,
   example_interfaces::srv::AddTwoInts_Request::SharedPtr request)
 {
   auto result = client->async_send_request(request);

--- a/lifecycle/src/lifecycle_service_client.cpp
+++ b/lifecycle/src/lifecycle_service_client.cpp
@@ -182,8 +182,8 @@ public:
   }
 
 private:
-  std::shared_ptr<rclcpp::client::Client<lifecycle_msgs::srv::GetState>> client_get_state_;
-  std::shared_ptr<rclcpp::client::Client<lifecycle_msgs::srv::ChangeState>> client_change_state_;
+  std::shared_ptr<rclcpp::Client<lifecycle_msgs::srv::GetState>> client_get_state_;
+  std::shared_ptr<rclcpp::Client<lifecycle_msgs::srv::ChangeState>> client_change_state_;
 };
 
 /**


### PR DESCRIPTION
connects to ros2/rclcpp#410
requires ros2/rclcpp#410

Demos were using `rclcpp::Publisher` but `rclcpp::service::Service` (because it hadn't been escalated)