### PR TITLE
Pendulum teleop flakiness reduction

### DIFF
--- a/pendulum_control/src/pendulum_demo.cpp
+++ b/pendulum_control/src/pendulum_demo.cpp
@@ -197,8 +197,12 @@ int main(int argc, char * argv[])
       pendulum_controller->on_pendulum_setpoint(msg);
     };
 
+  // Receive the most recently published message from the teleop node publisher.
+  auto qos_profile_setpoint_sub(qos_profile);
+  qos_profile_setpoint_sub.durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
+
   auto setpoint_sub = controller_node->create_subscription<pendulum_msgs::msg::JointCommand>(
-    "pendulum_setpoint", controller_command_callback, qos_profile, nullptr, false,
+    "pendulum_setpoint", controller_command_callback, qos_profile_setpoint_sub, nullptr, false,
     setpoint_msg_strategy);
 
   // Initialize the logger publisher.

--- a/pendulum_control/src/pendulum_teleop.cpp
+++ b/pendulum_control/src/pendulum_teleop.cpp
@@ -54,9 +54,9 @@ int main(int argc, char * argv[])
   rclcpp::sleep_for(500ms);
   pub->publish(msg);
   rclcpp::spin_some(teleop_node);
-  std::cout << "Teleop message published." << std::endl;
+  printf("Teleop message published.\n");
   rclcpp::sleep_for(1s);
-  std::cout << "Teleop node exited." << std::endl;
+  printf("Teleop node exited.\n");
 
   rclcpp::shutdown();
 }

--- a/pendulum_control/src/pendulum_teleop.cpp
+++ b/pendulum_control/src/pendulum_teleop.cpp
@@ -54,6 +54,8 @@ int main(int argc, char * argv[])
   rclcpp::sleep_for(500ms);
   pub->publish(msg);
   rclcpp::spin_some(teleop_node);
+  std::cout << "Teleop message published." << std::endl;
+  rclcpp::sleep_for(1s);
   std::cout << "Teleop node exited." << std::endl;
 
   rclcpp::shutdown();

--- a/pendulum_control/test/test_pendulum_demo.py.in
+++ b/pendulum_control/test/test_pendulum_demo.py.in
@@ -16,6 +16,9 @@ def setup():
     os.environ['OSPL_VERBOSITY'] = '8'  # 8 = OS_NONE
     # bare minimum formatting for console output matching
     os.environ['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '{message}'
+    # force flush of the stdout buffer.
+    # this ensures a correct sync of prints from processes executed within the launch file.
+    os.environ['RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED'] = '1'
 
 
 def test_executable():

--- a/pendulum_control/test/test_pendulum_demo.py.in
+++ b/pendulum_control/test/test_pendulum_demo.py.in
@@ -56,6 +56,7 @@ def test_executable():
 
     pendulum_demo_handler = create_handler(
         pendulum_demo_name, launch_descriptor, pendulum_demo_output_file,
+        exit_on_match=False,  # the process will exit automatically after a set number of iterations
         filtered_prefixes=filtered_prefixes,
         filtered_rmw_implementation=rmw_implementation)
     assert pendulum_demo_handler, \

--- a/pendulum_control/test/test_pendulum_teleop.py.in
+++ b/pendulum_control/test/test_pendulum_teleop.py.in
@@ -17,6 +17,9 @@ def setup():
     os.environ['OSPL_VERBOSITY'] = '8'  # 8 = OS_NONE
     # bare minimum formatting for console output matching
     os.environ['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '{message}'
+    # force flush of the stdout buffer.
+    # this ensures a correct sync of prints from processes executed within the launch file.
+    os.environ['RCUTILS_CONSOLE_STDOUT_LINE_BUFFERED'] = '1'
 
 
 def test_executable():


### PR DESCRIPTION
As mentioned in https://github.com/ros2/build_cop/issues/94, there is still an unresolved/unidentified issue that causes the teleop test to hang, so this won't resolve flakiness completely. I reason that these changes are still worth merging so that they can be ruled out as the cause for future investigations.

CI linux with connext (only combo tests run for): [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4169)](https://ci.ros2.org/job/ci_linux/4169/)

Repeating 100 times: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4170)](https://ci.ros2.org/job/ci_linux/4170/) (I have seen on other builds that it's still prone to failure if you keep repeating the tests, but it's better)