### PR TITLE
Aligned prints

### DIFF
--- a/demo_nodes_cpp/src/parameters/list_parameters.cpp
+++ b/demo_nodes_cpp/src/parameters/list_parameters.cpp
@@ -56,7 +56,7 @@ int main(int argc, char ** argv)
   auto parameters_and_prefixes = parameters_client->list_parameters({"foo", "bar"}, 10);
 
   std::stringstream ss;
-  ss << "Parameter names:";
+  ss << "\nParameter names:";
   for (auto & name : parameters_and_prefixes.names) {
     ss << "\n " << name;
   }

--- a/demo_nodes_cpp/src/parameters/list_parameters_async.cpp
+++ b/demo_nodes_cpp/src/parameters/list_parameters_async.cpp
@@ -66,7 +66,7 @@ int main(int argc, char ** argv)
   auto parameter_list = parameter_list_future.get();
 
   std::stringstream ss;
-  ss << "Parameter names:";
+  ss << "\nParameter names:";
   for (auto & name : parameter_list.names) {
     ss << "\n " << name;
   }

--- a/demo_nodes_cpp/src/parameters/parameter_events.cpp
+++ b/demo_nodes_cpp/src/parameters/parameter_events.cpp
@@ -25,7 +25,7 @@ void on_parameter_event(
 {
   // TODO(wjwwood): The message should have an operator<<, which would replace all of this.
   std::stringstream ss;
-  ss << "Parameter event:\n new parameters:";
+  ss << "\nParameter event:\n new parameters:";
   for (auto & new_parameter : event->new_parameters) {
     ss << "\n  " << new_parameter.name;
   }
@@ -37,6 +37,7 @@ void on_parameter_event(
   for (auto & deleted_parameter : event->deleted_parameters) {
     ss << "\n  " << deleted_parameter.name;
   }
+  ss << "\n";
   RCLCPP_INFO(logger, ss.str().c_str())
 }
 

--- a/demo_nodes_cpp/src/parameters/parameter_events_async.cpp
+++ b/demo_nodes_cpp/src/parameters/parameter_events_async.cpp
@@ -38,7 +38,7 @@ public:
       {
         // TODO(wjwwood): The message should have an operator<<, which would replace all of this.
         std::stringstream ss;
-        ss << "Parameter event:\n new parameters:";
+        ss << "\nParameter event:\n new parameters:";
         for (auto & new_parameter : event->new_parameters) {
           ss << "\n  " << new_parameter.name;
         }
@@ -50,6 +50,7 @@ public:
         for (auto & deleted_parameter : event->deleted_parameters) {
           ss << "\n  " << deleted_parameter.name;
         }
+        ss << "\n";
         RCLCPP_INFO(this->get_logger(), ss.str().c_str())
       };
 

--- a/demo_nodes_cpp/src/parameters/set_and_get_parameters.cpp
+++ b/demo_nodes_cpp/src/parameters/set_and_get_parameters.cpp
@@ -57,9 +57,9 @@ int main(int argc, char ** argv)
   std::stringstream ss;
   // Get a few of the parameters just set.
   for (auto & parameter : parameters_client->get_parameters({"foo", "baz"})) {
-    ss << "Parameter name: " << parameter.get_name() << "\n";
-    ss << "Parameter value (" << parameter.get_type_name() << "): " <<
-      parameter.value_to_string() << "\n";
+    ss << "\nParameter name: " << parameter.get_name();
+    ss << "\nParameter value (" << parameter.get_type_name() << "): " <<
+      parameter.value_to_string();
   }
   RCLCPP_INFO(node->get_logger(), ss.str().c_str())
 

--- a/demo_nodes_cpp/src/parameters/set_and_get_parameters_async.cpp
+++ b/demo_nodes_cpp/src/parameters/set_and_get_parameters_async.cpp
@@ -71,9 +71,9 @@ int main(int argc, char ** argv)
   }
   std::stringstream ss;
   for (auto & parameter : parameters.get()) {
-    ss << "Parameter name: " << parameter.get_name() << "\n";
-    ss << "Parameter value (" << parameter.get_type_name() << "): " <<
-      parameter.value_to_string() << "\n";
+    ss << "\nParameter name: " << parameter.get_name();
+    ss << "\nParameter value (" << parameter.get_type_name() << "): " <<
+      parameter.value_to_string();
   }
   RCLCPP_INFO(node->get_logger(), ss.str().c_str())
 

--- a/demo_nodes_cpp/test/list_parameters.txt
+++ b/demo_nodes_cpp/test/list_parameters.txt
@@ -1,5 +1,6 @@
 Setting parameters...
 Listing parameters...
+
 Parameter names:
  bar
  foo

--- a/demo_nodes_cpp/test/list_parameters_async.txt
+++ b/demo_nodes_cpp/test/list_parameters_async.txt
@@ -1,5 +1,6 @@
 Setting parameters...
 Listing parameters...
+
 Parameter names:
  bar
  foo

--- a/demo_nodes_cpp/test/parameter_events.txt
+++ b/demo_nodes_cpp/test/parameter_events.txt
@@ -1,30 +1,42 @@
+
 Parameter event:
  new parameters:
   foo
  changed parameters:
  deleted parameters:
+
+
 Parameter event:
  new parameters:
   bar
  changed parameters:
  deleted parameters:
+
+
 Parameter event:
  new parameters:
   baz
  changed parameters:
  deleted parameters:
+
+
 Parameter event:
  new parameters:
   foobar
  changed parameters:
  deleted parameters:
+
+
 Parameter event:
  new parameters:
  changed parameters:
   foo
  deleted parameters:
+
+
 Parameter event:
  new parameters:
  changed parameters:
   bar
  deleted parameters:
+

--- a/demo_nodes_cpp/test/parameter_events_async.txt
+++ b/demo_nodes_cpp/test/parameter_events_async.txt
@@ -1,30 +1,42 @@
+
 Parameter event:
  new parameters:
   foo
  changed parameters:
  deleted parameters:
+
+
 Parameter event:
  new parameters:
   bar
  changed parameters:
  deleted parameters:
+
+
 Parameter event:
  new parameters:
   baz
  changed parameters:
  deleted parameters:
+
+
 Parameter event:
  new parameters:
   foobar
  changed parameters:
  deleted parameters:
+
+
 Parameter event:
  new parameters:
  changed parameters:
   foo
  deleted parameters:
+
+
 Parameter event:
  new parameters:
  changed parameters:
   bar
  deleted parameters:
+

--- a/demo_nodes_cpp/test/set_and_get_parameters.txt
+++ b/demo_nodes_cpp/test/set_and_get_parameters.txt
@@ -1,3 +1,4 @@
+
 Parameter name: foo
 Parameter value (integer): 2
 Parameter name: baz

--- a/demo_nodes_cpp/test/set_and_get_parameters_async.txt
+++ b/demo_nodes_cpp/test/set_and_get_parameters_async.txt
@@ -1,3 +1,4 @@
+
 Parameter name: foo
 Parameter value (integer): 2
 Parameter name: baz


### PR DESCRIPTION
Currently:
```
[INFO] [set_and_get_parameters]: Parameter name: foo
Parameter value (integer): 2
Parameter name: baz
Parameter value (double): 1.450000
```

With this change:
```
[INFO] [set_and_get_parameters]: 
Parameter name: foo
Parameter value (integer): 2
Parameter name: baz
Parameter value (double): 1.450000
```

Neither is ideal but I think it's a better user experience to have the prints aligned

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3769)](http://ci.ros2.org/job/ci_linux/3769/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=912)](http://ci.ros2.org/job/ci_linux-aarch64/912/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3103)](http://ci.ros2.org/job/ci_osx/3103/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3858)](http://ci.ros2.org/job/ci_windows/3858/)