### PR TITLE
Use `spin_until_future_complete` instead of `spin_some` in parameters_event demo

### DIFF
--- a/demo_nodes_cpp/src/parameters/parameter_events.cpp
+++ b/demo_nodes_cpp/src/parameters/parameter_events.cpp
@@ -88,12 +88,7 @@ int main(int argc, char ** argv)
 
   // TODO(wjwwood): Create and use delete_parameter
 
-  // TODO(hidmic): Fast-RTPS takes a significant amount of time to deliver
-  //               requests and response, thus the rather long sleep. Reduce
-  //               once that's resolved.
-  rclcpp::sleep_for(3s);
-
-  rclcpp::spin_some(node);
+  rclcpp::spin(node);
 
   rclcpp::shutdown();
 

--- a/demo_nodes_cpp/src/parameters/parameter_events.cpp
+++ b/demo_nodes_cpp/src/parameters/parameter_events.cpp
@@ -16,6 +16,7 @@
 #include <future>
 #include <memory>
 #include <sstream>
+#include <utility>
 
 #include "rclcpp/rclcpp.hpp"
 
@@ -65,7 +66,7 @@ int main(int argc, char ** argv)
 
   // Setup callback for changes to parameters.
   auto sub = parameters_client->on_parameter_event(
-    [node, promise=std::move(events_received_promise)](
+    [node, promise = std::move(events_received_promise)](
       const rcl_interfaces::msg::ParameterEvent::SharedPtr event) -> void
     {
       static size_t n_times_called = 0u;


### PR DESCRIPTION
From https://github.com/ros2/rclcpp/pull/844, `spin_some` collects pending executables just once, and executes all of them.

That broke this example, because the following happens.
The clients requests aren't handled by the services until `spin` is called.
The parameter event is published by the service when handling the requests.

If executables are not collected more than once, `on_parameter_event` callbacks won't be ever called (the only ones called are the ones from the previous `declare_parameter` calls).

The bad thing, is that now the user have to terminate the example by using `ctrl-c` (maybe, add a log saying that).

Fixes: https://ci.ros2.org/view/nightly/job/nightly_linux_release/1428/testReport/junit/demo_nodes_cpp/TestExecutablesTutorial/test_processes_output/.