### PR TITLE
Only keep the last sample in the image tools by default.

### DIFF
--- a/image_tools/src/cam2image.cpp
+++ b/image_tools/src/cam2image.cpp
@@ -77,10 +77,10 @@ int main(int argc, char * argv[])
 
   // Initialize default demo parameters
   bool show_camera = false;
-  size_t depth = 10;
+  size_t depth = rmw_qos_profile_default.depth;
   double freq = 30.0;
-  rmw_qos_reliability_policy_t reliability_policy = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
-  rmw_qos_history_policy_t history_policy = RMW_QOS_POLICY_HISTORY_KEEP_ALL;
+  rmw_qos_reliability_policy_t reliability_policy = rmw_qos_profile_default.reliability;
+  rmw_qos_history_policy_t history_policy = rmw_qos_profile_default.history;
   size_t width = 320;
   size_t height = 240;
   bool burger_mode = false;
@@ -92,10 +92,10 @@ int main(int argc, char * argv[])
   setvbuf(stdout, NULL, _IONBF, BUFSIZ);
 
   // Configure demo parameters with command line options.
-  bool success = parse_command_options(
-    argc, argv, &depth, &reliability_policy, &history_policy, &show_camera, &freq, &width, &height,
-    &burger_mode, &topic);
-  if (!success) {
+  if (!parse_command_options(
+      argc, argv, &depth, &reliability_policy, &history_policy, &show_camera, &freq, &width,
+      &height, &burger_mode, &topic))
+  {
     return 0;
   }
 

--- a/image_tools/src/options.cpp
+++ b/image_tools/src/options.cpp
@@ -59,11 +59,13 @@ bool parse_command_options(
     ss << " -r: Reliability QoS setting:" << std::endl;
     ss << "    0 - best effort" << std::endl;
     ss << "    1 - reliable (default)" << std::endl;
-    ss << " -d: Queue depth. 10 (default)" << std::endl;
+    ss << " -d: Depth of the queue: only honored if used together with “keep last”. " <<
+      "10 (default)" << std::endl;
     ss << " -f: Publish frequency in Hz. 30 (default)" << std::endl;
     ss << " -k: History QoS setting:" << std::endl;
-    ss << "    0 - only keep last sample" << std::endl;
-    ss << "    1 - keep all the samples (default)" << std::endl;
+    ss << "    0 - only store up to N samples, configurable via the queue depth (default)" <<
+      std::endl;
+    ss << "    1 - keep all the samples" << std::endl;
     if (show_camera != nullptr) {
       ss << " -s: Camera stream:" << std::endl;
       ss << "    0 - Do not show the camera stream" << std::endl;

--- a/image_tools/src/options.cpp
+++ b/image_tools/src/options.cpp
@@ -59,7 +59,7 @@ bool parse_command_options(
     ss << " -r: Reliability QoS setting:" << std::endl;
     ss << "    0 - best effort" << std::endl;
     ss << "    1 - reliable (default)" << std::endl;
-    ss << " -d: Depth of the queue: only honored if used together with “keep last”. " <<
+    ss << " -d: Depth of the queue: only honored if used together with 'keep last'. " <<
       "10 (default)" << std::endl;
     ss << " -f: Publish frequency in Hz. 30 (default)" << std::endl;
     ss << " -k: History QoS setting:" << std::endl;

--- a/image_tools/src/showimage.cpp
+++ b/image_tools/src/showimage.cpp
@@ -90,9 +90,9 @@ int main(int argc, char * argv[])
   rclcpp::init(argc, argv);
 
   // Initialize default demo parameters
-  size_t depth = 10;
-  rmw_qos_reliability_policy_t reliability_policy = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
-  rmw_qos_history_policy_t history_policy = RMW_QOS_POLICY_HISTORY_KEEP_ALL;
+  size_t depth = rmw_qos_profile_default.depth;
+  rmw_qos_reliability_policy_t reliability_policy = rmw_qos_profile_default.reliability;
+  rmw_qos_history_policy_t history_policy = rmw_qos_profile_default.history;
   bool show_camera = true;
   std::string topic("image");
 
@@ -120,12 +120,6 @@ int main(int argc, char * argv[])
   // Set quality of service profile based on command line options.
   rmw_qos_profile_t custom_qos_profile = rmw_qos_profile_default;
 
-  // The history policy determines how messages are saved until the message is taken by the reader.
-  // KEEP_ALL saves all messages until they are taken.
-  // KEEP_LAST enforces a limit on the number of messages that are saved, specified by the "depth"
-  // parameter.
-  custom_qos_profile.history = history_policy;
-
   // Depth represents how many messages to store in history when the history policy is KEEP_LAST.
   custom_qos_profile.depth = depth;
 
@@ -133,6 +127,12 @@ int main(int argc, char * argv[])
   // ensure that every message gets received in order, or best effort, meaning that the transport
   // makes no guarantees about the order or reliability of delivery.
   custom_qos_profile.reliability = reliability_policy;
+
+  // The history policy determines how messages are saved until the message is taken by the reader.
+  // KEEP_ALL saves all messages until they are taken.
+  // KEEP_LAST enforces a limit on the number of messages that are saved, specified by the "depth"
+  // parameter.
+  custom_qos_profile.history = history_policy;
 
   auto callback = [show_camera, &node](const sensor_msgs::msg::Image::SharedPtr msg)
     {


### PR DESCRIPTION
Particularly for cam2image, running it without a subscriber
and KEEP_ALL will eventually cause it to exhaust virtual
memory space.  Running it with KEEP_LAST lets it run indefinitely
without growing memory usage.

We saw this problem while just running cam2image for this tutorial https://github.com/ros2/ros2/wiki/Rosbag-with-ROS1-Bridge .  We had left it running for a little while before running the bridge/rosbag, and it would crash after a few minutes.  With this change in place, we can leave it running for as long as we like.