### PR TITLE
Refine demo_nodes_cpp source codes

### DIFF
--- a/demo_nodes_cpp/src/services/add_two_ints_client.cpp
+++ b/demo_nodes_cpp/src/services/add_two_ints_client.cpp
@@ -34,10 +34,10 @@ void print_usage()
 }
 
 // TODO(wjwwood): make this into a method of rclcpp::Client.
-example_interfaces::srv::AddTwoInts_Response::SharedPtr send_request(
+example_interfaces::srv::AddTwoInts::Response::SharedPtr send_request(
   rclcpp::Node::SharedPtr node,
   rclcpp::Client<example_interfaces::srv::AddTwoInts>::SharedPtr client,
-  example_interfaces::srv::AddTwoInts_Request::SharedPtr request)
+  example_interfaces::srv::AddTwoInts::Request::SharedPtr request)
 {
   auto result = client->async_send_request(request);
   // Wait for the result.

--- a/demo_nodes_cpp/src/timers/reuse_timer.cpp
+++ b/demo_nodes_cpp/src/timers/reuse_timer.cpp
@@ -20,10 +20,10 @@
 
 using namespace std::chrono_literals;
 
-class OneOffTimerNode : public rclcpp::Node
+class ReuseTimerNode : public rclcpp::Node
 {
 public:
-  OneOffTimerNode()
+  ReuseTimerNode()
   : Node("reuse_timer"), count(0)
   {
     one_off_timer = this->create_wall_timer(
@@ -60,7 +60,7 @@ int main(int argc, char * argv[])
 
   rclcpp::init(argc, argv);
 
-  auto node = std::make_shared<OneOffTimerNode>();
+  auto node = std::make_shared<ReuseTimerNode>();
 
   rclcpp::spin(node);
 


### PR DESCRIPTION
This PR refines `demo_nodes_cpp` source codes below:

- https://github.com/ros2/demos/commit/53da24a4b5f4fb995cf528641f3c8382950a4268: Use `AddTwoInts` namespace for readability.
- https://github.com/ros2/demos/commit/ef6ed16f62af6c8a62bb45e5de83831c487323f6: Fix class name typo (which I think so).

There is no problem to call the following commands.
```
$ ros2 run demo_nodes_cpp reuse_timer
$ ros2 launch demo_nodes_cpp add_two_ints.launch.py
```

