### PR TITLE
remove obsolete setup functions from tests

### DIFF
--- a/composition/test/test_api_pubsub_composition.py.in
+++ b/composition/test/test_api_pubsub_composition.py.in
@@ -12,19 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 from launch import LaunchDescriptor
 from launch.exit_handler import default_exit_handler
 from launch.exit_handler import exit_on_error_exit_handler
 from launch.launcher import DefaultLauncher
 from launch.output_handler import ConsoleOutput
 from launch_testing import create_handler
-
-
-def setup():
-    # bare minimum formatting for console output matching
-    os.environ['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '{message}'
 
 
 def test_api_pubsub_composition():

--- a/composition/test/test_api_srv_composition.py.in
+++ b/composition/test/test_api_srv_composition.py.in
@@ -12,19 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 from launch import LaunchDescriptor
 from launch.exit_handler import default_exit_handler
 from launch.exit_handler import exit_on_error_exit_handler
 from launch.launcher import DefaultLauncher
 from launch.output_handler import ConsoleOutput
 from launch_testing import create_handler
-
-
-def setup():
-    # bare minimum formatting for console output matching
-    os.environ['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '{message}'
 
 
 def test_api_srv_composition():

--- a/composition/test/test_api_srv_composition_client_first.py.in
+++ b/composition/test/test_api_srv_composition_client_first.py.in
@@ -12,19 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 from launch import LaunchDescriptor
 from launch.exit_handler import default_exit_handler
 from launch.exit_handler import exit_on_error_exit_handler
 from launch.launcher import DefaultLauncher
 from launch.output_handler import ConsoleOutput
 from launch_testing import create_handler
-
-
-def setup():
-    # bare minimum formatting for console output matching
-    os.environ['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '{message}'
 
 
 def test_api_srv_composition_client_first():

--- a/composition/test/test_dlopen_composition.py.in
+++ b/composition/test/test_dlopen_composition.py.in
@@ -12,18 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 from launch import LaunchDescriptor
 from launch.exit_handler import default_exit_handler
 from launch.launcher import DefaultLauncher
 from launch.output_handler import ConsoleOutput
 from launch_testing import create_handler
-
-
-def setup():
-    # bare minimum formatting for console output matching
-    os.environ['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '{message}'
 
 
 def test_dlopen_composition():

--- a/composition/test/test_linktime_composition.py.in
+++ b/composition/test/test_linktime_composition.py.in
@@ -22,11 +22,6 @@ from launch.output_handler import ConsoleOutput
 from launch_testing import create_handler
 
 
-def setup():
-    # bare minimum formatting for console output matching
-    os.environ['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '{message}'
-
-
 def test_linktime_composition():
     if os.name == 'nt':
         print('The link time registration of classes does not work on Windows')

--- a/composition/test/test_manual_composition.py.in
+++ b/composition/test/test_manual_composition.py.in
@@ -12,18 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
 from launch import LaunchDescriptor
 from launch.exit_handler import default_exit_handler
 from launch.launcher import DefaultLauncher
 from launch.output_handler import ConsoleOutput
 from launch_testing import create_handler
-
-
-def setup():
-    # bare minimum formatting for console output matching
-    os.environ['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '{message}'
 
 
 def test_manual_composition():

--- a/demo_nodes_cpp_native/test/test_executables_tutorial.py.in
+++ b/demo_nodes_cpp_native/test/test_executables_tutorial.py.in
@@ -1,8 +1,6 @@
 # generated from demo_nodes_cpp/test/test_executables_tutorial.py.in
 # generated code does not contain a copyright notice
 
-import os
-
 from launch import LaunchDescriptor
 from launch.exit_handler import ignore_exit_handler
 from launch.exit_handler import primary_ignore_returncode_exit_handler
@@ -10,11 +8,6 @@ from launch.launcher import DefaultLauncher
 from launch.output_handler import ConsoleOutput
 from launch_testing import create_handler
 from launch_testing import get_default_filtered_prefixes
-
-
-def setup():
-    # bare minimum formatting for console output matching
-    os.environ['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '{message}'
 
 
 def test_executable():


### PR DESCRIPTION
Just the composition tests:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3875)](http://ci.ros2.org/job/ci_linux/3875/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=996)](http://ci.ros2.org/job/ci_linux-aarch64/996/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3201)](http://ci.ros2.org/job/ci_osx/3201/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3952)](http://ci.ros2.org/job/ci_windows/3952/)

And with `--retest-until-fail 20`:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3876)](http://ci.ros2.org/job/ci_linux/3876/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3202)](http://ci.ros2.org/job/ci_osx/3202/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3953)](http://ci.ros2.org/job/ci_windows/3953/)

~~I will likely go ahead and merge this in order to get the next round of nightlies using this. As before I will of course address any comments / feedback (if there is any).~~

**Update:** I am not convinced this patch (the second commit with the delay) is any improvement based on the repeated test results...