### PR TITLE
Pendulum fixes

### DIFF
--- a/pendulum_control/include/pendulum_control/rtt_executor.hpp
+++ b/pendulum_control/include/pendulum_control/rtt_executor.hpp
@@ -52,25 +52,11 @@ public:
   /// Default destructor
   virtual ~RttExecutor() {}
 
-  /// Return the status of rttest.
-  // \return True if rttest has initialized, false if it is uninitialized or has finished.
-  bool is_rttest_ready() const
-  {
-    return rttest_ready;
-  }
-
   /// Return true if the executor is currently spinning.
   // \return True if rclcpp is running and if the "running" boolean is set to true.
   bool is_running() const
   {
     return rclcpp::ok() && running;
-  }
-
-  /// Retrieve the results measured by rttest
-  // \param[in] output A struct containing performance statistics.
-  void get_rtt_results(rttest_results & output) const
-  {
-    output = results;
   }
 
   void set_rtt_results_message(pendulum_msgs::msg::RttestResults & msg) const
@@ -102,23 +88,6 @@ public:
       rttest_finish();
     }
     rttest_ready = rttest_running();
-  }
-
-  /// Instrumented "spin_some"
-  /**
-   * This function can have unexpected results if it is called in succession with a non-monotonic
-   * input value. It is up to the user to ensure "i" increases linearly.
-   * \param[in] The iteration for this spin operation, and the index into rttest's data buffer.
-   * \return Pass the error code from rttest (0 on success, non-zero error code on failure).
-   */
-  int rtt_spin_some(size_t i)
-  {
-    // Initialize the start time  if this is the first iteration.
-    if (i == 0) {
-      clock_gettime(0, &start_time_);
-    }
-    // Wrap Executor::spin_some into rttest.
-    return rttest_spin_once(RttExecutor::loop_callback, static_cast<void *>(this), &start_time_, i);
   }
 
   /// Core component of the executor. Do a little bit of work and update extra state.

--- a/pendulum_control/include/pendulum_control/rtt_executor.hpp
+++ b/pendulum_control/include/pendulum_control/rtt_executor.hpp
@@ -127,7 +127,7 @@ public:
   // True if rttest has initialized and hasn't been stopped yet.
   bool rttest_ready;
 
-  int last_sample;
+  int64_t last_sample;
 
 protected:
   // Absolute timestamp at which the first data point was collected in rttest.

--- a/pendulum_control/include/pendulum_control/rtt_executor.hpp
+++ b/pendulum_control/include/pendulum_control/rtt_executor.hpp
@@ -66,6 +66,8 @@ public:
     }
     msg.cur_latency = last_sample;
     msg.mean_latency = results.mean_latency;
+    assert(results.min_latency >= 0);
+    assert(results.max_latency >= 0);
     msg.min_latency = results.min_latency;
     msg.max_latency = results.max_latency;
     msg.minor_pagefaults = results.minor_pagefaults;

--- a/pendulum_control/src/pendulum_demo.cpp
+++ b/pendulum_control/src/pendulum_demo.cpp
@@ -249,9 +249,12 @@ int main(int argc, char * argv[])
   auto logger_publish_callback =
     [&logger_pub, &executor, &pendulum_motor, &pendulum_controller]() {
       pendulum_msgs::msg::RttestResults results_msg;
+      if (!executor->set_rtt_results_message(results_msg)) {
+        // No data is available, just get out instead of publishing bogus data.
+        return;
+      }
       results_msg.command = pendulum_controller->get_next_command_message();
       results_msg.state = pendulum_motor->get_next_sensor_message();
-      executor->set_rtt_results_message(results_msg);
       logger_pub->publish(results_msg);
     };
 

--- a/pendulum_control/test/pendulum_demo.regex
+++ b/pendulum_control/test/pendulum_demo.regex
@@ -8,6 +8,6 @@ rttest statistics:
     - Max: \d+ ns
     - Mean: \d+.\d+ ns
     - Standard deviation: \d+(\.\d+)?(e[\+\-]\d+)?
-
+\s+
 PendulumMotor received \d+ messages
 PendulumController received \d+ messages

--- a/pendulum_control/test/pendulum_demo.regex
+++ b/pendulum_control/test/pendulum_demo.regex
@@ -8,5 +8,6 @@ rttest statistics:
     - Max: \d+ ns
     - Mean: \d+.\d+ ns
     - Standard deviation: \d+(\.\d+)?(e[\+\-]\d+)?
+
 PendulumMotor received \d+ messages
 PendulumController received \d+ messages


### PR DESCRIPTION
This PR, along with https://github.com/ros2/realtime_support/pull/81 , should fix an issue in the `pendulum_control` demo where we publish uninitialized data.  There are three fixes in here, corresponding to the 3 commits:

1.  Remove some unused code in `rtt_executor.hpp`.  This isn't strictly required here, but there is no reason for this code to be here since it is never used.
1.  Switch the min_latency and max_latency fields in the RttestResults.msg to be signed integers.  The underlying latency data coming from `realtime_tools` is signed, so this should be signed as well.
1.  Make it so that we don't publish data if it hasn't yet been initialized.

With this in place, it looks to me like the uninitialized data problems that we have with pendulum_control tests should be gone.  This *may* solve https://github.com/ros2/build_cop/issues/133 ; I'll see what happens when CI comes back.  @cottsay FYI as current build farmer.

Fixes https://github.com/ros2/build_cop/issues/133
Fixes #386 