### PR TITLE
[composition] new test needs higher timeout

### DIFF
--- a/composition/CMakeLists.txt
+++ b/composition/CMakeLists.txt
@@ -193,7 +193,7 @@ if(BUILD_TESTING)
       ENV RMW_IMPLEMENTATION=${rmw_implementation}
       APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/test_ament_index/$<CONFIG>
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
-      TIMEOUT 100)
+      TIMEOUT 120)
     list(
       APPEND generated_python_files
       "${CMAKE_CURRENT_BINARY_DIR}/test_composition${target_suffix}_$<CONFIG>.py")


### PR DESCRIPTION
follow up of #187

The new test `test_api_srv_composition_client_first` takes at least 5 seconds to run as it waits for [5 seconds](https://github.com/ros2/demos/pull/187/files#diff-ab3688e496c20dae3827385c140d3686R119) before starting. As these service tests are usually given a 20 sec timeout, bumping the total timeout of only 10 second was pretty optimistic.
This PR adds 20 seconds to the global timeout to be consistent and reduce flakiness

Note that this will not fix these tests completely as both `test_api_pubsub_composition` and `test_api_srv_composition(_client_first)` are flaky and sometimes hang regardless of the given timeout