### PR TITLE
fix spelling of pytest marker

### DIFF
--- a/quality_of_service_demo/rclpy/test/test_linters.py
+++ b/quality_of_service_demo/rclpy/test/test_linters.py
@@ -35,7 +35,7 @@ def test_flake8():
     assert rc == 0, 'Found flake8 errors'
 
 
-@pytest.mark.liner
+@pytest.mark.linter
 @pytest.mark.pep257
 def test_pep257():
     # Test is called from package root


### PR DESCRIPTION
Introduced in https://github.com/ros2/demos/pull/338/files#diff-7025a0e7ee91af3fb2436989bff7e346R38.