### PR TITLE
Initialize time stamp for published image messages

### DIFF
--- a/image_tools/src/cam2image.cpp
+++ b/image_tools/src/cam2image.cpp
@@ -287,6 +287,7 @@ private:
     msg.data.resize(size);
     memcpy(&msg.data[0], frame.data, size);
     msg.header.frame_id = frame_id_;
+    msg.header.stamp = this->now();
   }
 
   cv::VideoCapture cap;


### PR DESCRIPTION
Use the current ROS time instead of leaving it unset.