### PR TITLE
Remove support for OpenCV 2

### DIFF
--- a/image_tools/src/burger.cpp
+++ b/image_tools/src/burger.cpp
@@ -82,12 +82,7 @@ Burger::Burger()
   std::vector<uint8_t> burger_png;
   burger_png.resize(burger_size);
   decode_base64(BURGER, burger_png);
-  // TODO(jacobperron): Remove pre-compiler check when we drop support for Xenial
-#if CV_MAJOR_VERSION < 3
-  burger_template = cv::imdecode(burger_png, CV_LOAD_IMAGE_COLOR);
-#else
   burger_template = cv::imdecode(burger_png, cv::ImreadModes::IMREAD_COLOR);
-#endif
   cv::floodFill(burger_template, cv::Point(1, 1), CV_RGB(1, 1, 1));
   cv::compare(burger_template, 1, burger_mask, cv::CMP_NE);
 #ifndef _WIN32

--- a/image_tools/src/cam2image.cpp
+++ b/image_tools/src/cam2image.cpp
@@ -193,8 +193,6 @@ int main(int argc, char * argv[])
         convert_frame_to_message(flipped_frame, i, msg);
       }
       if (show_camera) {
-        // NOTE(esteve): Use C version of cvShowImage to avoid this on Windows:
-        // http://stackoverflow.com/questions/20854682/opencv-multiple-unwanted-window-with-garbage-name
         cv::Mat cvframe = frame;
         // Show the image in a window called "cam2image".
         cv::imshow("cam2image", cvframe);

--- a/image_tools/src/cam2image.cpp
+++ b/image_tools/src/cam2image.cpp
@@ -156,14 +156,8 @@ int main(int argc, char * argv[])
     cap.open(0);
 
     // Set the width and height based on command line arguments.
-    // TODO(jacobperron): Remove pre-compiler check when we drop support for Xenial
-#if CV_MAJOR_VERSION < 3
-    cap.set(CV_CAP_PROP_FRAME_WIDTH, static_cast<double>(width));
-    cap.set(CV_CAP_PROP_FRAME_HEIGHT, static_cast<double>(height));
-#else
     cap.set(cv::CAP_PROP_FRAME_WIDTH, static_cast<double>(width));
     cap.set(cv::CAP_PROP_FRAME_HEIGHT, static_cast<double>(height));
-#endif
     if (!cap.isOpened()) {
       RCLCPP_ERROR(node_logger, "Could not open video stream");
       return 1;

--- a/image_tools/src/showimage.cpp
+++ b/image_tools/src/showimage.cpp
@@ -73,8 +73,6 @@ void show_image(
 
     cv::Mat cvframe = frame;
 
-    // NOTE(esteve): Use C version of cvShowImage to avoid this on Windows:
-    // http://stackoverflow.com/q/20854682
     // Show the image in a window called "showimage".
     cv::imshow("showimage", cvframe);
     // Draw the screen and wait for 1 millisecond.


### PR DESCRIPTION
No longer needed now that we've dropped support for Ubuntu 16.04 Xenial.