### PR TITLE
Increase allowed time for logging demo test

### DIFF
--- a/logging_demo/CMakeLists.txt
+++ b/logging_demo/CMakeLists.txt
@@ -98,7 +98,7 @@ if(BUILD_TESTING)
       "${CMAKE_CURRENT_BINARY_DIR}/test_logging_demo${target_suffix}_$<CONFIG>.py"
       ENV RMW_IMPLEMENTATION=${rmw_implementation}
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
-      TIMEOUT 20)
+      TIMEOUT 30)
     list(
       APPEND generated_python_files
       "${CMAKE_CURRENT_BINARY_DIR}/test_logging_demo${target_suffix}_$<CONFIG>.py")


### PR DESCRIPTION
Some nightlies had a timeout for the test added in https://github.com/ros2/demos/pull/194; it wasn't that the test didn't work as expected it was just because connext shutdown takes a while.

ci linux: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3706)](http://ci.ros2.org/job/ci_linux/3706/)
ci osx: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3040)](http://ci.ros2.org/job/ci_osx/3040/)
no connext on ARM
ci windows (though it was fine on windows): [![Build Status](http://ci.ros2.org/job/ci_windows/3806//badge/icon)](http://ci.ros2.org/job/ci_windows/3806/)

Repeated testing on linux to check it won't be flaky: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3707)](http://ci.ros2.org/job/ci_linux/3707/)