### PR TITLE
Need to specify NodeOption explicitly to allow declaration.

### DIFF
--- a/demo_nodes_cpp/src/parameters/even_parameters_node.cpp
+++ b/demo_nodes_cpp/src/parameters/even_parameters_node.cpp
@@ -26,13 +26,8 @@ class EvenParameterNode : public rclcpp::Node
 {
 public:
   DEMO_NODES_CPP_PUBLIC
-  explicit EvenParameterNode(
-    const rclcpp::NodeOptions & options = (
-      rclcpp::NodeOptions()
-      .allow_undeclared_parameters(true)
-      .automatically_declare_parameters_from_overrides(true))
-  )
-  : Node("even_parameters_node", options)
+  explicit EvenParameterNode(rclcpp::NodeOptions options)
+  : Node("even_parameters_node", options.allow_undeclared_parameters(true))
   {
     // Force flush of the stdout buffer.
     setvbuf(stdout, NULL, _IONBF, BUFSIZ);
@@ -80,13 +75,8 @@ public:
         }
         return result;
       };
-    this->add_on_set_parameters_callback(param_change_callback);
-  }
-
-  DEMO_NODES_CPP_PUBLIC
-  ~EvenParameterNode(void)
-  {
-    this->remove_on_set_parameters_callback(callback_handler.get());
+    // callback_handler needs to be alive to keep the callback functional
+    callback_handler = this->add_on_set_parameters_callback(param_change_callback);
   }
 
   OnSetParametersCallbackHandle::SharedPtr callback_handler;

--- a/demo_nodes_cpp/src/parameters/even_parameters_node.cpp
+++ b/demo_nodes_cpp/src/parameters/even_parameters_node.cpp
@@ -39,19 +39,10 @@ public:
     // Declare a parameter change request callback
     // This function will enforce that only setting even integer parameters is allowed
     // any other change will be discarded
-    auto existing_callback = this->set_on_parameters_set_callback(nullptr);
     auto param_change_callback =
-      [this, existing_callback](std::vector<rclcpp::Parameter> parameters)
+      [this](std::vector<rclcpp::Parameter> parameters)
       {
         auto result = rcl_interfaces::msg::SetParametersResult();
-        // first call the existing callback, if there was one
-        if (nullptr != existing_callback) {
-          result = existing_callback(parameters);
-          // if the existing callback failed, go ahead and return the result
-          if (!result.successful) {
-            return result;
-          }
-        }
         result.successful = true;
         for (auto parameter : parameters) {
           rclcpp::ParameterType parameter_type = parameter.get_type();
@@ -89,8 +80,16 @@ public:
         }
         return result;
       };
-    this->set_on_parameters_set_callback(param_change_callback);
+    this->add_on_set_parameters_callback(param_change_callback);
   }
+
+  DEMO_NODES_CPP_PUBLIC
+  ~EvenParameterNode(void)
+  {
+    this->remove_on_set_parameters_callback(callback_handler.get());
+  }
+
+  OnSetParametersCallbackHandle::SharedPtr callback_handler;
 };
 
 }  // namespace demo_nodes_cpp

--- a/demo_nodes_cpp/src/parameters/even_parameters_node.cpp
+++ b/demo_nodes_cpp/src/parameters/even_parameters_node.cpp
@@ -26,7 +26,12 @@ class EvenParameterNode : public rclcpp::Node
 {
 public:
   DEMO_NODES_CPP_PUBLIC
-  explicit EvenParameterNode(const rclcpp::NodeOptions options)
+  explicit EvenParameterNode(
+    const rclcpp::NodeOptions & options = (
+      rclcpp::NodeOptions()
+      .allow_undeclared_parameters(true)
+      .automatically_declare_parameters_from_overrides(true))
+  )
   : Node("even_parameters_node", options)
   {
     // Force flush of the stdout buffer.

--- a/demo_nodes_cpp/src/parameters/parameter_blackboard.cpp
+++ b/demo_nodes_cpp/src/parameters/parameter_blackboard.cpp
@@ -29,11 +29,12 @@ class ParameterBlackboard : public rclcpp::Node
 public:
   DEMO_NODES_CPP_PUBLIC
   explicit ParameterBlackboard(
-  rclcpp::NodeOptions options
+    rclcpp::NodeOptions options
   )
-  : Node("parameter_blackboard",
-    options.allow_undeclared_parameters(true).
-    automatically_declare_parameters_from_overrides(true))
+  : Node(
+      "parameter_blackboard",
+      options.allow_undeclared_parameters(true).
+      automatically_declare_parameters_from_overrides(true))
   {
     RCLCPP_INFO(this->get_logger(),
       "Parameter blackboard node named '%s' ready, and serving '%zu' parameters already!",

--- a/demo_nodes_cpp/src/parameters/parameter_blackboard.cpp
+++ b/demo_nodes_cpp/src/parameters/parameter_blackboard.cpp
@@ -31,7 +31,9 @@ public:
   explicit ParameterBlackboard(
   rclcpp::NodeOptions options
   )
-  : Node("parameter_blackboard", options.allow_undeclared_parameters(true).automatically_declare_parameters_from_overrides(true))
+  : Node("parameter_blackboard",
+    options.allow_undeclared_parameters(true).
+    automatically_declare_parameters_from_overrides(true))
   {
     RCLCPP_INFO(this->get_logger(),
       "Parameter blackboard node named '%s' ready, and serving '%zu' parameters already!",

--- a/demo_nodes_cpp/src/parameters/parameter_blackboard.cpp
+++ b/demo_nodes_cpp/src/parameters/parameter_blackboard.cpp
@@ -29,12 +29,9 @@ class ParameterBlackboard : public rclcpp::Node
 public:
   DEMO_NODES_CPP_PUBLIC
   explicit ParameterBlackboard(
-    const rclcpp::NodeOptions & options = (
-      rclcpp::NodeOptions()
-      .allow_undeclared_parameters(true)
-      .automatically_declare_parameters_from_overrides(true)
-  ))
-  : Node("parameter_blackboard", options)
+  rclcpp::NodeOptions options
+  )
+  : Node("parameter_blackboard", options.allow_undeclared_parameters(true).automatically_declare_parameters_from_overrides(true))
   {
     RCLCPP_INFO(this->get_logger(),
       "Parameter blackboard node named '%s' ready, and serving '%zu' parameters already!",


### PR DESCRIPTION
for EvenParameterNode sample, NodeOption should be specified explicitly to allow declaration the parameters from the other nodes.

Client(ros2 param cli to set parameter)
```
root@6cc2c62d0dd0:~/ros2_colcon_ws# ros2 param set /even_parameters_node foo 2
Setting parameter failed: parameter 'foo' cannot be set because it was not declared
```

EvenParameterNode
```
root@6cc2c62d0dd0:~/ros2_colcon_ws# ros2 run demo_nodes_cpp even_parameters_node
[WARN] [rclcpp]: Failed to set parameter: parameter 'foo' cannot be set because it was not declared
```

with above, expected behavior is to be able to set even number for EvenParameterNode.