### PR TITLE
Fix lint warning from invalid escape sequences

### DIFF
--- a/topic_monitor/topic_monitor/scripts/topic_monitor.py
+++ b/topic_monitor/topic_monitor/scripts/topic_monitor.py
@@ -112,7 +112,7 @@ class TopicMonitor:
     """Monitor of a set of topics that match a specified topic name pattern."""
 
     def __init__(self, window_size):
-        self.data_topic_pattern = re.compile('(/(?P<data_name>\w*)_data_?(?P<reliability>\w*))')
+        self.data_topic_pattern = re.compile(r'(/(?P<data_name>\w*)_data_?(?P<reliability>\w*))')
         self.monitored_topics = {}
         self.monitored_topics_lock = Lock()
         self.publishers = {}


### PR DESCRIPTION
Use raw string for regex pattern to avoid warning.

CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5348)](http://ci.ros2.org/job/ci_linux/5348/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2078)](http://ci.ros2.org/job/ci_linux-aarch64/2078/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4441)](http://ci.ros2.org/job/ci_osx/4441/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5311)](http://ci.ros2.org/job/ci_windows/5311/)