### PR TITLE
Don't redefine add_dependencies

### DIFF
--- a/demo_nodes_cpp/CMakeLists.txt
+++ b/demo_nodes_cpp/CMakeLists.txt
@@ -32,7 +32,7 @@ function(custom_executable subfolder target)
   DESTINATION lib/${PROJECT_NAME})
 endfunction()
 
-function(add_dependencies library)
+function(add_demo_dependencies library)
   target_compile_definitions(${library}
     PRIVATE "DEMO_NODES_CPP_BUILDING_DLL")
   ament_target_dependencies(${library}
@@ -73,10 +73,10 @@ add_library(topics_library SHARED
   src/topics/listener.cpp
   src/topics/listener_serialized_message.cpp
   src/topics/listener_best_effort.cpp)
-add_dependencies(timers_library)
-add_dependencies(services_library)
-add_dependencies(parameters_library)
-add_dependencies(topics_library)
+add_demo_dependencies(timers_library)
+add_demo_dependencies(services_library)
+add_demo_dependencies(parameters_library)
+add_demo_dependencies(topics_library)
 
 rclcpp_components_register_node(timers_library
   PLUGIN "demo_nodes_cpp::OneOffTimerNode"


### PR DESCRIPTION
rosidl defines `add_dependencies`, and cmake will gladly redefine functions without a warning. If you have a multi-project CMake tree, this can lead to weirdness

CMake Error at src/ros2/demos/demo_nodes_cpp/CMakeLists.txt:42 (target_compile_definitions):
  target_compile_definitions called with non-compilable target type
Call Stack (most recent call first):
  install/share/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_interfaces.cmake:129 (add_dependencies)
  install/share/ament_cmake_core/cmake/core/ament_execute_extensions.cmake:48 (include)
  install/share/rosidl_cmake/cmake/rosidl_generate_interfaces.cmake:286 (ament_execute_extensions)
  src/ros2/demos/logging_demo/CMakeLists.txt:21 (rosidl_generate_interfaces)

Signed-off-by: Dan Rose <dan@digilabs.io>
