### PR TITLE
Increase pendulum_control test timeout to 60 seconds.

### DIFF
--- a/pendulum_control/CMakeLists.txt
+++ b/pendulum_control/CMakeLists.txt
@@ -114,7 +114,7 @@ if(BUILD_TESTING)
     add_launch_test(
       "${CMAKE_CURRENT_BINARY_DIR}/test_pendulum__${rmw_implementation}.py"
       TARGET test_pendulum__${rmw_implementation}
-      TIMEOUT 20
+      TIMEOUT 60
       ENV
       RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
       RMW_IMPLEMENTATION=${rmw_implementation}
@@ -130,7 +130,7 @@ if(BUILD_TESTING)
     add_launch_test(
       "${CMAKE_CURRENT_BINARY_DIR}/test_pendulum_teleop__${rmw_implementation}.py"
       TARGET test_pendulum_teleop__${rmw_implementation}
-      TIMEOUT 20
+      TIMEOUT 60
       ENV
       RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
       RMW_IMPLEMENTATION=${rmw_implementation}


### PR DESCRIPTION
Under heavy IO load, aarch64 machines in particular can
take longer than 20 seconds to finish these tests.  Increase
the timeout to 60 seconds to give a much larger margin.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

I'm pretty sure that this will fix https://github.com/ros2/build_cop/issues/133, but we'll have to wait a few days for the nightlies to run to be sure.