### PR TITLE
Set logging format in tests to avoid drift when defaults change.

### DIFF
--- a/logging_demo/test/test_logging_demo.py.in
+++ b/logging_demo/test/test_logging_demo.py.in
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import unittest
 
 from launch import LaunchDescription
@@ -24,11 +25,14 @@ import launch_testing_ros
 
 
 def generate_test_description():
+    env = os.environ.copy()
+    env['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '[{severity}] [{name}]: {message}'
     launch_description = LaunchDescription()
     process_under_test = ExecuteProcess(
         cmd=['@LOGGING_DEMO_MAIN_EXECUTABLE@'],
         name='test_logging_demo',
-        output='screen'
+        output='screen',
+        env=env,
     )
     launch_description.add_action(process_under_test)
     launch_description.add_action(


### PR DESCRIPTION
https://github.com/ros2/rcutils/pull/190 changed the default logging format which impacted these tests which compare the output against sample output.

As discussed in https://github.com/ros2/rcutils/pull/190#issuecomment-562796353 setting the logging format in the test prevents it from being broken by future changes, so that's the approach I've taken.