### PR TITLE
Fix pendulum inertia in physic model.

### DIFF
--- a/pendulum_control/include/pendulum_control/pendulum_motor.hpp
+++ b/pendulum_control/include/pendulum_control/pendulum_motor.hpp
@@ -195,7 +195,7 @@ private:
     rttest_lock_and_prefault_dynamic();
     while (!done_) {
       state_.acceleration = GRAVITY * std::sin(state_.position - PI / 2.0) / properties_.length +
-        state_.torque / (properties_.mass + properties_.length);
+        state_.torque / (properties_.mass * properties_.length * properties_.length);
       state_.velocity += state_.acceleration * dt_;
       state_.position += state_.velocity * dt_;
       if (state_.position > PI) {


### PR DESCRIPTION
After going through the real time programming tutorial, I started reading the code, and realized that there might be an issue with the physic model of the pendulum.
When computing the acceleration caused by the motor: `acceleration = torque / inertia`. Assuming a point mass inertia, the inertia should be: `mass * length^2`