### PR TITLE
Replace `ros2 msg` command in lifecycle README

### DIFF
--- a/lifecycle/README.rst
+++ b/lifecycle/README.rst
@@ -337,7 +337,7 @@ You can find them though in the lifecycle_msgs package.
 
 .. code-block:: bash
 
-    $ ros2 msg show lifecycle_msgs/Transition
+    $ ros2 interface show lifecycle_msgs/msg/Transition
 
 Outlook
 -------


### PR DESCRIPTION
The lifecycle readme uses the command `ros2 msg show ...` to show a message interface.  I don't believe `ros2 msg` is a command in Foxy.  I replaced it with `ros2 interface` and updated the message's path so that the call prints out the desired message.