### PR TITLE
Fix armhf build warnings

### DIFF
--- a/pendulum_control/src/pendulum_demo.cpp
+++ b/pendulum_control/src/pendulum_demo.cpp
@@ -300,8 +300,8 @@ int main(int argc, char * argv[])
   // deallocation is handled automatically by objects going out of scope
   running = false;
 
-  printf("PendulumMotor received %lu messages\n", pendulum_motor->messages_received);
-  printf("PendulumController received %lu messages\n", pendulum_controller->messages_received);
+  printf("PendulumMotor received %zu messages\n", pendulum_motor->messages_received);
+  printf("PendulumController received %zu messages\n", pendulum_controller->messages_received);
 
   rclcpp::shutdown();
 

--- a/pendulum_control/src/pendulum_logger.cpp
+++ b/pendulum_control/src/pendulum_logger.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cinttypes>
 #include <fstream>
 #include <string>
 
@@ -46,13 +47,13 @@ int main(int argc, char * argv[])
       printf("Commanded motor angle: %f\n", msg->command.position);
       printf("Actual motor angle: %f\n", msg->state.position);
 
-      printf("Current latency: %lu ns\n", msg->cur_latency);
+      printf("Current latency: %" PRIu64 " ns\n", msg->cur_latency);
       printf("Mean latency: %f ns\n", msg->mean_latency);
-      printf("Min latency: %lu ns\n", msg->min_latency);
-      printf("Max latency: %lu ns\n", msg->max_latency);
+      printf("Min latency: %" PRIu64 " ns\n", msg->min_latency);
+      printf("Max latency: %" PRIu64 " ns\n", msg->max_latency);
 
-      printf("Minor pagefaults during execution: %lu\n", msg->minor_pagefaults);
-      printf("Major pagefaults during execution: %lu\n\n", msg->major_pagefaults);
+      printf("Minor pagefaults during execution: %" PRIu64 "\n", msg->minor_pagefaults);
+      printf("Major pagefaults during execution: %" PRIu64 "\n\n", msg->major_pagefaults);
 
       std::ofstream fstream;
       struct timespec timestamp;


### PR DESCRIPTION
Fix armhf build warnings caused by incorrect format specifiers.

Build warnings seen [here](https://ci.ros2.org/view/nightly/job/nightly_linux-armhf_debug/35/warnings23Result/new/package.-5560703/).
Related to https://github.com/ros2/ros2/issues/721.

Signed-off-by: Prajakta Gokhale <prajaktg@amazon.com>