### PR TITLE
Import rclpy.logging before get_logger() call

### DIFF
--- a/topic_monitor/topic_monitor/scripts/topic_monitor.py
+++ b/topic_monitor/topic_monitor/scripts/topic_monitor.py
@@ -19,13 +19,14 @@ from threading import Lock, Thread
 import time
 
 import rclpy
+import rclpy.logging
 from rclpy.qos import qos_profile_default
 from rclpy.qos import QoSReliabilityPolicy
 
 from std_msgs.msg import Float32, Header
 
 QOS_DEPTH = 10
-logger = rclpy.logging.get_named_logger('topic_monitor')
+logger = rclpy.logging.get_logger('topic_monitor')
 
 
 class MonitoredTopic:


### PR DESCRIPTION
Necessary since https://github.com/ros2/rclpy/pull/147
also fix renamed function