### PR TITLE
Fixes lifecycle_service_client namespace

### DIFF
--- a/lifecycle/src/lifecycle_service_client.cpp
+++ b/lifecycle/src/lifecycle_service_client.cpp
@@ -36,10 +36,10 @@ static constexpr char const * lifecycle_node = "lc_talker";
 // <node name>/<service name>.
 // In this demo, we use get_state and change_state
 // and thus the two service topics are:
-// /lc_talker/get_state
-// /lc_talker/change_state
-static constexpr char const * node_get_state_topic = "/lc_talker/get_state";
-static constexpr char const * node_change_state_topic = "/lc_talker/change_state";
+// lc_talker/get_state
+// lc_talker/change_state
+static constexpr char const * node_get_state_topic = "lc_talker/get_state";
+static constexpr char const * node_change_state_topic = "lc_talker/change_state";
 
 template<typename FutureT, typename WaitTimeT>
 std::future_status


### PR DESCRIPTION
The lifecycle demo works as expected with the following commands.
terminal 1:
```
ros2 run lifecycle lifecycle_talker
```
terminal 2:
```
ros2 run lifecycle lifecycle_service_client
```

lifecycle_service_client creates clients for
/lc_talker/get_state
/lc_talker/change_state

By providing topic names starting with '/', the clients do not automatically
prepend the current namespace. So, the following did not work as expected.
terminal 1:
```
ros2 run lifecycle lifecycle_talker __ns:=/foo
```
terminal 2:
```
ros2 run lifecycle lifecycle_service_client __ns:=/foo
```
Results in the error:
```
[ERROR] [foo.lc_client]: Service /lc_talker/change_state is not available.
```

After removing the leading '/' from the lifecycle_service_client topic names,
the demo works as expected with and without providing a namespace.

Signed-off-by: cevans87 <c.d.evans87@gmail.com>