### PR TITLE
Be explicit about reliability in Lifespan demos

### DIFF
--- a/quality_of_service_demo/rclcpp/src/lifespan.cpp
+++ b/quality_of_service_demo/rclcpp/src/lifespan.cpp
@@ -101,6 +101,9 @@ int main(int argc, char * argv[])
 
   rclcpp::QoS qos_profile(history);
   qos_profile
+  // Guaranteed delivery is needed to send messages to late-joining subscriptions.
+  .reliable()
+  // Store messages on the publisher so that they can be affected by Lifespan.
   .transient_local()
   .lifespan(lifespan_duration);
 

--- a/quality_of_service_demo/rclpy/quality_of_service_demo_py/lifespan.py
+++ b/quality_of_service_demo/rclpy/quality_of_service_demo_py/lifespan.py
@@ -21,6 +21,7 @@ from rclpy.duration import Duration
 from rclpy.executors import SingleThreadedExecutor
 from rclpy.qos import QoSDurabilityPolicy
 from rclpy.qos import QoSProfile
+from rclpy.qos import QoSReliabilityPolicy
 
 
 def parse_args():
@@ -51,7 +52,10 @@ def main(args=None):
 
     qos_profile = QoSProfile(
         depth=parsed_args.history,
-        durability=QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL,
+        # Guaranteed delivery is needed to send messages to late-joining subscription.
+        reliability=QoSReliabilityPolicy.RELIABLE,
+        # Store messages on the publisher so that they can be affected by Lifespan.
+        durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
         lifespan=lifespan)
 
     listener = Listener(


### PR DESCRIPTION
Explicitly specify Reliability policy in the Lifespan demos to be less dependent on defaults.

The Python version of this demo brought up the issue https://github.com/ros2/rclpy/issues/353, which turned out to just be a difference in default settings between `rclcpp` and `rclpy`. The problem is fixed by making those defaults the same between clients (https://github.com/ros2/rclpy/pull/356) and there is value in that use case, but there is a separate value in being explicit about the settings needed for this functionality to work as expected.

Signed-off-by: Emerson Knapp <eknapp@amazon.com>