### PR TITLE
add parameter_blackboard to make some tutorials easier

### DIFF
--- a/demo_nodes_cpp/CMakeLists.txt
+++ b/demo_nodes_cpp/CMakeLists.txt
@@ -45,6 +45,7 @@ custom_executable(services add_two_ints_server)
 # Tutorials of Parameters with Asynchronous and Synchronous
 custom_executable(parameters list_parameters)
 custom_executable(parameters list_parameters_async)
+custom_executable(parameters parameter_blackboard)
 custom_executable(parameters parameter_events)
 custom_executable(parameters parameter_events_async)
 custom_executable(parameters even_parameters_node)

--- a/demo_nodes_cpp/src/parameters/parameter_blackboard.cpp
+++ b/demo_nodes_cpp/src/parameters/parameter_blackboard.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdio>
 #include <memory>
 #include <string>
 

--- a/demo_nodes_cpp/src/parameters/parameter_blackboard.cpp
+++ b/demo_nodes_cpp/src/parameters/parameter_blackboard.cpp
@@ -1,0 +1,47 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdio>
+#include <memory>
+#include <string>
+
+#include "rcl_interfaces/srv/list_parameters.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+class ParameterBlackboard : public rclcpp::Node
+{
+public:
+  ParameterBlackboard(
+    const std::string & name = "parameter_blackboard",
+    const std::string & namespace_ = "",
+    const rclcpp::NodeOptions & options = (
+      rclcpp::NodeOptions()
+      .allow_undeclared_parameters(true)
+      .automatically_declare_initial_parameters(true)
+  ))
+  : rclcpp::Node(name, namespace_, options)
+  {
+    RCLCPP_INFO(this->get_logger(),
+      "Parameter blackboard node named '%s' ready, and serving '%zu' parameters already!",
+      this->get_fully_qualified_name(), this->list_parameters(
+        {}, rcl_interfaces::srv::ListParameters::Request::DEPTH_RECURSIVE).names.size());
+  }
+};
+
+int main(int argc, char const * argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<ParameterBlackboard>());
+  return 0;
+}


### PR DESCRIPTION
Basically it is just a node that allows you to set parameters on it remotely or with the YAML file, without declaring them.

I plan to use it here:

https://index.ros.org/doc/ros2/Tutorials/Node-arguments/#parameters

Instead of `talker`.