### PR TITLE
Prevent frame going out of scope when converting RGB -> BGR

### DIFF
--- a/image_tools/src/showimage.cpp
+++ b/image_tools/src/showimage.cpp
@@ -67,14 +67,11 @@ void show_image(
       msg->height, msg->width, encoding2mat_type(msg->encoding),
       const_cast<unsigned char *>(msg->data.data()), msg->step);
 
-    CvMat cvframe;
     if (msg->encoding == "rgb8") {
-      cv::Mat frame2;
-      cv::cvtColor(frame, frame2, cv::COLOR_RGB2BGR);
-      cvframe = frame2;
-    } else {
-      cvframe = frame;
+      cv::cvtColor(frame, frame, cv::COLOR_RGB2BGR);
     }
+
+    CvMat cvframe = frame;
 
     // NOTE(esteve): Use C version of cvShowImage to avoid this on Windows:
     // http://stackoverflow.com/q/20854682


### PR DESCRIPTION
In `showimage`, when an image is encoded in RGB, it is converted into a BGR image. However, the converted frame is deallocated when the `cv:Mat` referencing it, `frame2`, goes out of scope, resulting in a segmentation fault when trying to show it.

This PR fixes this by reusing the original `cv::Mat` in `cv::cvtColor`, which is safe, and stays in scope until the end of the function.