### PR TITLE
change timer with period of 0s to 1ms

### DIFF
--- a/demo_nodes_cpp/src/parameters/parameter_events_async.cpp
+++ b/demo_nodes_cpp/src/parameters/parameter_events_async.cpp
@@ -59,7 +59,7 @@ public:
 
     // Queue a `set_parameters` request as soon as `spin` is called on this node.
     // TODO(dhood): consider adding a "call soon" notion to Node to not require a timer for this.
-    timer_ = create_wall_timer(0s,
+    timer_ = create_wall_timer(1ms,
         [this]() {
           this->queue_first_set_parameter_request();
         });


### PR DESCRIPTION
Related to ros2/rcl#291.

A timer with a period of 0s is kind of weird. It implies an infinite frequency.