### PR TITLE
remove non-existing dependency

### DIFF
--- a/action_tutorials/action_tutorials_py/package.xml
+++ b/action_tutorials/action_tutorials_py/package.xml
@@ -7,8 +7,6 @@
   <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_python</buildtool_depend>
-
   <depend>action_tutorials_interfaces</depend>
 
   <exec_depend>rclpy</exec_depend>


### PR DESCRIPTION
Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>

rosdep cannot resolve it causing the nightly docker image to [fail to build](https://cloud.docker.com/u/osrf/repository/registry-1.docker.io/osrf/ros2/builds/5e698625-e8c7-4c14-bd9c-281223304d52)

---

Is it possible to run a linux packaging job after this PR is merged?
Currently the nightly images are pointing to ROS 2 dashing and need a new archive to rebuild successfully (see https://github.com/osrf/docker_images/issues/304)