### PR TITLE
cmake 3.10 compatibility: pass absolute path to file(GENERATE) function

### DIFF
--- a/composition/CMakeLists.txt
+++ b/composition/CMakeLists.txt
@@ -161,7 +161,7 @@ if(BUILD_TESTING)
 
   file(GENERATE
     OUTPUT
-    "test_ament_index/$<CONFIG>/share/ament_index/resource_index/node_plugin/${PROJECT_NAME}"
+    "${CMAKE_CURRENT_BINARY_DIR}/test_ament_index/$<CONFIG>/share/ament_index/resource_index/node_plugin/${PROJECT_NAME}"
     CONTENT "${node_plugins}")
 
   set(generated_python_files)
@@ -185,8 +185,9 @@ if(BUILD_TESTING)
       @ONLY
     )
     file(GENERATE
-      OUTPUT test_composition${target_suffix}_$<CONFIG>.py
-      INPUT test_composition${target_suffix}.py.genexp)
+      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test_composition${target_suffix}_$<CONFIG>.py"
+      INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_composition${target_suffix}.py.genexp"
+    )
     ament_add_pytest_test(test_composition${target_suffix}
       "${CMAKE_CURRENT_BINARY_DIR}/test_composition${target_suffix}_$<CONFIG>.py"
       ENV RMW_IMPLEMENTATION=${rmw_implementation}

--- a/demo_nodes_cpp/CMakeLists.txt
+++ b/demo_nodes_cpp/CMakeLists.txt
@@ -102,7 +102,7 @@ if(BUILD_TESTING)
         @ONLY
       )
       file(GENERATE
-        OUTPUT "test_${exe_list_underscore}${target_suffix}_$<CONFIG>.py"
+        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test_${exe_list_underscore}${target_suffix}_$<CONFIG>.py"
         INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_${exe_list_underscore}${target_suffix}.py.configured"
       )
 

--- a/demo_nodes_cpp_native/CMakeLists.txt
+++ b/demo_nodes_cpp_native/CMakeLists.txt
@@ -56,7 +56,7 @@ if(rmw_fastrtps_cpp_FOUND)
       @ONLY
     )
     file(GENERATE
-      OUTPUT "test_${exe_list_underscore}_$<CONFIG>.py"
+      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test_${exe_list_underscore}_$<CONFIG>.py"
       INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_${exe_list_underscore}.py.configured"
     )
 

--- a/image_tools/CMakeLists.txt
+++ b/image_tools/CMakeLists.txt
@@ -68,8 +68,9 @@ if(BUILD_TESTING)
     )
 
     file(GENERATE
-      OUTPUT test_showimage_cam2image${target_suffix}_$<CONFIG>.py
-      INPUT test_showimage_cam2image${target_suffix}.py.genexp)
+      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test_showimage_cam2image${target_suffix}_$<CONFIG>.py"
+      INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_showimage_cam2image${target_suffix}.py.genexp"
+    )
 
     ament_add_pytest_test(test_showimage_cam2image${target_suffix}
       "${CMAKE_CURRENT_BINARY_DIR}/test_showimage_cam2image${target_suffix}_$<CONFIG>.py"

--- a/intra_process_demo/CMakeLists.txt
+++ b/intra_process_demo/CMakeLists.txt
@@ -128,7 +128,7 @@ if(BUILD_TESTING)
         @ONLY
       )
       file(GENERATE
-        OUTPUT "test_${exe_list_underscore}${target_suffix}_$<CONFIG>.py"
+        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test_${exe_list_underscore}${target_suffix}_$<CONFIG>.py"
         INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_${exe_list_underscore}${target_suffix}.py.configured"
       )
 


### PR DESCRIPTION
This is needed to support cmake 3.10. We could define the policy based on the version of CMake but I preferred updating the codebase to have something compliant with all cmake versions without relying on undefined behavior.

More details at https://cmake.org/cmake/help/git-stage/policy/CMP0070.html

Example of CMake warning without this patch:
```
Policy CMP0070 is not set: Define file(GENERATE) behavior for relative
paths.  Run "cmake --help-policy CMP0070" for policy details.  Use the
cmake_policy command to set the policy and suppress this warning.

file(GENERATE) given relative OUTPUT path:

  test/test_services__rmw_connext_cpp_RelWithDebInfo.py

This is not defined behavior unless CMP0070 is set to NEW.  For
compatibility with older versions of CMake, the previous undefined behavior
will be used.
```

connects to ros2/rcl#195