### PR TITLE
Replace rmw_connext_cpp with rmw_connextdds

### DIFF
--- a/pendulum_control/README.md
+++ b/pendulum_control/README.md
@@ -13,10 +13,10 @@ Run:
 
 ```
 . install/setup.bash
-pendulum_demo[__rmw_opensplice/__rmw_connext]
+pendulum_demo[__rmw_opensplice/__rmw_connextdds]
 ```
-The demo runs with both PrismTech OpenSplice and RTI Connext (if RTI Connext is available).
-However, it has better performance with RTI Connext.
+The demo runs with both PrismTech OpenSplice and RTI Connext DDS (if RTI Connext DDS is available).
+However, it has better performance with RTI Connext DDS.
 
 A few command line arguments related to real-time performance profiling are provided by rttest.
 See https://github.com/ros2/rttest/blob/master/README.md for more information.
@@ -24,7 +24,7 @@ See https://github.com/ros2/rttest/blob/master/README.md for more information.
 The demo will spit out a lot of output as it runs. Try redirecting the results to a file:
 
 ```
-pendulum_demo[__rmw_opensplice/__rmw_connext] > output.txt
+pendulum_demo[__rmw_opensplice/__rmw_connextdds] > output.txt
 ```
 
 ## Running with real-time performance

--- a/pendulum_control/README.md
+++ b/pendulum_control/README.md
@@ -13,9 +13,9 @@ Run:
 
 ```
 . install/setup.bash
-pendulum_demo[__rmw_opensplice/__rmw_connextdds]
+pendulum_demo__rmw_connextdds
 ```
-The demo runs with both PrismTech OpenSplice and RTI Connext DDS (if RTI Connext DDS is available).
+The demo runs with RTI Connext DDS (if RTI Connext DDS is available).
 However, it has better performance with RTI Connext DDS.
 
 A few command line arguments related to real-time performance profiling are provided by rttest.
@@ -24,7 +24,7 @@ See https://github.com/ros2/rttest/blob/master/README.md for more information.
 The demo will spit out a lot of output as it runs. Try redirecting the results to a file:
 
 ```
-pendulum_demo[__rmw_opensplice/__rmw_connextdds] > output.txt
+pendulum_demo__rmw_connextdds > output.txt
 ```
 
 ## Running with real-time performance

--- a/pendulum_control/README.md
+++ b/pendulum_control/README.md
@@ -1,31 +1,17 @@
 ## Build instructions
 
-If you haven't already, clone [rttest](https://github.com/ros2/rttest) into your ament workspace.
+This pendulum control demo is available in the default ROS 2 install.
+Follow the instructions to build ROS 2 from source: https://docs.ros.org/en/rolling/Installation/Linux-Development-Setup.html
 
-Build your ament workspace:
-
-```
-./src/ament/ament_tools/scripts/ament.py build --symlink-install
-```
-You can add `--only pendulum_control` if you want to only rebuild this package.
-
-Run:
+## Running the demo
 
 ```
 . install/setup.bash
-pendulum_demo__rmw_connextdds
+. install/pendulum_control/bin/pendulum_demo
 ```
-The demo runs with RTI Connext DDS (if RTI Connext DDS is available).
-However, it has better performance with RTI Connext DDS.
 
 A few command line arguments related to real-time performance profiling are provided by rttest.
 See https://github.com/ros2/rttest/blob/master/README.md for more information.
-
-The demo will spit out a lot of output as it runs. Try redirecting the results to a file:
-
-```
-pendulum_demo__rmw_connextdds > output.txt
-```
 
 ## Running with real-time performance
 

--- a/quality_of_service_demo/README.md
+++ b/quality_of_service_demo/README.md
@@ -152,12 +152,12 @@ and the "Deadline missed" messages will no longer be printed.
 
 This demo shows how to get a notification when a subscription loses a message.
 
-The feature is available in some rmw implementations: rmw_cyclonedds, rmw_connext.
+The feature is available in some rmw implementations: rmw_cyclonedds, rmw_connextdds.
 CycloneDDS partially implements the feature and it only triggers the event under some limited circumstances, thus it's recommended to try the demo with Connext.
 
 To run the demo:
 ```
-export RMW_IMPLEMENTATION = rmw_connext_cpp
+export RMW_IMPLEMENTATION = rmw_connextdds
 ros2 run quality_of_service_demo_cpp message_lost_listener &
 # -s allows specifying the message size in KiB. This argument is optional, defaults to 8192KiB.
 ros2 run quality_of_service_demo_cpp message_lost_talker -s 8192


### PR DESCRIPTION
This PR replaces all references to `rmw_connext_cpp` with `rmw_connextdds`.

See [rticommunity/rmw_connextdds #9](https://github.com/rticommunity/rmw_connextdds/issues/9) for a list of related PRs, and an overview of all the changes required to replace [ros2/rmw_connext](https://github.com/ros2/rmw_connext) (`rmw_connext_cpp`) with [rticommunity/rmw_connextdds](https://github.com/rticommunity/rmw_connextdds) in the ROS2 source tree.