### PR TITLE
Remove the action_msgs dependency CMake code

### DIFF
--- a/action_tutorials/CMakeLists.txt
+++ b/action_tutorials/CMakeLists.txt
@@ -11,13 +11,11 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 # find dependencies
-find_package(action_msgs REQUIRED)
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "action/Fibonacci.action"
-  DEPENDENCIES action_msgs
 )
 
 install(


### PR DESCRIPTION
It is implicitly added by rosidl_generate_interfaces().

Follow up from ros2/rosidl#369