### PR TITLE
Do not show freq parameter on help when not necessary

### DIFF
--- a/image_tools/src/options.cpp
+++ b/image_tools/src/options.cpp
@@ -61,7 +61,9 @@ bool parse_command_options(
     ss << "    1 - reliable (default)" << std::endl;
     ss << " -d: Depth of the queue: only honored if used together with 'keep last'. " <<
       "10 (default)" << std::endl;
-    ss << " -f: Publish frequency in Hz. 30 (default)" << std::endl;
+    if (freq != nullptr) {
+      ss << " -f: Publish frequency in Hz. 30 (default)" << std::endl;
+    }
     ss << " -k: History QoS setting:" << std::endl;
     ss << "    0 - only store up to N samples, configurable via the queue depth (default)" <<
       std::endl;


### PR DESCRIPTION
Do not show frequency parameter on image_tools when not necessary. Relate ros2/ros2_documentation#41

