### PR TITLE
Fix typo in lifecycle directory

### DIFF
--- a/lifecycle/src/lifecycle_listener.cpp
+++ b/lifecycle/src/lifecycle_listener.cpp
@@ -42,7 +42,7 @@ public:
         std::bind(&LifecycleListener::data_callback, this, std::placeholders::_1));
 
     // Notification event topic. All state changes
-    // are published here as TransiitonEvents with
+    // are published here as TransitionEvents with
     // a start and goal state indicating the transition
     sub_notification_ = this->create_subscription<lifecycle_msgs::msg::TransitionEvent>(
       "/lc_talker/transition_event", std::bind(&LifecycleListener::notification_callback, this,

--- a/lifecycle/src/lifecycle_talker.cpp
+++ b/lifecycle/src/lifecycle_talker.cpp
@@ -32,7 +32,7 @@
 
 using namespace std::chrono_literals;
 
-/// LifeycycleTalker inheriting from rclcpp_lifecycle::LifecycleNode
+/// LifecycleTalker inheriting from rclcpp_lifecycle::LifecycleNode
 /**
  * The lifecycle talker does not like the regular "talker" node
  * inherit from node, but rather from lifecyclenode. This brings
@@ -108,7 +108,7 @@ public:
   {
     // This callback is supposed to be used for initialization and
     // configuring purposes.
-    // We thus initalize and configure our messages, publishers and timers.
+    // We thus initialize and configure our messages, publishers and timers.
     // The lifecycle node API does return lifecycle components such as
     // lifecycle publishers. These entities obey the lifecycle and
     // can comply to the current state of the node.


### PR DESCRIPTION
This PR simply fixes typo which I found in lifecycle directory.