### PR TITLE
change ParameterEventHandler to take events as const ref instead of shared pointer

### DIFF
--- a/demo_nodes_cpp/src/parameters/parameter_event_handler.cpp
+++ b/demo_nodes_cpp/src/parameters/parameter_event_handler.cpp
@@ -105,16 +105,16 @@ int main(int argc, char ** argv)
 
   // We can also monitor all parameter changes and do our own filtering/searching
   auto cb3 =
-    [fqn, remote_param_name, &node](const rcl_interfaces::msg::ParameterEvent::SharedPtr & event) {
+    [fqn, remote_param_name, &node](const rcl_interfaces::msg::ParameterEvent & event) {
       // Use a regular expression to scan for any updates to parameters in "/a_namespace"
       // as well as any parameter changes to our own node
       std::regex re("(/a_namespace/.*)|(/this_node)");
-      if (regex_match(event->node, re)) {
+      if (regex_match(event.node, re)) {
         // You can use 'get_parameter_from_event' if you know the node name and parameter name
         // that you're looking for
         rclcpp::Parameter p;
         if (rclcpp::ParameterEventHandler::get_parameter_from_event(
-            *event, p,
+            event, p,
             remote_param_name, fqn))
         {
           RCLCPP_INFO(
@@ -126,7 +126,7 @@ int main(int argc, char ** argv)
 
         // You can also use 'get_parameter*s*_from_event' to enumerate all changes that came
         // in on this event
-        auto params = rclcpp::ParameterEventHandler::get_parameters_from_event(*event);
+        auto params = rclcpp::ParameterEventHandler::get_parameters_from_event(event);
         for (auto & p : params) {
           RCLCPP_INFO(
             node->get_logger(), "cb3: Received an update to parameter \"%s\" of type: %s: \"%s\"",

--- a/lifecycle/CMakeLists.txt
+++ b/lifecycle/CMakeLists.txt
@@ -17,34 +17,27 @@ find_package(lifecycle_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
 
-include_directories(
-  include
-  ${std_msgs_INCLUDE_DIRS}
-  ${lifecycle_msgs_INCLUDE_DIRS}
-  ${rclcpp_lifecycle_INCLUDE_DIRS}
-  ${rclcpp_INCLUDE_DIRS})
-
 ### demos
 add_executable(lifecycle_talker
   src/lifecycle_talker.cpp)
-target_link_libraries(lifecycle_talker
-  ${rclcpp_lifecycle_LIBRARIES}
-  ${std_msgs_LIBRARIES}
-  rclcpp::rclcpp
+ament_target_dependencies(lifecycle_talker
+  "lifecycle_msgs"
+  "rclcpp_lifecycle"
+  "std_msgs"
 )
 add_executable(lifecycle_listener
   src/lifecycle_listener.cpp)
-target_link_libraries(lifecycle_listener
-  ${rclcpp_lifecycle_LIBRARIES}
-  ${std_msgs_LIBRARIES}
-  rclcpp::rclcpp
+ament_target_dependencies(lifecycle_listener
+  "lifecycle_msgs"
+  "rclcpp_lifecycle"
+  "std_msgs"
 )
 add_executable(lifecycle_service_client
   src/lifecycle_service_client.cpp)
-target_link_libraries(lifecycle_service_client
-  ${rclcpp_lifecycle_LIBRARIES}
-  ${std_msgs_LIBRARIES}
-  rclcpp::rclcpp
+ament_target_dependencies(lifecycle_service_client
+  "lifecycle_msgs"
+  "rclcpp_lifecycle"
+  "std_msgs"
 )
 
 install(TARGETS

--- a/lifecycle/CMakeLists.txt
+++ b/lifecycle/CMakeLists.txt
@@ -30,18 +30,21 @@ add_executable(lifecycle_talker
 target_link_libraries(lifecycle_talker
   ${rclcpp_lifecycle_LIBRARIES}
   ${std_msgs_LIBRARIES}
+  rclcpp::rclcpp
 )
 add_executable(lifecycle_listener
   src/lifecycle_listener.cpp)
 target_link_libraries(lifecycle_listener
   ${rclcpp_lifecycle_LIBRARIES}
   ${std_msgs_LIBRARIES}
+  rclcpp::rclcpp
 )
 add_executable(lifecycle_service_client
   src/lifecycle_service_client.cpp)
 target_link_libraries(lifecycle_service_client
   ${rclcpp_lifecycle_LIBRARIES}
   ${std_msgs_LIBRARIES}
+  rclcpp::rclcpp
 )
 
 install(TARGETS


### PR DESCRIPTION
This is related to, and requires, https://github.com/ros2/rclcpp/pull/1598

@mjeronimo can you think of any other places we need to update something like this? Documentation?