### PR TITLE
Remove deprecated warning for rclcpp in clang builds

### DIFF
--- a/pendulum_control/include/pendulum_control/rtt_executor.hpp
+++ b/pendulum_control/include/pendulum_control/rtt_executor.hpp
@@ -33,7 +33,7 @@
 namespace pendulum_control
 {
 /// Instrumented executor that syncs Executor::spin functions with rttest_spin.
-class RttExecutor : public rclcpp::executor::Executor
+class RttExecutor : public rclcpp::Executor
 {
 public:
   /// Constructor


### PR DESCRIPTION
Signed-off-by: Anas Abou Allaban <aabouallaban@pm.me>

Resolve the [following build warning](https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/476/clang-tidy/new/folder.-926644094/) for the `nightly_linux_clang_libcxx` build.

Can't seem to run CI for the clang build but can confirm local build passes with no warnings.