### PR TITLE
Remove command line parsing from C++ demos

### DIFF
--- a/demo_nodes_cpp/src/parameters/list_parameters.cpp
+++ b/demo_nodes_cpp/src/parameters/list_parameters.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
 #include <memory>
 #include <sstream>
 

--- a/demo_nodes_cpp/src/parameters/list_parameters_async.cpp
+++ b/demo_nodes_cpp/src/parameters/list_parameters_async.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
 #include <memory>
 #include <sstream>
 

--- a/demo_nodes_cpp/src/parameters/set_and_get_parameters.cpp
+++ b/demo_nodes_cpp/src/parameters/set_and_get_parameters.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
 #include <memory>
 #include <sstream>
 #include <vector>

--- a/demo_nodes_cpp/src/parameters/set_and_get_parameters_async.cpp
+++ b/demo_nodes_cpp/src/parameters/set_and_get_parameters_async.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
 #include <memory>
 #include <sstream>
 #include <vector>

--- a/demo_nodes_cpp/src/services/add_two_ints_client.cpp
+++ b/demo_nodes_cpp/src/services/add_two_ints_client.cpp
@@ -12,26 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <chrono>
-#include <iostream>
 #include <memory>
-#include <string>
 
 #include "rclcpp/rclcpp.hpp"
-#include "rcutils/cmdline_parser.h"
 
 #include "example_interfaces/srv/add_two_ints.hpp"
