### PR TITLE
Fix logging demo test

### DIFF
--- a/logging_demo/test/test_logging_demo.py.in
+++ b/logging_demo/test/test_logging_demo.py.in
@@ -38,6 +38,7 @@ def generate_test_description(ready_fn):
 
 
 class TestLoggingDemo(unittest.TestCase):
+
     output_filter = launch_testing_ros.tools.basic_output_filter(
         filtered_rmw_implementation='@rmw_implementation@'
     )

--- a/logging_demo/test/test_logging_demo.py.in
+++ b/logging_demo/test/test_logging_demo.py.in
@@ -38,12 +38,9 @@ def generate_test_description(ready_fn):
 
 
 class TestLoggingDemo(unittest.TestCase):
-
-    @classmethod
-    def setUpClass(cls):
-        cls.output_filter = launch_testing_ros.tools.basic_output_filter(
-            filtered_rmw_implementation='@rmw_implementation@'
-        )
+    output_filter = launch_testing_ros.tools.basic_output_filter(
+        filtered_rmw_implementation='@rmw_implementation@'
+    )
 
     def test_default_severity(self, proc_output, process_under_test):
         """Test process' logs at default severity."""


### PR DESCRIPTION
By relocating `output_filter` assignment. Running CI for Linux only as changes are cross-platform.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8412)](http://ci.ros2.org/job/ci_linux/8412/)