### PR TITLE
Add support for yuv422

### DIFF
--- a/image_tools/src/showimage.cpp
+++ b/image_tools/src/showimage.cpp
@@ -205,7 +205,8 @@ private:
       if (msg->encoding == "rgb8") {
         cv::cvtColor(frame, frame, cv::COLOR_RGB2BGR);
       } else if (msg->encoding == "yuv422") {
-        msg->is_bigendian? cv::cvtColor(frame, frame, cv::COLOR_YUV2BGR_UYVY): cv::cvtColor(frame, frame, cv::COLOR_YUV2BGR_YUYV);
+        msg->is_bigendian? cv::cvtColor(frame, frame, cv::COLOR_YUV2BGR_UYVY): 
+          cv::cvtColor(frame, frame, cv::COLOR_YUV2BGR_YUYV);
       }
 
       cv::Mat cvframe = frame;

--- a/image_tools/src/showimage.cpp
+++ b/image_tools/src/showimage.cpp
@@ -180,6 +180,8 @@ private:
       return CV_32FC1;
     } else if (encoding == "rgb8") {
       return CV_8UC3;
+    } else if (encoding == "yuv422") {
+      return CV_8UC2;
     } else {
       throw std::runtime_error("Unsupported encoding type");
     }
@@ -202,6 +204,8 @@ private:
 
       if (msg->encoding == "rgb8") {
         cv::cvtColor(frame, frame, cv::COLOR_RGB2BGR);
+      } else if (msg->encoding == "yuv422") {
+        msg->is_bigendian? cv::cvtColor(frame, frame, cv::COLOR_YUV2BGR_UYVY): cv::cvtColor(frame, frame, cv::COLOR_YUV2BGR_YUYV);
       }
 
       cv::Mat cvframe = frame;


### PR DESCRIPTION
Added support for showimage demo tool for visualizing YUV422 image formats.
Note that is_bigendian is used to determine the ordering of the pixels.