### PR TITLE
[action_tutorials_cpp] Return without sending goal if exiting

### DIFF
--- a/action_tutorials/action_tutorials_cpp/src/fibonacci_action_client.cpp
+++ b/action_tutorials/action_tutorials_cpp/src/fibonacci_action_client.cpp
@@ -58,6 +58,7 @@ public:
     if (!this->client_ptr_->wait_for_action_server(std::chrono::seconds(10))) {
       RCLCPP_ERROR(this->get_logger(), "Action server not available after waiting");
       rclcpp::shutdown();
+      return;
     }
 
     auto goal_msg = Fibonacci::Goal();


### PR DESCRIPTION
If the action client does not see an action server within 10 seconds, it shuts down. However, it currently tries to send the goal after shutting down.

```
$ ros2 run action_tutorials_cpp fibonacci_action_client 
[ERROR] [fibonacci_action_client]: Action server not available after waiting
[INFO] [fibonacci_action_client]: Sending goal
```

This PR changes behavior to exit without trying to send the goal.