### PR TITLE
Fix memory leak in the dummy robot examples.

### DIFF
--- a/dummy_robot/dummy_map_server/src/dummy_map_server.cpp
+++ b/dummy_robot/dummy_map_server/src/dummy_map_server.cpp
@@ -53,6 +53,10 @@ int main(int argc, char * argv[])
     msg.data.push_back(-1);
   }
 
+  rclcpp::TimeSource ts(node);
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  ts.attachClock(clock);
+
   int lhs = 0;
   int center = 1;
   int rhs = 2;
@@ -64,9 +68,6 @@ int main(int argc, char * argv[])
     msg.data[(++center) % (msg.info.width * msg.info.height)] = 100;
     msg.data[(++rhs) % (msg.info.width * msg.info.height)] = 0;
 
-    rclcpp::TimeSource ts(node);
-    rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
-    ts.attachClock(clock);
     msg.header.stamp = clock->now();
 
     map_pub->publish(msg);

--- a/dummy_robot/dummy_sensors/src/dummy_joint_states.cpp
+++ b/dummy_robot/dummy_sensors/src/dummy_joint_states.cpp
@@ -39,6 +39,10 @@ int main(int argc, char * argv[])
   msg.position.push_back(0.0);
   msg.position.push_back(0.0);
 
+  rclcpp::TimeSource ts(node);
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  ts.attachClock(clock);
+
   auto counter = 0.0;
   auto joint_value = 0.0;
   while (rclcpp::ok()) {
@@ -49,9 +53,6 @@ int main(int argc, char * argv[])
       msg.position[i] = joint_value;
     }
 
-    rclcpp::TimeSource ts(node);
-    rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
-    ts.attachClock(clock);
     msg.header.stamp = clock->now();
 
     joint_state_pub->publish(msg);

--- a/dummy_robot/dummy_sensors/src/dummy_laser.cpp
+++ b/dummy_robot/dummy_sensors/src/dummy_laser.cpp
@@ -71,6 +71,10 @@ int main(int argc, char * argv[])
   RCLCPP_INFO(node->get_logger(), "scan size:\t%zu", msg.ranges.size());
   RCLCPP_INFO(node->get_logger(), "scan time increment: \t%f", msg.time_increment);
 
+  rclcpp::TimeSource ts(node);
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  ts.attachClock(clock);
+
   auto counter = 0.0;
   auto amplitude = 1;
   auto distance = 0.0f;
@@ -82,9 +86,6 @@ int main(int argc, char * argv[])
       msg.ranges[i] = distance;
     }
 
-    rclcpp::TimeSource ts(node);
-    rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
-    ts.attachClock(clock);
     msg.header.stamp = clock->now();
 
     laser_pub->publish(msg);


### PR DESCRIPTION
They were repeatedly creating a new clock in the loop, and then
leaking that clock.  Instead, create the clock once at the top
of the loop.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix #340 