-
-using namespace std::chrono_literals;
-
-void print_usage()
-{
-  printf("Usage for add_two_ints_client app:\n");
-  printf("add_two_ints_client [-t topic_name] [-h]\n");
-  printf("options:\n");
-  printf("-h : Print this help function.\n");
-  printf("-s service_name : Specify the service name for this client. Defaults to add_two_ints.\n");
-}
 
 // TODO(wjwwood): make this into a method of rclcpp::Client.
 example_interfaces::srv::AddTwoInts::Response::SharedPtr send_request(
@@ -59,24 +44,13 @@ int main(int argc, char ** argv)
 
   auto node = rclcpp::Node::make_shared("add_two_ints_client");
 
-  if (rcutils_cli_option_exist(argv, argv + argc, "-h")) {
-    print_usage();
-    return 0;
-  }
-
-  auto topic = std::string("add_two_ints");
-  char * cli_option = rcutils_cli_get_option(argv, argv + argc, "-s");
-  if (nullptr != cli_option) {
-    topic = std::string(cli_option);
-  }
-
-  auto client = node->create_client<example_interfaces::srv::AddTwoInts>(topic);
+  auto client = node->create_client<example_interfaces::srv::AddTwoInts>("add_two_ints");
 
   auto request = std::make_shared<example_interfaces::srv::AddTwoInts::Request>();
   request->a = 2;
   request->b = 3;
 
-  while (!client->wait_for_service(1s)) {
+  while (!client->wait_for_service(std::chrono::seconds(1))) {
     if (!rclcpp::ok()) {
       RCLCPP_ERROR(node->get_logger(), "Interrupted while waiting for the service. Exiting.");
       return 0;

--- a/demo_nodes_cpp/src/services/add_two_ints_client.cpp
+++ b/demo_nodes_cpp/src/services/add_two_ints_client.cpp
@@ -12,11 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
 #include <memory>
 
 #include "rclcpp/rclcpp.hpp"
 
 #include "example_interfaces/srv/add_two_ints.hpp"
+
+using namespace std::chrono_literals;
 
 // TODO(wjwwood): make this into a method of rclcpp::Client.
 example_interfaces::srv::AddTwoInts::Response::SharedPtr send_request(
@@ -50,7 +53,7 @@ int main(int argc, char ** argv)
   request->a = 2;
   request->b = 3;
 
-  while (!client->wait_for_service(std::chrono::seconds(1))) {
+  while (!client->wait_for_service(1s)) {
     if (!rclcpp::ok()) {
       RCLCPP_ERROR(node->get_logger(), "Interrupted while waiting for the service. Exiting.");
       return 0;

--- a/demo_nodes_cpp/src/services/add_two_ints_client_async.cpp
+++ b/demo_nodes_cpp/src/services/add_two_ints_client_async.cpp
@@ -13,21 +13,14 @@
 // limitations under the License.
 
 #include <cinttypes>
-#include <chrono>
-#include <iostream>
 #include <memory>
-#include <string>
-#include <vector>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
-#include "rcutils/cmdline_parser.h"
 
 #include "example_interfaces/srv/add_two_ints.hpp"
 
 #include "demo_nodes_cpp/visibility_control.h"
-
-using namespace std::chrono_literals;
 
 namespace demo_nodes_cpp
 {
@@ -39,24 +32,14 @@ public:
   : Node("add_two_ints_client", options)
   {
     setvbuf(stdout, NULL, _IONBF, BUFSIZ);
-    std::vector<std::string> args = options.arguments();
-    if (find_command_option(args, "-h")) {
-      print_usage();
-      rclcpp::shutdown();
-    } else {
-      std::string tmptopic = get_command_option(args, "-s");
-      if (!tmptopic.empty()) {
-        service_name_ = tmptopic;
-      }
-      client_ = create_client<example_interfaces::srv::AddTwoInts>(service_name_);
-      queue_async_request();
-    }
+    client_ = create_client<example_interfaces::srv::AddTwoInts>("add_two_ints");
+    queue_async_request();
   }
 
   DEMO_NODES_CPP_PUBLIC
   void queue_async_request()
   {
-    while (!client_->wait_for_service(1s)) {
+    while (!client_->wait_for_service(std::chrono::seconds(1))) {
       if (!rclcpp::ok()) {
         RCLCPP_ERROR(this->get_logger(), "Interrupted while waiting for the service. Exiting.");
         return;
@@ -82,34 +65,7 @@ public:
   }
 
 private:
-  DEMO_NODES_CPP_LOCAL
-  void print_usage()
-  {
-    printf("Usage for add_two_ints_client app:\n");
-    printf("add_two_ints_client [-s service_name] [-h]\n");
-    printf("options:\n");
-    printf("-h : Print this help function.\n");
-    printf("-s service_name : Specify the service name for client. Defaults to add_two_ints.\n");
-  }
-
-  DEMO_NODES_CPP_LOCAL
-  bool find_command_option(const std::vector<std::string> & args, const std::string & option)
-  {
-    return std::find(args.begin(), args.end(), option) != args.end();
-  }
-
-  DEMO_NODES_CPP_LOCAL
-  std::string get_command_option(const std::vector<std::string> & args, const std::string & option)
-  {
-    auto it = std::find(args.begin(), args.end(), option);
-    if (it != args.end() && ++it != args.end()) {
-      return *it;
-    }
-    return std::string();
-  }
-
   rclcpp::Client<example_interfaces::srv::AddTwoInts>::SharedPtr client_;
-  std::string service_name_ = "add_two_ints";
 };
 
 }  // namespace demo_nodes_cpp

--- a/demo_nodes_cpp/src/services/add_two_ints_client_async.cpp
+++ b/demo_nodes_cpp/src/services/add_two_ints_client_async.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
 #include <cinttypes>
 #include <memory>
 
@@ -21,6 +22,8 @@
 #include "example_interfaces/srv/add_two_ints.hpp"
 
 #include "demo_nodes_cpp/visibility_control.h"
+
+using namespace std::chrono_literals;
 
 namespace demo_nodes_cpp
 {
@@ -39,7 +42,7 @@ public:
   DEMO_NODES_CPP_PUBLIC
   void queue_async_request()
   {
-    while (!client_->wait_for_service(std::chrono::seconds(1))) {
+    while (!client_->wait_for_service(1s)) {
       if (!rclcpp::ok()) {
         RCLCPP_ERROR(this->get_logger(), "Interrupted while waiting for the service. Exiting.");
         return;

--- a/demo_nodes_cpp/src/services/add_two_ints_server.cpp
+++ b/demo_nodes_cpp/src/services/add_two_ints_server.cpp
@@ -13,14 +13,10 @@
 // limitations under the License.
 
 #include <cinttypes>
-#include <cstdio>
 #include <memory>
-#include <string>
-#include <vector>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
-#include "rcutils/cmdline_parser.h"
 
 #include "example_interfaces/srv/add_two_ints.hpp"
 
@@ -37,22 +33,6 @@ public:
   : Node("add_two_ints_server", options)
   {
     setvbuf(stdout, NULL, _IONBF, BUFSIZ);
-    std::vector<std::string> args = options.arguments();
-    if (find_command_option(args, "-h")) {
-      print_usage();
-      rclcpp::shutdown();
-    } else {
-      std::string tmptopic = get_command_option(args, "-s");
-      if (!tmptopic.empty()) {
-        service_name_ = tmptopic;
-      }
-      execute();
-    }
-  }
-
-  DEMO_NODES_CPP_PUBLIC
-  void execute()
-  {
     auto handle_add_two_ints =
       [this](const std::shared_ptr<rmw_request_id_t> request_header,
         const std::shared_ptr<example_interfaces::srv::AddTwoInts::Request> request,
@@ -64,38 +44,11 @@ public:
         response->sum = request->a + request->b;
       };
     // Create a service that will use the callback function to handle requests.
-    srv_ = create_service<example_interfaces::srv::AddTwoInts>(service_name_, handle_add_two_ints);
+    srv_ = create_service<example_interfaces::srv::AddTwoInts>("add_two_ints", handle_add_two_ints);
   }
 
 private:
-  DEMO_NODES_CPP_LOCAL
-  void print_usage()
-  {
-    printf("Usage for add_two_ints_server app:\n");
-    printf("add_two_ints_server [-s service_name] [-h]\n");
-    printf("options:\n");
-    printf("-h : Print this help function.\n");
-    printf("-s service_name : Specify the service name for server. Defaults to add_two_ints.\n");
-  }
-
-  DEMO_NODES_CPP_LOCAL
-  bool find_command_option(const std::vector<std::string> & args, const std::string & option)
-  {
-    return std::find(args.begin(), args.end(), option) != args.end();
-  }
-
-  DEMO_NODES_CPP_LOCAL
-  std::string get_command_option(const std::vector<std::string> & args, const std::string & option)
-  {
-    auto it = std::find(args.begin(), args.end(), option);
-    if (it != args.end() && ++it != args.end()) {
-      return *it;
-    }
-    return std::string();
-  }
-
   rclcpp::Service<example_interfaces::srv::AddTwoInts>::SharedPtr srv_;
-  std::string service_name_ = "add_two_ints";
 };
 
 }  // namespace demo_nodes_cpp

--- a/demo_nodes_cpp/src/topics/allocator_tutorial.cpp
+++ b/demo_nodes_cpp/src/topics/allocator_tutorial.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
 #include <list>
 #include <memory>
 #include <string>
@@ -22,6 +23,7 @@
 #include "rclcpp/strategies/allocator_memory_strategy.hpp"
 #include "std_msgs/msg/u_int32.hpp"
 
+using namespace std::chrono_literals;
 
 // For demonstration purposes only, not necessary for allocator_traits
 static uint32_t num_allocs = 0;
@@ -207,7 +209,7 @@ int main(int argc, char ** argv)
   MessageAlloc message_alloc = *alloc;
   rclcpp::allocator::set_allocator_for_deleter(&message_deleter, &message_alloc);
 
-  rclcpp::sleep_for(std::chrono::milliseconds(1));
+  rclcpp::sleep_for(1ms);
   is_running = true;
 
   uint32_t i = 0;
@@ -220,7 +222,7 @@ int main(int argc, char ** argv)
     msg->data = i;
     ++i;
     publisher->publish(std::move(msg));
-    rclcpp::sleep_for(std::chrono::milliseconds(10));
+    rclcpp::sleep_for(10ms);
     executor.spin_some();
   }
   is_running = false;

--- a/demo_nodes_cpp/src/topics/listener.cpp
+++ b/demo_nodes_cpp/src/topics/listener.cpp
@@ -12,11 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdio>
-#include <memory>
-#include <string>
-#include <vector>
-
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
 #include "rcutils/cmdline_parser.h"
@@ -39,57 +34,20 @@ public:
     // Create a callback function for when messages are received.
     // Variations of this function also exist using, for example UniquePtr for zero-copy transport.
     setvbuf(stdout, NULL, _IONBF, BUFSIZ);
-    std::vector<std::string> args = options.arguments();
-    if (find_command_option(args, "-h")) {
-      print_usage();
-      rclcpp::shutdown();
-    } else {
-      std::string tmptopic = get_command_option(args, "-t");
-      if (!tmptopic.empty()) {
-        topic_name_ = tmptopic;
-      }
-      auto callback =
-        [this](const std_msgs::msg::String::SharedPtr msg) -> void
-        {
-          RCLCPP_INFO(this->get_logger(), "I heard: [%s]", msg->data.c_str());
-        };
-      // Create a subscription to the topic which can be matched with one or more compatible ROS
-      // publishers.
-      // Note that not all publishers on the same topic with the same type will be compatible:
-      // they must have compatible Quality of Service policies.
-      sub_ = create_subscription<std_msgs::msg::String>(topic_name_, 10, callback);
-    }
+    auto callback =
+      [this](const std_msgs::msg::String::SharedPtr msg) -> void
+      {
+        RCLCPP_INFO(this->get_logger(), "I heard: [%s]", msg->data.c_str());
+      };
+    // Create a subscription to the topic which can be matched with one or more compatible ROS
+    // publishers.
+    // Note that not all publishers on the same topic with the same type will be compatible:
+    // they must have compatible Quality of Service policies.
+    sub_ = create_subscription<std_msgs::msg::String>("chatter", 10, callback);
   }
 
 private:
-  DEMO_NODES_CPP_LOCAL
-  void print_usage()
-  {
-    printf("Usage for listener app:\n");
-    printf("listener [-t topic_name] [-h]\n");
-    printf("options:\n");
-    printf("-h : Print this help function.\n");
-    printf("-t topic_name : Specify the topic on which to subscribe. Defaults to chatter.\n");
-  }
-
-  DEMO_NODES_CPP_LOCAL
-  bool find_command_option(const std::vector<std::string> & args, const std::string & option)
-  {
-    return std::find(args.begin(), args.end(), option) != args.end();
-  }
-
-  DEMO_NODES_CPP_LOCAL
-  std::string get_command_option(const std::vector<std::string> & args, const std::string & option)
-  {
-    auto it = std::find(args.begin(), args.end(), option);
-    if (it != args.end() && ++it != args.end()) {
-      return *it;
-    }
-    return std::string();
-  }
-
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr sub_;
-  std::string topic_name_ = "chatter";
 };
 
 }  // namespace demo_nodes_cpp

--- a/demo_nodes_cpp/src/topics/listener.cpp
+++ b/demo_nodes_cpp/src/topics/listener.cpp
@@ -14,7 +14,6 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
-#include "rcutils/cmdline_parser.h"
 
 #include "std_msgs/msg/string.hpp"
 

--- a/demo_nodes_cpp/src/topics/listener_serialized_message.cpp
+++ b/demo_nodes_cpp/src/topics/listener_serialized_message.cpp
@@ -18,7 +18,6 @@
 #include "rcl/types.h"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
-#include "rcutils/cmdline_parser.h"
 
 #include "std_msgs/msg/string.hpp"
 

--- a/demo_nodes_cpp/src/topics/listener_serialized_message.cpp
+++ b/demo_nodes_cpp/src/topics/listener_serialized_message.cpp
@@ -14,8 +14,6 @@
 
 #include <iostream>
 #include <memory>
-#include <string>
-#include <vector>
 
 #include "rcl/types.h"
 #include "rclcpp/rclcpp.hpp"
@@ -40,82 +38,45 @@ public:
   : Node("serialized_message_listener", options)
   {
     setvbuf(stdout, NULL, _IONBF, BUFSIZ);
-    std::vector<std::string> args = options.arguments();
-    if (find_command_option(args, "-h")) {
-      print_usage();
-      rclcpp::shutdown();
-    } else {
-      std::string tmptopic = get_command_option(args, "-t");
-      if (!tmptopic.empty()) {
-        topic_name_ = tmptopic;
-      }
-      // We create a callback to a rmw_serialized_message_t here. This will pass a serialized
-      // message to the callback. We can then further deserialize it and convert it into
-      // a ros2 compliant message.
-      auto callback =
-        [](const std::shared_ptr<rmw_serialized_message_t> msg) -> void
-        {
-          // Print the serialized data message in HEX representation
-          // This output corresponds to what you would see in e.g. Wireshark
-          // when tracing the RTPS packets.
-          std::cout << "I heard data of length: " << msg->buffer_length << std::endl;
-          for (size_t i = 0; i < msg->buffer_length; ++i) {
-            printf("%02x ", msg->buffer[i]);
-          }
-          printf("\n");
+    // We create a callback to a rmw_serialized_message_t here. This will pass a serialized
+    // message to the callback. We can then further deserialize it and convert it into
+    // a ros2 compliant message.
+    auto callback =
+      [](const std::shared_ptr<rmw_serialized_message_t> msg) -> void
+      {
+        // Print the serialized data message in HEX representation
+        // This output corresponds to what you would see in e.g. Wireshark
+        // when tracing the RTPS packets.
+        std::cout << "I heard data of length: " << msg->buffer_length << std::endl;
+        for (size_t i = 0; i < msg->buffer_length; ++i) {
+          printf("%02x ", msg->buffer[i]);
+        }
+        printf("\n");
 
-          // In order to deserialize the message we have to manually create a ROS2
-          // message in which we want to convert the serialized data.
-          auto string_msg = std::make_shared<std_msgs::msg::String>();
-          auto string_ts =
-            rosidl_typesupport_cpp::get_message_type_support_handle<std_msgs::msg::String>();
-          // The rmw_deserialize function takes the serialized data and a corresponding typesupport
-          // which is responsible on how to convert this data into a ROS2 message.
-          auto ret = rmw_deserialize(msg.get(), string_ts, string_msg.get());
-          if (ret != RMW_RET_OK) {
-            fprintf(stderr, "failed to deserialize serialized message\n");
-            return;
-          }
-          // Finally print the ROS2 message data
-          std::cout << "serialized data after deserialization: " << string_msg->data << std::endl;
-        };
-      // Create a subscription to the topic which can be matched with one or more compatible ROS
-      // publishers.
-      // Note that not all publishers on the same topic with the same type will be compatible:
-      // they must have compatible Quality of Service policies.
-      sub_ = create_subscription<std_msgs::msg::String>(topic_name_, 10, callback);
-    }
+        // In order to deserialize the message we have to manually create a ROS2
+        // message in which we want to convert the serialized data.
+        auto string_msg = std::make_shared<std_msgs::msg::String>();
+        auto string_ts =
+          rosidl_typesupport_cpp::get_message_type_support_handle<std_msgs::msg::String>();
+        // The rmw_deserialize function takes the serialized data and a corresponding typesupport
+        // which is responsible on how to convert this data into a ROS2 message.
+        auto ret = rmw_deserialize(msg.get(), string_ts, string_msg.get());
+        if (ret != RMW_RET_OK) {
+          fprintf(stderr, "failed to deserialize serialized message\n");
+          return;
+        }
+        // Finally print the ROS2 message data
+        std::cout << "serialized data after deserialization: " << string_msg->data << std::endl;
+      };
+    // Create a subscription to the topic which can be matched with one or more compatible ROS
+    // publishers.
+    // Note that not all publishers on the same topic with the same type will be compatible:
+    // they must have compatible Quality of Service policies.
+    sub_ = create_subscription<std_msgs::msg::String>("chatter", 10, callback);
   }
 
 private:
-  DEMO_NODES_CPP_LOCAL
-  void print_usage()
-  {
-    printf("Usage for listener app:\n");
-    printf("listener [-t topic_name] [-h]\n");
-    printf("options:\n");
-    printf("-h : Print this help function.\n");
-    printf("-t topic_name : Specify the topic on which to subscribe. Defaults to chatter.\n");
-  }
-
-  DEMO_NODES_CPP_LOCAL
-  bool find_command_option(const std::vector<std::string> & args, const std::string & option)
-  {
-    return std::find(args.begin(), args.end(), option) != args.end();
-  }
-
-  DEMO_NODES_CPP_LOCAL
-  std::string get_command_option(const std::vector<std::string> & args, const std::string & option)
-  {
-    auto it = std::find(args.begin(), args.end(), option);
-    if (it != args.end() && ++it != args.end()) {
-      return *it;
-    }
-    return std::string();
-  }
-
   rclcpp::Subscription<rmw_serialized_message_t>::SharedPtr sub_;
-  std::string topic_name_ = "chatter";
 };
 
 }  // namespace demo_nodes_cpp

--- a/demo_nodes_cpp/src/topics/talker.cpp
+++ b/demo_nodes_cpp/src/topics/talker.cpp
@@ -42,66 +42,29 @@ public:
   {
     // Create a function for when messages are to be sent.
     setvbuf(stdout, NULL, _IONBF, BUFSIZ);
-    std::vector<std::string> args = options.arguments();
-    if (find_command_option(args, "-h")) {
-      print_usage();
-      rclcpp::shutdown();
-    } else {
-      std::string tmptopic = get_command_option(args, "-t");
-      if (!tmptopic.empty()) {
-        topic_name_ = tmptopic;
-      }
-      auto publish_message =
-        [this]() -> void
-        {
-          msg_ = std::make_unique<std_msgs::msg::String>();
-          msg_->data = "Hello World: " + std::to_string(count_++);
-          RCLCPP_INFO(this->get_logger(), "Publishing: '%s'", msg_->data.c_str());
-          // Put the message into a queue to be processed by the middleware.
-          // This call is non-blocking.
-          pub_->publish(std::move(msg_));
-        };
-      // Create a publisher with a custom Quality of Service profile.
-      rclcpp::QoS qos(rclcpp::KeepLast(7));
-      pub_ = this->create_publisher<std_msgs::msg::String>(topic_name_, qos);
+    auto publish_message =
+      [this]() -> void
+      {
+        msg_ = std::make_unique<std_msgs::msg::String>();
+        msg_->data = "Hello World: " + std::to_string(count_++);
+        RCLCPP_INFO(this->get_logger(), "Publishing: '%s'", msg_->data.c_str());
+        // Put the message into a queue to be processed by the middleware.
+        // This call is non-blocking.
+        pub_->publish(std::move(msg_));
+      };
+    // Create a publisher with a custom Quality of Service profile.
+    rclcpp::QoS qos(rclcpp::KeepLast(7));
+    pub_ = this->create_publisher<std_msgs::msg::String>("chatter", qos);
 
-      // Use a timer to schedule periodic message publishing.
-      timer_ = this->create_wall_timer(1s, publish_message);
-    }
+    // Use a timer to schedule periodic message publishing.
+    timer_ = this->create_wall_timer(1s, publish_message);
   }
 
 private:
-  DEMO_NODES_CPP_LOCAL
-  void print_usage()
-  {
-    printf("Usage for talker app:\n");
-    printf("talker [-t topic_name] [-h]\n");
-    printf("options:\n");
-    printf("-h : Print this help function.\n");
-    printf("-t topic_name : Specify the topic on which to publish. Defaults to chatter.\n");
-  }
-
-  DEMO_NODES_CPP_LOCAL
-  bool find_command_option(const std::vector<std::string> & args, const std::string & option)
-  {
-    return std::find(args.begin(), args.end(), option) != args.end();
-  }
-
-  DEMO_NODES_CPP_LOCAL
-  std::string get_command_option(const std::vector<std::string> & args, const std::string & option)
-  {
-    auto it = std::find(args.begin(), args.end(), option);
-    if (it != args.end() && ++it != args.end()) {
-      return *it;
-    }
-    return std::string();
-  }
-
   size_t count_ = 1;
   std::unique_ptr<std_msgs::msg::String> msg_;
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr pub_;
   rclcpp::TimerBase::SharedPtr timer_;
-  std::string topic_name_ = "chatter";
 };
 
 }  // namespace demo_nodes_cpp

--- a/demo_nodes_cpp/src/topics/talker.cpp
+++ b/demo_nodes_cpp/src/topics/talker.cpp
@@ -15,13 +15,10 @@
 #include <chrono>
 #include <cstdio>
 #include <memory>
-#include <string>
 #include <utility>
-#include <vector>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
-#include "rcutils/cmdline_parser.h"
 
 #include "std_msgs/msg/string.hpp"
 

--- a/demo_nodes_cpp/src/topics/talker_serialized_message.cpp
+++ b/demo_nodes_cpp/src/topics/talker_serialized_message.cpp
@@ -14,8 +14,6 @@
 
 #include <iostream>
 #include <memory>
-#include <string>
-#include <vector>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
@@ -45,89 +43,79 @@ public:
     // For this we initially allocate a container message
     // which can hold the data.
     setvbuf(stdout, NULL, _IONBF, BUFSIZ);
-    std::vector<std::string> args = options.arguments();
-    if (find_command_option(args, "-h")) {
-      print_usage();
-      rclcpp::shutdown();
-    } else {
-      std::string tmptopic = get_command_option(args, "-t");
-      if (!tmptopic.empty()) {
-        topic_name_ = tmptopic;
-      }
-      serialized_msg_ = rmw_get_zero_initialized_serialized_message();
-      auto allocator = rcutils_get_default_allocator();
-      auto initial_capacity = 0u;
-      auto ret = rmw_serialized_message_init(
-        &serialized_msg_,
-        initial_capacity,
-        &allocator);
-      if (ret != RCL_RET_OK) {
-        throw std::runtime_error("failed to initialize serialized message");
-      }
-
-      // Create a function for when messages are to be sent.
-      auto publish_message =
-        [this]() -> void
-        {
-          // In this example we send a std_msgs/String as serialized data.
-          // This is the manual CDR serialization of a string message with the content of
-          // Hello World: <count_> equivalent to talker example.
-          // The serialized data is composed of a 8 Byte header
-          // plus the length of the actual message payload.
-          // If we were to compose this serialized message by hand, we would execute the following:
-          // rcutils_snprintf(
-          //   serialized_msg_.buffer, serialized_msg_.buffer_length, "%c%c%c%c%c%c%c%c%s %zu",
-          //   0x00, 0x01, 0x00, 0x00, 0x0f, 0x00, 0x00, 0x00, "Hello World:", count_++);
-
-          // In order to ease things up, we call the rmw_serialize function,
-          // which can do the above conversion for us.
-          // For this, we initially fill up a std_msgs/String message and fill up its content
-          auto string_msg = std::make_shared<std_msgs::msg::String>();
-          string_msg->data = "Hello World:" + std::to_string(count_++);
-
-          // We know the size of the data to be sent, and thus can pre-allocate the
-          // necessary memory to hold all the data.
-          // This is specifically interesting to do here, because this means
-          // no dynamic memory allocation has to be done down the stack.
-          // If we don't allocate enough memory, the serialized message will be
-          // dynamically allocated before sending it to the wire.
-          auto message_header_length = 8u;
-          auto message_payload_length = static_cast<size_t>(string_msg->data.size());
-          auto ret = rmw_serialized_message_resize(
-            &serialized_msg_, message_header_length + message_payload_length);
-          if (ret != RCL_RET_OK) {
-            throw std::runtime_error("failed to resize serialized message");
-          }
-
-          auto string_ts =
-            rosidl_typesupport_cpp::get_message_type_support_handle<std_msgs::msg::String>();
-          // Given the correct typesupport, we can convert our ROS2 message into
-          // its binary representation (serialized_msg)
-          ret = rmw_serialize(string_msg.get(), string_ts, &serialized_msg_);
-          if (ret != RMW_RET_OK) {
-            fprintf(stderr, "failed to serialize serialized message\n");
-            return;
-          }
-
-          // For demonstration we print the ROS2 message format
-          printf("ROS message:\n");
-          printf("%s\n", string_msg->data.c_str());
-          // And after the corresponding binary representation
-          printf("serialized message:\n");
-          for (size_t i = 0; i < serialized_msg_.buffer_length; ++i) {
-            printf("%02x ", serialized_msg_.buffer[i]);
-          }
-          printf("\n");
-
-          pub_->publish(serialized_msg_);
-        };
-
-      rclcpp::QoS qos(rclcpp::KeepLast(7));
-      pub_ = this->create_publisher<std_msgs::msg::String>(topic_name_, qos);
-
-      // Use a timer to schedule periodic message publishing.
-      timer_ = this->create_wall_timer(1s, publish_message);
+    serialized_msg_ = rmw_get_zero_initialized_serialized_message();
+    auto allocator = rcutils_get_default_allocator();
+    auto initial_capacity = 0u;
+    auto ret = rmw_serialized_message_init(
+      &serialized_msg_,
+      initial_capacity,
+      &allocator);
+    if (ret != RCL_RET_OK) {
+      throw std::runtime_error("failed to initialize serialized message");
     }
+
+    // Create a function for when messages are to be sent.
+    auto publish_message =
+      [this]() -> void
+      {
+        // In this example we send a std_msgs/String as serialized data.
+        // This is the manual CDR serialization of a string message with the content of
+        // Hello World: <count_> equivalent to talker example.
+        // The serialized data is composed of a 8 Byte header
+        // plus the length of the actual message payload.
+        // If we were to compose this serialized message by hand, we would execute the following:
+        // rcutils_snprintf(
+        //   serialized_msg_.buffer, serialized_msg_.buffer_length, "%c%c%c%c%c%c%c%c%s %zu",
+        //   0x00, 0x01, 0x00, 0x00, 0x0f, 0x00, 0x00, 0x00, "Hello World:", count_++);
+
+        // In order to ease things up, we call the rmw_serialize function,
+        // which can do the above conversion for us.
+        // For this, we initially fill up a std_msgs/String message and fill up its content
+        auto string_msg = std::make_shared<std_msgs::msg::String>();
+        string_msg->data = "Hello World:" + std::to_string(count_++);
+
+        // We know the size of the data to be sent, and thus can pre-allocate the
+        // necessary memory to hold all the data.
+        // This is specifically interesting to do here, because this means
+        // no dynamic memory allocation has to be done down the stack.
+        // If we don't allocate enough memory, the serialized message will be
+        // dynamically allocated before sending it to the wire.
+        auto message_header_length = 8u;
+        auto message_payload_length = static_cast<size_t>(string_msg->data.size());
+        auto ret = rmw_serialized_message_resize(
+          &serialized_msg_, message_header_length + message_payload_length);
+        if (ret != RCL_RET_OK) {
+          throw std::runtime_error("failed to resize serialized message");
+        }
+
+        auto string_ts =
+          rosidl_typesupport_cpp::get_message_type_support_handle<std_msgs::msg::String>();
+        // Given the correct typesupport, we can convert our ROS2 message into
+        // its binary representation (serialized_msg)
+        ret = rmw_serialize(string_msg.get(), string_ts, &serialized_msg_);
+        if (ret != RMW_RET_OK) {
+          fprintf(stderr, "failed to serialize serialized message\n");
+          return;
+        }
+
+        // For demonstration we print the ROS2 message format
+        printf("ROS message:\n");
+        printf("%s\n", string_msg->data.c_str());
+        // And after the corresponding binary representation
+        printf("serialized message:\n");
+        for (size_t i = 0; i < serialized_msg_.buffer_length; ++i) {
+          printf("%02x ", serialized_msg_.buffer[i]);
+        }
+        printf("\n");
+
+        pub_->publish(serialized_msg_);
+      };
+
+    rclcpp::QoS qos(rclcpp::KeepLast(7));
+    pub_ = this->create_publisher<std_msgs::msg::String>("chatter", qos);
+
+    // Use a timer to schedule periodic message publishing.
+    timer_ = this->create_wall_timer(1s, publish_message);
   }
 
   DEMO_NODES_CPP_PUBLIC
@@ -140,37 +128,10 @@ public:
   }
 
 private:
-  DEMO_NODES_CPP_LOCAL
-  void print_usage()
-  {
-    printf("Usage for talker app:\n");
-    printf("talker [-t topic_name] [-h]\n");
-    printf("options:\n");
-    printf("-h : Print this help function.\n");
-    printf("-t topic_name : Specify the topic on which to publish. Defaults to chatter.\n");
-  }
-
-  DEMO_NODES_CPP_LOCAL
-  bool find_command_option(const std::vector<std::string> & args, const std::string & option)
-  {
-    return std::find(args.begin(), args.end(), option) != args.end();
-  }
-
-  DEMO_NODES_CPP_LOCAL
-  std::string get_command_option(const std::vector<std::string> & args, const std::string & option)
-  {
-    auto it = std::find(args.begin(), args.end(), option);
-    if (it != args.end() && ++it != args.end()) {
-      return *it;
-    }
-    return std::string();
-  }
-
   size_t count_ = 1;
   rcl_serialized_message_t serialized_msg_;
   rclcpp::Publisher<std_msgs::msg::String>::SharedPtr pub_;
   rclcpp::TimerBase::SharedPtr timer_;
-  std::string topic_name_ = "chatter";
 };
 
 }  // namespace demo_nodes_cpp

--- a/demo_nodes_cpp/src/topics/talker_serialized_message.cpp
+++ b/demo_nodes_cpp/src/topics/talker_serialized_message.cpp
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
 #include <iostream>
 #include <memory>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
 
-#include "rcutils/cmdline_parser.h"
-#include "rcutils/snprintf.h"
+#include "rcutils/allocator.h"
 
 #include "std_msgs/msg/string.hpp"
 


### PR DESCRIPTION
The only options being parsed were for setting the topic or service name, but the more ROS-way
to do this is via a remap. For example:

    ros2 run demo_nodes_cpp add_two_ints_server --ros-args -r add_two_ints:=new_service_name

Connects to #390 