### PR TITLE
Prevent argparse from parsing ROS args in Python demos

### DIFF
--- a/demo_nodes_py/demo_nodes_py/topics/listener_qos.py
+++ b/demo_nodes_py/demo_nodes_py/topics/listener_qos.py
@@ -20,6 +20,7 @@ from rclpy.node import Node
 from rclpy.qos import qos_profile_sensor_data
 from rclpy.qos import QoSProfile
 from rclpy.qos import QoSReliabilityPolicy
+from rclpy.utilities import remove_ros_args
 
 from std_msgs.msg import String
 
@@ -48,11 +49,9 @@ def main(argv=sys.argv[1:]):
     parser.add_argument(
         '-n', '--number_of_cycles', type=int, default=20,
         help='max number of spin_once iterations')
-    parser.add_argument(
-        'argv', nargs=argparse.REMAINDER,
-        help='Pass arbitrary arguments to the executable')
-    args = parser.parse_args(argv)
-    rclpy.init(args=args.argv)
+    args = parser.parse_args(remove_ros_args(args=argv))
+
+    rclpy.init(args=argv)
 
     if args.reliable:
         custom_qos_profile = QoSProfile(

--- a/demo_nodes_py/demo_nodes_py/topics/talker_qos.py
+++ b/demo_nodes_py/demo_nodes_py/topics/talker_qos.py
@@ -20,6 +20,7 @@ from rclpy.node import Node
 from rclpy.qos import qos_profile_sensor_data
 from rclpy.qos import QoSProfile
 from rclpy.qos import QoSReliabilityPolicy
+from rclpy.utilities import remove_ros_args
 
 from std_msgs.msg import String
 
@@ -55,11 +56,9 @@ def main(argv=sys.argv[1:]):
     parser.add_argument(
         '-n', '--number_of_cycles', type=int, default=20,
         help='number of sending attempts')
-    parser.add_argument(
-        'argv', nargs=argparse.REMAINDER,
-        help='Pass arbitrary arguments to the executable')
-    args = parser.parse_args(argv)
-    rclpy.init(args=args.argv)
+    args = parser.parse_args(remove_ros_args(args=argv))
+
+    rclpy.init(args=argv)
 
     if args.reliable:
         custom_qos_profile = QoSProfile(


### PR DESCRIPTION
Precisely what the title says. If ROS args are not removed, `argparse` chokes on them.

Depends on https://github.com/ros2/rcl/pull/518.