### PR TITLE
Replace ready_fn with ReadyToTest action

### DIFF
--- a/composition/test/test_api_pubsub_composition.py.in
+++ b/composition/test/test_api_pubsub_composition.py.in
@@ -16,14 +16,14 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
 import launch_testing
+import launch_testing.actions
 import launch_testing.asserts
 import launch_testing_ros
 
 
-def generate_test_description(ready_fn):
+def generate_test_description():
     launch_description = LaunchDescription()
     process_under_test = ExecuteProcess(
         cmd=['@API_COMPOSITION_EXECUTABLE@'],
@@ -50,7 +50,7 @@ def generate_test_description(ready_fn):
         )
     )
     launch_description.add_action(
-        OpaqueFunction(function=lambda context: ready_fn())
+        launch_testing.actions.ReadyToTest()
     )
     return launch_description, locals()
 

--- a/composition/test/test_api_srv_composition.py.in
+++ b/composition/test/test_api_srv_composition.py.in
@@ -16,14 +16,14 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
 import launch_testing
+import launch_testing.actions
 import launch_testing.asserts
 import launch_testing_ros
 
 
-def generate_test_description(ready_fn):
+def generate_test_description():
     launch_description = LaunchDescription()
     process_under_test = ExecuteProcess(
         cmd=['@API_COMPOSITION_EXECUTABLE@'],
@@ -50,7 +50,7 @@ def generate_test_description(ready_fn):
         )
     )
     launch_description.add_action(
-        OpaqueFunction(function=lambda context: ready_fn())
+        launch_testing.actions.ReadyToTest()
     )
     return launch_description, locals()
 

--- a/composition/test/test_api_srv_composition_client_first.py.in
+++ b/composition/test/test_api_srv_composition_client_first.py.in
@@ -16,14 +16,14 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
 import launch_testing
+import launch_testing.actions
 import launch_testing.asserts
 import launch_testing_ros
 
 
-def generate_test_description(ready_fn):
+def generate_test_description():
     launch_description = LaunchDescription()
     process_under_test = ExecuteProcess(
         cmd=['@API_COMPOSITION_EXECUTABLE@'],
@@ -51,7 +51,7 @@ def generate_test_description(ready_fn):
         )
     )
     launch_description.add_action(
-        OpaqueFunction(function=lambda context: ready_fn())
+        launch_testing.actions.ReadyToTest()
     )
     return launch_description, locals()
 

--- a/composition/test/test_dlopen_composition.py.in
+++ b/composition/test/test_dlopen_composition.py.in
@@ -16,14 +16,14 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
 import launch_testing
+import launch_testing.actions
 import launch_testing.asserts
 import launch_testing_ros
 
 
