### PR TITLE
rename return functions for loaned messages

### DIFF
--- a/demo_nodes_cpp/src/topics/talker_loaned_message.cpp
+++ b/demo_nodes_cpp/src/topics/talker_loaned_message.cpp
@@ -62,7 +62,7 @@ public:
         // capabilities.
         // If the middleware doesn't support this, the loaned message will be allocated
         // with the allocator instance provided by the publisher.
-        auto pod_loaned_msg = pod_pub_->loan_message();
+        auto pod_loaned_msg = pod_pub_->borrow_loaned_message();
         auto pod_msg_data = static_cast<double>(count_++);
         pod_loaned_msg.get().data = pod_msg_data;
         RCLCPP_INFO(this->get_logger(), "Publishing: '%f'", pod_msg_data);
@@ -76,7 +76,7 @@ public:
         // data type, the memory for the message will be allocated on the heap within
         // the scope of the `LoanedMessage` instance.
         // After the call to `publish()`, the message will be correctly allocated.
-        auto non_pod_loaned_msg = non_pod_pub_->loan_message();
+        auto non_pod_loaned_msg = non_pod_pub_->borrow_loaned_message();
         auto non_pod_msg_data = "Hello World: " + std::to_string(count_++);
         non_pod_loaned_msg.get().data = non_pod_msg_data;
         RCLCPP_INFO(this->get_logger(), "Publishing: '%s'", non_pod_msg_data.c_str());

--- a/demo_nodes_cpp/src/topics/talker_loaned_message.cpp
+++ b/demo_nodes_cpp/src/topics/talker_loaned_message.cpp
@@ -55,6 +55,7 @@ public:
     auto publish_message =
       [this]() -> void
       {
+        count_++;
         // We loan a message here and don't allocate the memory on the stack.
         // For middlewares which support message loaning, this means the middleware
         // completely owns the memory for this message.
@@ -63,7 +64,7 @@ public:
         // If the middleware doesn't support this, the loaned message will be allocated
         // with the allocator instance provided by the publisher.
         auto pod_loaned_msg = pod_pub_->borrow_loaned_message();
-        auto pod_msg_data = static_cast<double>(count_++);
+        auto pod_msg_data = static_cast<double>(count_);
         pod_loaned_msg.get().data = pod_msg_data;
         RCLCPP_INFO(this->get_logger(), "Publishing: '%f'", pod_msg_data);
         // As the middleware might own the memory allocated for this message,
@@ -77,7 +78,7 @@ public:
         // the scope of the `LoanedMessage` instance.
         // After the call to `publish()`, the message will be correctly allocated.
         auto non_pod_loaned_msg = non_pod_pub_->borrow_loaned_message();
-        auto non_pod_msg_data = "Hello World: " + std::to_string(count_++);
+        auto non_pod_msg_data = "Hello World: " + std::to_string(count_);
         non_pod_loaned_msg.get().data = non_pod_msg_data;
         RCLCPP_INFO(this->get_logger(), "Publishing: '%s'", non_pod_msg_data.c_str());
         non_pod_pub_->publish(std::move(non_pod_loaned_msg));


### PR DESCRIPTION
connects to https://github.com/ros2/rclcpp/pull/896

I also addressed a little bug where I only increase the message count once instead of for every call to publish.