### PR TITLE
Use underscores instead of dashes in setup.cfg

### DIFF
--- a/action_tutorials/action_tutorials_py/setup.cfg
+++ b/action_tutorials/action_tutorials_py/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/action_tutorials_py
+script_dir=$base/lib/action_tutorials_py
 [install]
-install-scripts=$base/lib/action_tutorials_py
+install_scripts=$base/lib/action_tutorials_py

--- a/demo_nodes_cpp/src/topics/talker.cpp
+++ b/demo_nodes_cpp/src/topics/talker.cpp
@@ -51,7 +51,7 @@ public:
       };
     // Create a publisher with a custom Quality of Service profile.
     rclcpp::QoS qos(rclcpp::KeepLast(7));
-    pub_ = this->create_publisher<std_msgs::msg::String>("chatter", qos.best_effort());
+    pub_ = this->create_publisher<std_msgs::msg::String>("chatter", qos);
 
     // Use a timer to schedule periodic message publishing.
     timer_ = this->create_wall_timer(1s, publish_message);

--- a/demo_nodes_cpp/src/topics/talker.cpp
+++ b/demo_nodes_cpp/src/topics/talker.cpp
@@ -51,7 +51,7 @@ public:
       };
     // Create a publisher with a custom Quality of Service profile.
     rclcpp::QoS qos(rclcpp::KeepLast(7));
-    pub_ = this->create_publisher<std_msgs::msg::String>("chatter", qos);
+    pub_ = this->create_publisher<std_msgs::msg::String>("chatter", qos.best_effort());
 
     // Use a timer to schedule periodic message publishing.
     timer_ = this->create_wall_timer(1s, publish_message);

--- a/demo_nodes_py/setup.cfg
+++ b/demo_nodes_py/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/demo_nodes_py
+script_dir=$base/lib/demo_nodes_py
 [install]
-install-scripts=$base/lib/demo_nodes_py
+install_scripts=$base/lib/demo_nodes_py

--- a/quality_of_service_demo/rclpy/setup.cfg
+++ b/quality_of_service_demo/rclpy/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/quality_of_service_demo_py
+script_dir=$base/lib/quality_of_service_demo_py
 [install]
-install-scripts=$base/lib/quality_of_service_demo_py
+install_scripts=$base/lib/quality_of_service_demo_py

--- a/topic_monitor/setup.cfg
+++ b/topic_monitor/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/topic_monitor
+script_dir=$base/lib/topic_monitor
 [install]
-install-scripts=$base/lib/topic_monitor
+install_scripts=$base/lib/topic_monitor


### PR DESCRIPTION
To avoid a python user warning when building:

https://ci.ros2.org/view/nightly/job/nightly_linux_release/1890/consoleFull#console-section-446