### PR TITLE
[dummy_robot_bringup] add missing launch_ros exec dependency

### DIFF
--- a/dummy_robot/dummy_robot_bringup/package.xml
+++ b/dummy_robot/dummy_robot_bringup/package.xml
@@ -15,6 +15,7 @@
   <exec_depend>dummy_map_server</exec_depend>
   <exec_depend>dummy_sensors</exec_depend>
   <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>ros2run</exec_depend>
 


### PR DESCRIPTION
Follow-up of https://github.com/ros2/demos/pull/262