### PR TITLE
image_tools should start with reliable policy

### DIFF
--- a/image_tools/src/cam2image.cpp
+++ b/image_tools/src/cam2image.cpp
@@ -204,7 +204,7 @@ private:
       reliability_desc.additional_constraints += entry.first + " ";
     }
     const std::string reliability_param = this->declare_parameter(
-      "reliability", name_to_reliability_policy_map.begin()->first, reliability_desc);
+      "reliability", "reliable", reliability_desc);
     auto reliability = name_to_reliability_policy_map.find(reliability_param);
     if (reliability == name_to_reliability_policy_map.end()) {
       std::ostringstream oss;

--- a/image_tools/src/showimage.cpp
+++ b/image_tools/src/showimage.cpp
@@ -127,7 +127,7 @@ private:
       reliability_desc.additional_constraints += entry.first + " ";
     }
     const std::string reliability_param = this->declare_parameter(
-      "reliability", name_to_reliability_policy_map.begin()->first, reliability_desc);
+      "reliability", "reliable", reliability_desc);
     auto reliability = name_to_reliability_policy_map.find(reliability_param);
     if (reliability == name_to_reliability_policy_map.end()) {
       std::ostringstream oss;


### PR DESCRIPTION
`std::map` sorts keys internally, so the first key is `best_effort` instead of the first inserted `reliable`. The [QoS demo](https://index.ros.org/doc/ros2/Tutorials/Quality-of-Service/) expects `cam2image` and `showimage` to start with `reliable` QoS.