### PR TITLE
replace mesh with box

### DIFF
--- a/dummy_robot/dummy_robot_bringup/launch/single_rrbot.urdf
+++ b/dummy_robot/dummy_robot_bringup/launch/single_rrbot.urdf
@@ -129,7 +129,7 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://rrbot_description/model/meshes/hokuyo.dae"/>
+        <box size="0.1 0.1 0.1"/>
       </geometry>
     </visual>
     <inertial>


### PR DESCRIPTION
This will avoid the error printed when using the `dummy_robot_bringup` demo and visualize the URDF in RViz:
```
[ERROR] [rviz2]: FileNotFoundException: Cannot locate resource package://rrbot_description/model/meshes/hokuyo.dae in resource group OgreAutodetect. in ResourceGroupManager::openResource at /Users/karsten/workspace/osrf/ros2_visualization/build/rviz_ogre_vendor/ogre-master-ca665a6-prefix/src/ogre-master-ca665a6/OgreMain/src/OgreResourceGroupManager.cpp (line 708)
[ERROR] [rviz2]: could not load model 'package://rrbot_description/model/meshes/hokuyo.dae' for link 'single_rrbot_hokuyo_link': FileNotFoundException: Cannot locate resource package://rrbot_description/model/meshes/hokuyo.dae in resource group OgreAutodetect. in ResourceGroupManager::openResource at /Users/karsten/workspace/osrf/ros2_visualization/build/rviz_ogre_vendor/ogre-master-ca665a6-prefix/src/ogre-master-ca665a6/OgreMain/src/OgreResourceGroupManager.cpp (line 708)
```

Signed-off-by: Karsten Knese <karsten@openrobotics.org>