### PR TITLE
Replace deprecated launch_ros usage

### DIFF
--- a/composition/launch/composition_demo.launch.py
+++ b/composition/launch/composition_demo.launch.py
@@ -25,7 +25,7 @@ def generate_launch_description():
             name='my_container',
             namespace='',
             package='rclcpp_components',
-            node_executable='component_container',
+            executable='component_container',
             composable_node_descriptions=[
                 ComposableNode(
                     package='composition',

--- a/demo_nodes_cpp/launch/services/add_two_ints.launch.py
+++ b/demo_nodes_cpp/launch/services/add_two_ints.launch.py
@@ -20,9 +20,9 @@ import launch_ros.actions
 
 def generate_launch_description():
     server = launch_ros.actions.Node(
-        package='demo_nodes_cpp', node_executable='add_two_ints_server', output='screen')
+        package='demo_nodes_cpp', executable='add_two_ints_server', output='screen')
     client = launch_ros.actions.Node(
-        package='demo_nodes_cpp', node_executable='add_two_ints_client', output='screen')
+        package='demo_nodes_cpp', executable='add_two_ints_client', output='screen')
     return launch.LaunchDescription([
         server,
         client,

--- a/demo_nodes_cpp/launch/services/add_two_ints_async.launch.py
+++ b/demo_nodes_cpp/launch/services/add_two_ints_async.launch.py
@@ -20,9 +20,9 @@ import launch_ros.actions
 
 def generate_launch_description():
     server = launch_ros.actions.Node(
-        package='demo_nodes_cpp', node_executable='add_two_ints_server', output='screen')
+        package='demo_nodes_cpp', executable='add_two_ints_server', output='screen')
     client = launch_ros.actions.Node(
-        package='demo_nodes_cpp', node_executable='add_two_ints_client_async', output='screen')
+        package='demo_nodes_cpp', executable='add_two_ints_client_async', output='screen')
     return launch.LaunchDescription([
         server,
         client,

--- a/demo_nodes_cpp/launch/topics/talker_listener.launch.py
+++ b/demo_nodes_cpp/launch/topics/talker_listener.launch.py
@@ -21,7 +21,7 @@ import launch_ros.actions
 def generate_launch_description():
     return LaunchDescription([
         launch_ros.actions.Node(
-            package='demo_nodes_cpp', node_executable='talker', output='screen'),
+            package='demo_nodes_cpp', executable='talker', output='screen'),
         launch_ros.actions.Node(
-            package='demo_nodes_cpp', node_executable='listener', output='screen'),
+            package='demo_nodes_cpp', executable='listener', output='screen'),
     ])

--- a/demo_nodes_cpp/launch/topics/talker_listener_best_effort.launch.py
+++ b/demo_nodes_cpp/launch/topics/talker_listener_best_effort.launch.py
@@ -21,7 +21,7 @@ import launch_ros.actions
 def generate_launch_description():
     return LaunchDescription([
         launch_ros.actions.Node(
-            package='demo_nodes_cpp', node_executable='talker', output='screen'),
+            package='demo_nodes_cpp', executable='talker', output='screen'),
         launch_ros.actions.Node(
-            package='demo_nodes_cpp', node_executable='listener_best_effort', output='screen'),
+            package='demo_nodes_cpp', executable='listener_best_effort', output='screen'),
     ])

--- a/dummy_robot/dummy_robot_bringup/launch/dummy_robot_bringup.launch.py
+++ b/dummy_robot/dummy_robot_bringup/launch/dummy_robot_bringup.launch.py
@@ -27,9 +27,9 @@ def generate_launch_description():
     rsp_params = {'robot_description': robot_desc}
 
     return LaunchDescription([
-        Node(package='dummy_map_server', node_executable='dummy_map_server', output='screen'),
-        Node(package='robot_state_publisher', node_executable='robot_state_publisher',
+        Node(package='dummy_map_server', executable='dummy_map_server', output='screen'),
+        Node(package='robot_state_publisher', executable='robot_state_publisher',
              output='screen', parameters=[rsp_params]),
-        Node(package='dummy_sensors', node_executable='dummy_joint_states', output='screen'),
-        Node(package='dummy_sensors', node_executable='dummy_laser', output='screen')
+        Node(package='dummy_sensors', executable='dummy_joint_states', output='screen'),
+        Node(package='dummy_sensors', executable='dummy_laser', output='screen')
     ])

--- a/image_tools/test/test_executables_demo.py.in
+++ b/image_tools/test/test_executables_demo.py.in
@@ -53,7 +53,7 @@ def generate_test_description():
     showimage_name = 'test_showimage'
 
     showimage_node = Node(
-        node_executable=showimage_executable,
+        executable=showimage_executable,
         name=showimage_name,
         parameters=[subscriber_node_parameters],
         output='screen'
@@ -66,7 +66,7 @@ def generate_test_description():
     cam2image_name = 'test_cam2image'
 
     cam2image_node = Node(
-        node_executable=cam2image_executable,
+        executable=cam2image_executable,
         name=cam2image_name,
         parameters=[publisher_node_parameters],
         output='screen'

--- a/lifecycle/launch/lifecycle_demo.launch.py
+++ b/lifecycle/launch/lifecycle_demo.launch.py
@@ -19,8 +19,8 @@ from launch_ros.actions import Node
 
 def generate_launch_description():
     return LaunchDescription([
-        LifecycleNode(package='lifecycle', node_executable='lifecycle_talker',
+        LifecycleNode(package='lifecycle', executable='lifecycle_talker',
                       name='lc_talker', output='screen'),
-        Node(package='lifecycle', node_executable='lifecycle_listener', output='screen'),
-        Node(package='lifecycle', node_executable='lifecycle_service_client', output='screen')
+        Node(package='lifecycle', executable='lifecycle_listener', output='screen'),
+        Node(package='lifecycle', executable='lifecycle_service_client', output='screen')
     ])

--- a/lifecycle/test/test_lifecycle.py
+++ b/lifecycle/test/test_lifecycle.py
@@ -32,11 +32,11 @@ import lifecycle_msgs.msg
 
 def generate_test_description():
     talker_node = launch_ros.actions.LifecycleNode(
-        package='lifecycle', node_executable='lifecycle_talker',
+        package='lifecycle', executable='lifecycle_talker',
         name='lc_talker', output='screen'
     )
     listener_node = launch_ros.actions.Node(
-        package='lifecycle', node_executable='lifecycle_listener',
+        package='lifecycle', executable='lifecycle_listener',
         name='listener', output='screen'
     )
     return launch.LaunchDescription([


### PR DESCRIPTION
The Node parameter 'node_executable' has been deprecated and replaced
with 'executable'.

Depends on https://github.com/ros2/launch_ros/pull/140