-def generate_test_description(ready_fn):
+def generate_test_description():
     launch_description = LaunchDescription()
     process_under_test = ExecuteProcess(
         cmd=[
@@ -38,7 +38,7 @@ def generate_test_description(ready_fn):
     )
     launch_description.add_action(process_under_test)
     launch_description.add_action(
-        OpaqueFunction(function=lambda context: ready_fn())
+        launch_testing.actions.ReadyToTest()
     )
     return launch_description, locals()
 

--- a/composition/test/test_linktime_composition.py.in
+++ b/composition/test/test_linktime_composition.py.in
@@ -19,14 +19,14 @@ from unittest.case import SkipTest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
 import launch_testing
+import launch_testing.actions
 import launch_testing.asserts
 import launch_testing_ros
 
 
-def generate_test_description(ready_fn):
+def generate_test_description():
     launch_description = LaunchDescription()
     process_under_test = ExecuteProcess(
         cmd=['@LINKTIME_COMPOSITION_EXECUTABLE@'],
@@ -35,7 +35,7 @@ def generate_test_description(ready_fn):
     )
     launch_description.add_action(process_under_test)
     launch_description.add_action(
-        OpaqueFunction(function=lambda context: ready_fn())
+        launch_testing.actions.ReadyToTest()
     )
     return launch_description, locals()
 

--- a/composition/test/test_manual_composition.py.in
+++ b/composition/test/test_manual_composition.py.in
@@ -16,14 +16,14 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
 import launch_testing
+import launch_testing.actions
 import launch_testing.asserts
 import launch_testing_ros
 
 
-def generate_test_description(ready_fn):
+def generate_test_description():
     launch_description = LaunchDescription()
     process_under_test = ExecuteProcess(
         cmd=['@MANUAL_COMPOSITION_EXECUTABLE@'],
@@ -32,7 +32,7 @@ def generate_test_description(ready_fn):
     )
     launch_description.add_action(process_under_test)
     launch_description.add_action(
-        OpaqueFunction(function=lambda context: ready_fn())
+        launch_testing.actions.ReadyToTest()
     )
     return launch_description, locals()
 

--- a/demo_nodes_cpp/test/test_executables_tutorial.py.in
+++ b/demo_nodes_cpp/test/test_executables_tutorial.py.in
@@ -7,15 +7,15 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
 import launch_testing
+import launch_testing.actions
 import launch_testing.asserts
 import launch_testing.util
 import launch_testing_ros
 
 
-def generate_test_description(ready_fn):
+def generate_test_description():
     os.environ['OSPL_VERBOSITY'] = '8'  # 8 = OS_NONE
     # bare minimum formatting for console output matching
     os.environ['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '{message}'
@@ -29,7 +29,7 @@ def generate_test_description(ready_fn):
         launch_description.add_action(process)
     launch_description.add_action(launch_testing.util.KeepAliveProc())
     launch_description.add_action(
-        OpaqueFunction(function=lambda context: ready_fn())
+        launch_testing.actions.ReadyToTest()
     )
     return launch_description, locals()
 

--- a/demo_nodes_cpp_native/test/test_executables_tutorial.py.in
+++ b/demo_nodes_cpp_native/test/test_executables_tutorial.py.in
@@ -5,14 +5,14 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
 import launch_testing
+import launch_testing.actions
 import launch_testing.asserts
 import launch_testing_ros
 
 
-def generate_test_description(ready_fn):
+def generate_test_description():
     launch_description = LaunchDescription()
     processes_under_test = [
         ExecuteProcess(cmd=[executable], name='test_executable_' + str(i), output='screen')
@@ -21,7 +21,7 @@ def generate_test_description(ready_fn):
     for process in processes_under_test:
         launch_description.add_action(process)
     launch_description.add_action(
-        OpaqueFunction(function=lambda context: ready_fn())
+        launch_testing.actions.ReadyToTest()
     )
     return launch_description, locals()
 

--- a/image_tools/test/test_executables_demo.py.in
+++ b/image_tools/test/test_executables_demo.py.in
@@ -17,16 +17,16 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 from launch.actions import SetEnvironmentVariable
 from launch_ros.actions import Node
 
 import launch_testing
+import launch_testing.actions
 import launch_testing.asserts
 import launch_testing_ros
 
 
-def generate_test_description(ready_fn):
+def generate_test_description():
     launch_description = LaunchDescription()
     publisher_node_parameters = {
         'reliability': 'reliable',
@@ -74,7 +74,7 @@ def generate_test_description(ready_fn):
     launch_description.add_action(cam2image_node)
 
     launch_description.add_action(
-        OpaqueFunction(function=lambda context: ready_fn())
+        launch_testing.actions.ReadyToTest()
     )
 
     return launch_description, locals()

--- a/intra_process_demo/test/test_executables_demo.py.in
+++ b/intra_process_demo/test/test_executables_demo.py.in
@@ -5,13 +5,13 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
 import launch_testing
+import launch_testing.actions
 import launch_testing.asserts
 
 
-def generate_test_description(ready_fn):
+def generate_test_description():
     launch_description = LaunchDescription()
     processes_under_test = [
         ExecuteProcess(
@@ -23,7 +23,7 @@ def generate_test_description(ready_fn):
     for process in processes_under_test:
         launch_description.add_action(process)
     launch_description.add_action(
-        OpaqueFunction(function=lambda context: ready_fn())
+        launch_testing.actions.ReadyToTest()
     )
     return launch_description, locals()
 

--- a/lifecycle/test/test_lifecycle.py
+++ b/lifecycle/test/test_lifecycle.py
@@ -24,12 +24,13 @@ import launch_ros.events
 import launch_ros.events.lifecycle
 
 import launch_testing
+import launch_testing.actions
 import launch_testing.asserts
 
 import lifecycle_msgs.msg
 
 
-def generate_test_description(ready_fn):
+def generate_test_description():
     talker_node = launch_ros.actions.LifecycleNode(
         package='lifecycle', node_executable='lifecycle_talker',
         node_name='lc_talker', output='screen'
@@ -110,7 +111,7 @@ def generate_test_description(ready_fn):
                 ],
             )
         ),
-        launch.actions.OpaqueFunction(function=lambda context: ready_fn()),
+        launch_testing.actions.ReadyToTest()
     ]), locals()
 
 

--- a/logging_demo/test/test_logging_demo.py.in
+++ b/logging_demo/test/test_logging_demo.py.in
@@ -16,14 +16,14 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
 import launch_testing
+import launch_testing.actions
 import launch_testing.asserts
 import launch_testing_ros
 
 
-def generate_test_description(ready_fn):
+def generate_test_description():
     launch_description = LaunchDescription()
     process_under_test = ExecuteProcess(
         cmd=['@LOGGING_DEMO_MAIN_EXECUTABLE@'],
@@ -32,7 +32,7 @@ def generate_test_description(ready_fn):
     )
     launch_description.add_action(process_under_test)
     launch_description.add_action(
-        OpaqueFunction(function=lambda context: ready_fn())
+        launch_testing.actions.ReadyToTest()
     )
     return launch_description, locals()
 

--- a/pendulum_control/test/test_pendulum_demo.py.in
+++ b/pendulum_control/test/test_pendulum_demo.py.in
@@ -7,14 +7,14 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
 import launch_testing
+import launch_testing.actions
 import launch_testing.asserts
 import launch_testing_ros
 
 
-def generate_test_description(ready_fn):
+def generate_test_description():
     os.environ['OSPL_VERBOSITY'] = '8'  # 8 = OS_NONE
     # bare minimum formatting for console output matching
     os.environ['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '{message}'
@@ -39,7 +39,7 @@ def generate_test_description(ready_fn):
     launch_description.add_action(pendulum_demo_process)
 
     launch_description.add_action(
-        OpaqueFunction(function=lambda context: ready_fn())
+        launch_testing.actions.ReadyToTest()
     )
     return launch_description, locals()
 

--- a/pendulum_control/test/test_pendulum_teleop.py.in
+++ b/pendulum_control/test/test_pendulum_teleop.py.in
@@ -8,14 +8,14 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
-from launch.actions import OpaqueFunction
 
 import launch_testing
+import launch_testing.actions
 import launch_testing.asserts
 import launch_testing_ros
 
 
-def generate_test_description(ready_fn):
+def generate_test_description():
     os.environ['OSPL_VERBOSITY'] = '8'  # 8 = OS_NONE
     # bare minimum formatting for console output matching
     os.environ['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '{message}'
@@ -43,7 +43,7 @@ def generate_test_description(ready_fn):
     launch_description.add_action(pendulum_teleop_process)
 
     launch_description.add_action(
-        OpaqueFunction(function=lambda context: ready_fn())
+        launch_testing.actions.ReadyToTest()
     )
     return launch_description, locals()
 


### PR DESCRIPTION
The ready_fn will be deprecated in the future in favor of the ReadyToTest() action in launch_testing.  See https://github.com/ros2/launch/pull/346#issuecomment-543830310 for background information

Signed-off-by: Pete Baughman <pete.baughman@apex.ai>