### PR TITLE
add wait_for_service

### DIFF
--- a/lifecycle/src/lifecycle_service_client_py.py
+++ b/lifecycle/src/lifecycle_service_client_py.py
@@ -27,7 +27,8 @@ def change_state(lifecycle_node, change_state_args=''):
     service_name = lifecycle_node + '/change_state'
     cli = node.create_client(ChangeState, service_name)
     if not cli.wait_for_service(timeout_sec=5.0):
-        print('Unable to call service', service_name)
+        node.get_logger().warn(
+            'Unable to call service %s' % service_name)
         return
 
     req = ChangeState.Request()
@@ -57,7 +58,8 @@ def get_state(lifecycle_node):
     service_name = lifecycle_node + '/get_state'
     cli = node.create_client(GetState, lifecycle_node + '/get_state')
     if not cli.wait_for_service(timeout_sec=5.0):
-        print('Unable to call service', service_name)
+        node.get_logger().warn(
+            'Unable to call service %s' % service_name)
         return
 
     req = GetState.Request()
@@ -74,7 +76,8 @@ def get_available_states(lifecycle_node):
     service_name = lifecycle_node + '/get_available_states'
     cli = node.create_client(GetAvailableStates, service_name)
     if not cli.wait_for_service(timeout_sec=5.0):
-        print('Unable to call service', service_name)
+        node.get_logger().warn(
+            'Unable to call service %s' % service_name)
         return
 
     req = GetAvailableStates.Request()
@@ -92,7 +95,8 @@ def get_available_transitions(lifecycle_node):
     service_name = lifecycle_node + '/get_available_transitions'
     cli = node.create_client(GetAvailableTransitions, service_name)
     if not cli.wait_for_service(timeout_sec=5.0):
-        print('Unable to call service', service_name)
+        node.get_logger().warn(
+            'Unable to call service %s' % service_name)
         return
 
     req = GetAvailableTransitions.Request()

--- a/lifecycle/src/lifecycle_service_client_py.py
+++ b/lifecycle/src/lifecycle_service_client_py.py
@@ -24,7 +24,12 @@ import rclpy
 def change_state(lifecycle_node, change_state_args=''):
     node = rclpy.create_node('lc_client_py')
 
-    cli = node.create_client(ChangeState, lifecycle_node + '/change_state')
+    service_name = lifecycle_node + '/change_state'
+    cli = node.create_client(ChangeState, service_name)
+    if not cli.wait_for_service(timeout_sec=5.0):
+        print('Unable to call service', service_name)
+        return
+
     req = ChangeState.Request()
     if change_state_args == 'configure':
         req.transition.id = Transition.TRANSITION_CONFIGURE
@@ -49,7 +54,12 @@ def change_state(lifecycle_node, change_state_args=''):
 def get_state(lifecycle_node):
     node = rclpy.create_node('lc_client_py')
 
+    service_name = lifecycle_node + '/get_state'
     cli = node.create_client(GetState, lifecycle_node + '/get_state')
+    if not cli.wait_for_service(timeout_sec=5.0):
+        print('Unable to call service', service_name)
+        return
+
     req = GetState.Request()
     cli.call(req)
     cli.wait_for_future()
@@ -61,7 +71,12 @@ def get_state(lifecycle_node):
 def get_available_states(lifecycle_node):
     node = rclpy.create_node('lc_client_py')
 
-    cli = node.create_client(GetAvailableStates, lifecycle_node + '/get_available_states')
+    service_name = lifecycle_node + '/get_available_states'
+    cli = node.create_client(GetAvailableStates, service_name)
+    if not cli.wait_for_service(timeout_sec=5.0):
+        print('Unable to call service', service_name)
+        return
+
     req = GetAvailableStates.Request()
     cli.call(req)
     cli.wait_for_future()
@@ -74,8 +89,12 @@ def get_available_states(lifecycle_node):
 def get_available_transitions(lifecycle_node):
     node = rclpy.create_node('lc_client_py')
 
-    cli = node.create_client(
-        GetAvailableTransitions, lifecycle_node + '/get_available_transitions')
+    service_name = lifecycle_node + '/get_available_transitions'
+    cli = node.create_client(GetAvailableTransitions, service_name)
+    if not cli.wait_for_service(timeout_sec=5.0):
+        print('Unable to call service', service_name)
+        return
+
     req = GetAvailableTransitions.Request()
     cli.call(req)
     cli.wait_for_future()

--- a/lifecycle/src/lifecycle_service_client_py.py
+++ b/lifecycle/src/lifecycle_service_client_py.py
@@ -56,7 +56,7 @@ def get_state(lifecycle_node):
     node = rclpy.create_node('lc_client_py')
 
     service_name = lifecycle_node + '/get_state'
-    cli = node.create_client(GetState, lifecycle_node + '/get_state')
+    cli = node.create_client(GetState, service_name)
     if not cli.wait_for_service(timeout_sec=5.0):
         node.get_logger().warn(
             'Unable to call service %s' % service_name)


### PR DESCRIPTION
Fixes https://github.com/ros2/demos/issues/213

Call wait_for_service prior to calling it to make sure the lifecycle service is available. In the case of calling a node wo/ this service available, the request times out after 5.0 seconds and prints an error message.

```
$ ros2 run lifecycle lifecycle_service_client_py.py -- get_state lc_listener
Unable to call service lc_listener/get_state
```

@clalancette can you verify this please?