### PR TITLE
Parameter services automatically start

### DIFF
--- a/demo_nodes_cpp/src/parameters/list_parameters.cpp
+++ b/demo_nodes_cpp/src/parameters/list_parameters.cpp
@@ -28,9 +28,6 @@ int main(int argc, char ** argv)
 
   auto node = rclcpp::Node::make_shared("list_parameters");
 
-  // TODO(esteve): Make the parameter service automatically start with the node.
-  auto parameter_service = std::make_shared<rclcpp::ParameterService>(node);
-
   auto parameters_client = std::make_shared<rclcpp::SyncParametersClient>(node);
   while (!parameters_client->wait_for_service(1s)) {
     if (!rclcpp::ok()) {

--- a/demo_nodes_cpp/src/parameters/list_parameters_async.cpp
+++ b/demo_nodes_cpp/src/parameters/list_parameters_async.cpp
@@ -28,9 +28,6 @@ int main(int argc, char ** argv)
 
   auto node = rclcpp::Node::make_shared("list_parameters_async");
 
-  // TODO(esteve): Make the parameter service automatically start with the node.
-  auto parameter_service = std::make_shared<rclcpp::ParameterService>(node);
-
   auto parameters_client = std::make_shared<rclcpp::AsyncParametersClient>(node);
   while (!parameters_client->wait_for_service(1s)) {
     if (!rclcpp::ok()) {

--- a/demo_nodes_cpp/src/parameters/parameter_events.cpp
+++ b/demo_nodes_cpp/src/parameters/parameter_events.cpp
@@ -50,9 +50,6 @@ int main(int argc, char ** argv)
 
   auto node = rclcpp::Node::make_shared("parameter_events");
 
-  // TODO(esteve): Make the parameter service automatically start with the node.
-  auto parameter_service = std::make_shared<rclcpp::ParameterService>(node);
-
   auto parameters_client = std::make_shared<rclcpp::SyncParametersClient>(node);
   while (!parameters_client->wait_for_service(1s)) {
     if (!rclcpp::ok()) {

--- a/demo_nodes_cpp/src/parameters/parameter_events_async.cpp
+++ b/demo_nodes_cpp/src/parameters/parameter_events_async.cpp
@@ -133,8 +133,6 @@ int main(int argc, char ** argv)
   rclcpp::init(argc, argv);
 
   auto node = std::make_shared<ParameterEventsAsyncNode>();
-  // TODO(esteve): Make the parameter service automatically start with the node.
-  auto parameter_service = std::make_shared<rclcpp::ParameterService>(node);
 
   rclcpp::spin(node);
   rclcpp::shutdown();

--- a/demo_nodes_cpp/src/parameters/parameter_node.cpp
+++ b/demo_nodes_cpp/src/parameters/parameter_node.cpp
@@ -62,8 +62,6 @@ int main(int argc, char ** argv)
   rclcpp::init(argc, argv);
 
   auto node = std::make_shared<ParameterNode>();
-  // TODO(esteve): Make the parameter service automatically start with the node.
-  auto parameter_service = std::make_shared<rclcpp::ParameterService>(node);
 
   rclcpp::spin(node);
   rclcpp::shutdown();

--- a/demo_nodes_cpp/src/parameters/ros2param.cpp
+++ b/demo_nodes_cpp/src/parameters/ros2param.cpp
@@ -108,7 +108,6 @@ int main(int argc, char ** argv)
   auto node = rclcpp::Node::make_shared("ros2param");
   auto parameters_client =
     std::make_shared<rclcpp::AsyncParametersClient>(node, remote_node);
-  auto parameter_service = std::make_shared<rclcpp::ParameterService>(node);
   while (!parameters_client->wait_for_service(1s)) {
     if (!rclcpp::ok()) {
       RCLCPP_ERROR(node->get_logger(), "Interrupted while waiting for the service. Exiting.")

--- a/demo_nodes_cpp/src/parameters/set_and_get_parameters.cpp
+++ b/demo_nodes_cpp/src/parameters/set_and_get_parameters.cpp
@@ -29,9 +29,6 @@ int main(int argc, char ** argv)
 
   auto node = rclcpp::Node::make_shared("set_and_get_parameters");
 
-  // TODO(wjwwood): Make the parameter service automatically start with the node.
-  auto parameter_service = std::make_shared<rclcpp::ParameterService>(node);
-
   auto parameters_client = std::make_shared<rclcpp::SyncParametersClient>(node);
   while (!parameters_client->wait_for_service(1s)) {
     if (!rclcpp::ok()) {

--- a/demo_nodes_cpp/src/parameters/set_and_get_parameters_async.cpp
+++ b/demo_nodes_cpp/src/parameters/set_and_get_parameters_async.cpp
@@ -29,9 +29,6 @@ int main(int argc, char ** argv)
 
   auto node = rclcpp::Node::make_shared("set_and_get_parameters_async");
 
-  // TODO(wjwwood): Make the parameter service automatically start with the node.
-  auto parameter_service = std::make_shared<rclcpp::ParameterService>(node);
-
   auto parameters_client = std::make_shared<rclcpp::AsyncParametersClient>(node);
   while (!parameters_client->wait_for_service(1s)) {
     if (!rclcpp::ok()) {


### PR DESCRIPTION
Removes code that was manually starting the parameter service.

Connects to ros2/rclcpp#478