### PR TITLE
remove now redundant args=sys.argv

### DIFF
--- a/demo_nodes_py/demo_nodes_py/topics/listener.py
+++ b/demo_nodes_py/demo_nodes_py/topics/listener.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-
 import rclpy
 from rclpy.node import Node
 
@@ -31,9 +29,6 @@ class Listener(Node):
 
 
 def main(args=None):
-    if args is None:
-        args = sys.argv
-
     rclpy.init(args=args)
 
     node = Listener()

--- a/demo_nodes_py/demo_nodes_py/topics/talker.py
+++ b/demo_nodes_py/demo_nodes_py/topics/talker.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-
 import rclpy
 from rclpy.node import Node
 
@@ -38,9 +36,6 @@ class Talker(Node):
 
 
 def main(args=None):
-    if args is None:
-        args = sys.argv
-
     rclpy.init(args=args)
 
     node = Talker()


### PR DESCRIPTION
`rclpy.init()` performs that logic already: https://github.com/ros2/rclpy/blob/98cdadeb9befa64eac3915b17e65f8ac02e1bec4/rclpy/rclpy/__init__.py#L27