### PR TITLE
Clean up lifecycle demo

### DIFF
--- a/lifecycle/CMakeLists.txt
+++ b/lifecycle/CMakeLists.txt
@@ -11,55 +11,28 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
-find_package(ament_cmake REQUIRED)
-find_package(rclcpp_lifecycle REQUIRED)
-find_package(lifecycle_msgs REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(std_msgs REQUIRED)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
-### demos
-add_executable(lifecycle_talker
+ament_auto_add_executable(lifecycle_talker
   src/lifecycle_talker.cpp)
-ament_target_dependencies(lifecycle_talker
-  "lifecycle_msgs"
-  "rclcpp_lifecycle"
-  "std_msgs"
-)
-add_executable(lifecycle_listener
-  src/lifecycle_listener.cpp)
-ament_target_dependencies(lifecycle_listener
-  "lifecycle_msgs"
-  "rclcpp_lifecycle"
-  "std_msgs"
-)
-add_executable(lifecycle_service_client
-  src/lifecycle_service_client.cpp)
-ament_target_dependencies(lifecycle_service_client
-  "lifecycle_msgs"
-  "rclcpp_lifecycle"
-  "std_msgs"
-)
 
-install(TARGETS
-  lifecycle_talker
-  lifecycle_listener
-  lifecycle_service_client
-  DESTINATION lib/${PROJECT_NAME})
+ament_auto_add_executable(lifecycle_listener
+  src/lifecycle_listener.cpp)
+
+ament_auto_add_executable(lifecycle_service_client
+  src/lifecycle_service_client.cpp)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
-  find_package(ros_testing REQUIRED)
   add_ros_test(
     test/test_lifecycle.py
     TIMEOUT 60
   )
 endif()
 
-install(DIRECTORY
-  launch
-  DESTINATION share/${PROJECT_NAME}/
+ament_auto_package(
+  INSTALL_TO_SHARE launch
 )
-
-ament_package()

--- a/lifecycle/include/lifecycle/lifecycle_listener.hpp
+++ b/lifecycle/include/lifecycle/lifecycle_listener.hpp
@@ -1,0 +1,49 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef LIFECYCLE__LIFECYCLE_LISTENER_HPP_
+#define LIFECYCLE__LIFECYCLE_LISTENER_HPP_
+
+#include <memory>
+#include <string>
+
+#include "lifecycle_msgs/msg/transition_event.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "std_msgs/msg/string.hpp"
+
+/// LifecycleListener class as a simple listener node
+/**
+ * We subscribe to two topics
+ * - lifecycle_chatter: The data topic from the talker
+ * - lc_talker__transition_event: The topic publishing
+ *   notifications about state changes of the node
+ *   lc_talker
+ */
+class LifecycleListener : public rclcpp::Node
+{
+public:
+  explicit LifecycleListener(const std::string & node_name);
+
+  void data_callback(const std_msgs::msg::String::SharedPtr msg);
+
+  void notification_callback(const lifecycle_msgs::msg::TransitionEvent::SharedPtr msg);
+
+private:
+  std::shared_ptr<rclcpp::Subscription<std_msgs::msg::String>> sub_data_;
+  std::shared_ptr<rclcpp::Subscription<lifecycle_msgs::msg::TransitionEvent>>
+  sub_notification_;
+};
+
+#endif  // LIFECYCLE__LIFECYCLE_LISTENER_HPP_

--- a/lifecycle/include/lifecycle/lifecycle_service_client.hpp
+++ b/lifecycle/include/lifecycle/lifecycle_service_client.hpp
@@ -1,0 +1,105 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef LIFECYCLE__LIFECYCLE_SERVICE_CLIENT_HPP_
+#define LIFECYCLE__LIFECYCLE_SERVICE_CLIENT_HPP_
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "lifecycle_msgs/msg/state.hpp"
+#include "lifecycle_msgs/msg/transition.hpp"
+#include "lifecycle_msgs/srv/change_state.hpp"
+#include "lifecycle_msgs/srv/get_state.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+
+// which node to handle
+static constexpr char const * lifecycle_node = "lc_talker";
+
+// Every lifecycle node has various services
+// attached to it. By convention, we use the format of
+// <node name>/<service name>.
+// In this demo, we use get_state and change_state
+// and thus the two service topics are:
+// lc_talker/get_state
+// lc_talker/change_state
+static constexpr char const * node_get_state_topic = "lc_talker/get_state";
+static constexpr char const * node_change_state_topic = "lc_talker/change_state";
+
+template<typename FutureT, typename WaitTimeT>
+std::future_status
+wait_for_result(
+  FutureT & future,
+  WaitTimeT time_to_wait)
+{
+  auto end = std::chrono::steady_clock::now() + time_to_wait;
+  std::chrono::milliseconds wait_period(100);
+  std::future_status status = std::future_status::timeout;
+  do {
+    auto now = std::chrono::steady_clock::now();
+    auto time_left = end - now;
+    if (time_left <= std::chrono::seconds(0)) {break;}
+    status = future.wait_for((time_left < wait_period) ? time_left : wait_period);
+  } while (rclcpp::ok() && status != std::future_status::ready);
+  return status;
+}
+
+class LifecycleServiceClient : public rclcpp::Node
+{
+public:
+  explicit LifecycleServiceClient(const std::string & node_name);
+
+  void init();
+
+  /// Requests the current state of the node
+  /**
+   * In this function, we send a service request
+   * asking for the current state of the node
+   * lc_talker.
+   * If it does return within the given time_out,
+   * we return the current state of the node, if
+   * not, we return an unknown state.
+   * \param time_out Duration in seconds specifying
+   * how long we wait for a response before returning
+   * unknown state
+   */
+  unsigned int get_state(std::chrono::seconds time_out = std::chrono::seconds(3));
+
+  /// Invokes a transition
+  /**
+   * We send a Service request and indicate
+   * that we want to invoke transition with
+   * the id "transition".
+   * By default, these transitions are
+   * - configure
+   * - activate
+   * - cleanup
+   * - shutdown
+   * \param transition id specifying which
+   * transition to invoke
+   * \param time_out Duration in seconds specifying
+   * how long we wait for a response before returning
+   * unknown state
+   */
+  bool change_state(
+    std::uint8_t transition,
+    std::chrono::seconds time_out = std::chrono::seconds(3));
+
+private:
+  std::shared_ptr<rclcpp::Client<lifecycle_msgs::srv::GetState>> client_get_state_;
+  std::shared_ptr<rclcpp::Client<lifecycle_msgs::srv::ChangeState>> client_change_state_;
+};
+#endif  // LIFECYCLE__LIFECYCLE_SERVICE_CLIENT_HPP_

--- a/lifecycle/include/lifecycle/lifecycle_talker.hpp
+++ b/lifecycle/include/lifecycle/lifecycle_talker.hpp
@@ -1,0 +1,157 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef LIFECYCLE__LIFECYCLE_TALKER_HPP_
+#define LIFECYCLE__LIFECYCLE_TALKER_HPP_
+
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
+
+#include "lifecycle_msgs/msg/transition.hpp"
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/publisher.hpp"
+
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "rclcpp_lifecycle/lifecycle_publisher.hpp"
+
+#include "std_msgs/msg/string.hpp"
+
+/// LifecycleTalker inheriting from rclcpp_lifecycle::LifecycleNode
+/**
+ * The lifecycle talker does not like the regular "talker" node
+ * inherit from node, but rather from lifecyclenode. This brings
+ * in a set of callbacks which are getting invoked depending on
+ * the current state of the node.
+ * Every lifecycle node has a set of services attached to it
+ * which make it controllable from the outside and invoke state
+ * changes.
+ * Available Services as for Beta1:
+ * - <node_name>__get_state
+ * - <node_name>__change_state
+ * - <node_name>__get_available_states
+ * - <node_name>__get_available_transitions
+ * Additionally, a publisher for state change notifications is
+ * created:
+ * - <node_name>__transition_event
+ */
+class LifecycleTalker : public rclcpp_lifecycle::LifecycleNode
+{
+public:
+  /// LifecycleTalker constructor
+  /**
+   * The lifecycletalker/lifecyclenode constructor has the same
+   * arguments a regular node.
+   */
+  explicit LifecycleTalker(const std::string & node_name, bool intra_process_comms = false);
+
+  /// Callback for walltimer in order to publish the message.
+  /**
+   * Callback for walltimer. This function gets invoked by the timer
+   * and executes the publishing.
+   * For this demo, we ask the node for its current state. If the
+   * lifecycle publisher is not activate, we still invoke publish, but
+   * the communication is blocked so that no messages is actually transferred.
+   */
+  void publish();
+
+  /// Transition callback for state configuring
+  /**
+   * on_configure callback is being called when the lifecycle node
+   * enters the "configuring" state.
+   * Depending on the return value of this function, the state machine
+   * either invokes a transition to the "inactive" state or stays
+   * in "unconfigured".
+   * TRANSITION_CALLBACK_SUCCESS transitions to "inactive"
+   * TRANSITION_CALLBACK_FAILURE transitions to "unconfigured"
+   * TRANSITION_CALLBACK_ERROR or any uncaught exceptions to "errorprocessing"
+   */
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_configure(const rclcpp_lifecycle::State &);
+
+  /// Transition callback for state activating
+  /**
+   * on_activate callback is being called when the lifecycle node
+   * enters the "activating" state.
+   * Depending on the return value of this function, the state machine
+   * either invokes a transition to the "active" state or stays
+   * in "inactive".
+   * TRANSITION_CALLBACK_SUCCESS transitions to "active"
+   * TRANSITION_CALLBACK_FAILURE transitions to "inactive"
+   * TRANSITION_CALLBACK_ERROR or any uncaught exceptions to "errorprocessing"
+   */
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_activate(const rclcpp_lifecycle::State &);
+
+  /// Transition callback for state deactivating
+  /**
+   * on_deactivate callback is being called when the lifecycle node
+   * enters the "deactivating" state.
+   * Depending on the return value of this function, the state machine
+   * either invokes a transition to the "inactive" state or stays
+   * in "active".
+   * TRANSITION_CALLBACK_SUCCESS transitions to "inactive"
+   * TRANSITION_CALLBACK_FAILURE transitions to "active"
+   * TRANSITION_CALLBACK_ERROR or any uncaught exceptions to "errorprocessing"
+   */
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_deactivate(const rclcpp_lifecycle::State &);
+
+  /// Transition callback for state cleaningup
+  /**
+   * on_cleanup callback is being called when the lifecycle node
+   * enters the "cleaningup" state.
+   * Depending on the return value of this function, the state machine
+   * either invokes a transition to the "unconfigured" state or stays
+   * in "inactive".
+   * TRANSITION_CALLBACK_SUCCESS transitions to "unconfigured"
+   * TRANSITION_CALLBACK_FAILURE transitions to "inactive"
+   * TRANSITION_CALLBACK_ERROR or any uncaught exceptions to "errorprocessing"
+   */
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_cleanup(const rclcpp_lifecycle::State &);
+
+  /// Transition callback for state shutting down
+  /**
+   * on_shutdown callback is being called when the lifecycle node
+   * enters the "shuttingdown" state.
+   * Depending on the return value of this function, the state machine
+   * either invokes a transition to the "finalized" state or stays
+   * in its current state.
+   * TRANSITION_CALLBACK_SUCCESS transitions to "finalized"
+   * TRANSITION_CALLBACK_FAILURE transitions to current state
+   * TRANSITION_CALLBACK_ERROR or any uncaught exceptions to "errorprocessing"
+   */
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+  on_shutdown(const rclcpp_lifecycle::State & state);
+
+private:
+  // We hold an instance of a lifecycle publisher. This lifecycle publisher
+  // can be activated or deactivated regarding on which state the lifecycle node
+  // is in.
+  // By default, a lifecycle publisher is inactive by creation and has to be
+  // activated to publish messages into the ROS world.
+  std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::String>> pub_;
+
+  // We hold an instance of a timer which periodically triggers the publish function.
+  // As for the beta version, this is a regular timer. In a future version, a
+  // lifecycle timer will be created which obeys the same lifecycle management as the
+  // lifecycle publisher.
+  std::shared_ptr<rclcpp::TimerBase> timer_;
+};
+
+#endif  // LIFECYCLE__LIFECYCLE_TALKER_HPP_

--- a/lifecycle/package.xml
+++ b/lifecycle/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>lifecycle</name>
   <version>0.14.0</version>
   <description>Package containing demos for lifecycle implementation</description>
@@ -9,15 +9,12 @@
   <license>Apache License 2.0</license>
   <author email="karsten@osrfoundation.org">Karsten Knese</author>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>lifecycle_msgs</build_depend>
-  <build_depend>rclcpp_lifecycle</build_depend>
-  <build_depend>std_msgs</build_depend>
-
-  <exec_depend>rclcpp_lifecycle</exec_depend>
-  <exec_depend>lifecycle_msgs</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>lifecycle_msgs</depend>
+  <depend>std_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/lifecycle/src/lifecycle_listener.cpp
+++ b/lifecycle/src/lifecycle_listener.cpp
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#include "lifecycle/lifecycle_listener.hpp"
 
 #include <memory>
 #include <string>
@@ -19,55 +20,37 @@
 
 #include "rclcpp/rclcpp.hpp"
 
-#include "rcutils/logging_macros.h"
-
 #include "std_msgs/msg/string.hpp"
 
-/// LifecycleListener class as a simple listener node
-/**
- * We subscribe to two topics
- * - lifecycle_chatter: The data topic from the talker
- * - lc_talker__transition_event: The topic publishing
- *   notifications about state changes of the node
- *   lc_talker
- */
-class LifecycleListener : public rclcpp::Node
+LifecycleListener::LifecycleListener(const std::string & node_name)
+: Node(node_name)
 {
-public:
-  explicit LifecycleListener(const std::string & node_name)
-  : Node(node_name)
-  {
-    // Data topic from the lc_talker node
-    sub_data_ = this->create_subscription<std_msgs::msg::String>(
-      "lifecycle_chatter", 10,
-      std::bind(&LifecycleListener::data_callback, this, std::placeholders::_1));
+  // Data topic from the lc_talker node
+  sub_data_ = this->create_subscription<std_msgs::msg::String>(
+    "lifecycle_chatter", 10,
+    std::bind(&LifecycleListener::data_callback, this, std::placeholders::_1));
 
-    // Notification event topic. All state changes
-    // are published here as TransitionEvents with
-    // a start and goal state indicating the transition
-    sub_notification_ = this->create_subscription<lifecycle_msgs::msg::TransitionEvent>(
-      "/lc_talker/transition_event",
-      10,
-      std::bind(&LifecycleListener::notification_callback, this, std::placeholders::_1));
-  }
+  // Notification event topic. All state changes
+  // are published here as TransitionEvents with
+  // a start and goal state indicating the transition
+  sub_notification_ = this->create_subscription<lifecycle_msgs::msg::TransitionEvent>(
+    "/lc_talker/transition_event",
+    10,
+    std::bind(&LifecycleListener::notification_callback, this, std::placeholders::_1));
+}
 
-  void data_callback(const std_msgs::msg::String::SharedPtr msg)
-  {
-    RCLCPP_INFO(get_logger(), "data_callback: %s", msg->data.c_str());
-  }
+void LifecycleListener::data_callback(const std_msgs::msg::String::SharedPtr msg)
+{
+  RCLCPP_INFO(this->get_logger(), "data_callback: %s", msg->data.c_str());
+}
 
-  void notification_callback(const lifecycle_msgs::msg::TransitionEvent::SharedPtr msg)
-  {
-    RCLCPP_INFO(
-      get_logger(), "notify callback: Transition from state %s to %s",
-      msg->start_state.label.c_str(), msg->goal_state.label.c_str());
-  }
-
-private:
-  std::shared_ptr<rclcpp::Subscription<std_msgs::msg::String>> sub_data_;
-  std::shared_ptr<rclcpp::Subscription<lifecycle_msgs::msg::TransitionEvent>>
-  sub_notification_;
-};
+void LifecycleListener::notification_callback(
+  const lifecycle_msgs::msg::TransitionEvent::SharedPtr msg)
+{
+  RCLCPP_INFO(
+    this->get_logger(), "notify callback: Transition from state %s to %s",
+    msg->start_state.label.c_str(), msg->goal_state.label.c_str());
+}
 
 int main(int argc, char ** argv)
 {

--- a/lifecycle/src/lifecycle_listener.cpp
+++ b/lifecycle/src/lifecycle_listener.cpp
@@ -16,12 +16,6 @@
 #include <memory>
 #include <string>
 
-#include "lifecycle_msgs/msg/transition_event.hpp"
-
-#include "rclcpp/rclcpp.hpp"
-
-#include "std_msgs/msg/string.hpp"
-
 LifecycleListener::LifecycleListener(const std::string & node_name)
 : Node(node_name)
 {

--- a/lifecycle/src/lifecycle_service_client.cpp
+++ b/lifecycle/src/lifecycle_service_client.cpp
@@ -13,17 +13,8 @@
 // limitations under the License.
 #include "lifecycle/lifecycle_service_client.hpp"
 
-#include <chrono>
 #include <memory>
 #include <string>
-#include <thread>
-
-#include "lifecycle_msgs/msg/state.hpp"
-#include "lifecycle_msgs/msg/transition.hpp"
-#include "lifecycle_msgs/srv/change_state.hpp"
-#include "lifecycle_msgs/srv/get_state.hpp"
-
-#include "rclcpp/rclcpp.hpp"
 
 LifecycleServiceClient::LifecycleServiceClient(const std::string & node_name)
 : Node(node_name)

--- a/lifecycle/src/lifecycle_service_client.cpp
+++ b/lifecycle/src/lifecycle_service_client.cpp
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#include "lifecycle/lifecycle_service_client.hpp"
 
 #include <chrono>
 #include <memory>
@@ -24,172 +25,129 @@
 
 #include "rclcpp/rclcpp.hpp"
 
-#include "rcutils/logging_macros.h"
+LifecycleServiceClient::LifecycleServiceClient(const std::string & node_name)
+: Node(node_name)
+{}
 
-using namespace std::chrono_literals;
-
-// which node to handle
-static constexpr char const * lifecycle_node = "lc_talker";
-
-// Every lifecycle node has various services
-// attached to it. By convention, we use the format of
-// <node name>/<service name>.
-// In this demo, we use get_state and change_state
-// and thus the two service topics are:
-// lc_talker/get_state
-// lc_talker/change_state
-static constexpr char const * node_get_state_topic = "lc_talker/get_state";
-static constexpr char const * node_change_state_topic = "lc_talker/change_state";
-
-template<typename FutureT, typename WaitTimeT>
-std::future_status
-wait_for_result(
-  FutureT & future,
-  WaitTimeT time_to_wait)
+void LifecycleServiceClient::init()
 {
-  auto end = std::chrono::steady_clock::now() + time_to_wait;
-  std::chrono::milliseconds wait_period(100);
-  std::future_status status = std::future_status::timeout;
-  do {
-    auto now = std::chrono::steady_clock::now();
-    auto time_left = end - now;
-    if (time_left <= std::chrono::seconds(0)) {break;}
-    status = future.wait_for((time_left < wait_period) ? time_left : wait_period);
-  } while (rclcpp::ok() && status != std::future_status::ready);
-  return status;
+  // Every lifecycle node spawns automatically a couple
+  // of services which allow an external interaction with
+  // these nodes.
+  // The two main important ones are GetState and ChangeState.
+  client_get_state_ = this->create_client<lifecycle_msgs::srv::GetState>(
+    node_get_state_topic);
+  client_change_state_ = this->create_client<lifecycle_msgs::srv::ChangeState>(
+    node_change_state_topic);
 }
 
-class LifecycleServiceClient : public rclcpp::Node
+/**
+ * In this function, we send a service request
+ * asking for the current state of the node
+ * lc_talker.
+ * If it does return within the given time_out,
+ * we return the current state of the node, if
+ * not, we return an unknown state.
+ * \param time_out Duration in seconds specifying
+ * how long we wait for a response before returning
+ * unknown state
+ */
+unsigned int
+LifecycleServiceClient::get_state(std::chrono::seconds time_out)
 {
-public:
-  explicit LifecycleServiceClient(const std::string & node_name)
-  : Node(node_name)
-  {}
+  auto request = std::make_shared<lifecycle_msgs::srv::GetState::Request>();
 
-  void
-  init()
-  {
-    // Every lifecycle node spawns automatically a couple
-    // of services which allow an external interaction with
-    // these nodes.
-    // The two main important ones are GetState and ChangeState.
-    client_get_state_ = this->create_client<lifecycle_msgs::srv::GetState>(
-      node_get_state_topic);
-    client_change_state_ = this->create_client<lifecycle_msgs::srv::ChangeState>(
-      node_change_state_topic);
+  if (!client_get_state_->wait_for_service(time_out)) {
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "Service %s is not available.",
+      client_get_state_->get_service_name());
+    return lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN;
   }
 
-  /// Requests the current state of the node
-  /**
-   * In this function, we send a service request
-   * asking for the current state of the node
-   * lc_talker.
-   * If it does return within the given time_out,
-   * we return the current state of the node, if
-   * not, we return an unknown state.
-   * \param time_out Duration in seconds specifying
-   * how long we wait for a response before returning
-   * unknown state
-   */
-  unsigned int
-  get_state(std::chrono::seconds time_out = 3s)
-  {
-    auto request = std::make_shared<lifecycle_msgs::srv::GetState::Request>();
+  // We send the service request for asking the current
+  // state of the lc_talker node.
+  auto future_result = client_get_state_->async_send_request(request);
 
-    if (!client_get_state_->wait_for_service(time_out)) {
-      RCLCPP_ERROR(
-        get_logger(),
-        "Service %s is not available.",
-        client_get_state_->get_service_name());
-      return lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN;
-    }
+  // Let's wait until we have the answer from the node.
+  // If the request times out, we return an unknown state.
+  auto future_status = wait_for_result(future_result, time_out);
 
-    // We send the service request for asking the current
-    // state of the lc_talker node.
-    auto future_result = client_get_state_->async_send_request(request);
-
-    // Let's wait until we have the answer from the node.
-    // If the request times out, we return an unknown state.
-    auto future_status = wait_for_result(future_result, time_out);
-
-    if (future_status != std::future_status::ready) {
-      RCLCPP_ERROR(
-        get_logger(), "Server time out while getting current state for node %s", lifecycle_node);
-      return lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN;
-    }
-
-    // We have an succesful answer. So let's print the current state.
-    if (future_result.get()) {
-      RCLCPP_INFO(
-        get_logger(), "Node %s has current state %s.",
-        lifecycle_node, future_result.get()->current_state.label.c_str());
-      return future_result.get()->current_state.id;
-    } else {
-      RCLCPP_ERROR(
-        get_logger(), "Failed to get current state for node %s", lifecycle_node);
-      return lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN;
-    }
+  if (future_status != std::future_status::ready) {
+    RCLCPP_ERROR(
+      this->get_logger(), "Server time out while getting current state for node %s",
+      lifecycle_node);
+    return lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN;
   }
 
-  /// Invokes a transition
-  /**
-   * We send a Service request and indicate
-   * that we want to invoke transition with
-   * the id "transition".
-   * By default, these transitions are
-   * - configure
-   * - activate
-   * - cleanup
-   * - shutdown
-   * \param transition id specifying which
-   * transition to invoke
-   * \param time_out Duration in seconds specifying
-   * how long we wait for a response before returning
-   * unknown state
-   */
-  bool
-  change_state(std::uint8_t transition, std::chrono::seconds time_out = 3s)
-  {
-    auto request = std::make_shared<lifecycle_msgs::srv::ChangeState::Request>();
-    request->transition.id = transition;
+  // We have an succesful answer. So let's print the current state.
+  if (future_result.get()) {
+    RCLCPP_INFO(
+      this->get_logger(), "Node %s has current state %s.",
+      lifecycle_node, future_result.get()->current_state.label.c_str());
+    return future_result.get()->current_state.id;
+  } else {
+    RCLCPP_ERROR(
+      this->get_logger(), "Failed to get current state for node %s", lifecycle_node);
+    return lifecycle_msgs::msg::State::PRIMARY_STATE_UNKNOWN;
+  }
+}
 
-    if (!client_change_state_->wait_for_service(time_out)) {
-      RCLCPP_ERROR(
-        get_logger(),
-        "Service %s is not available.",
-        client_change_state_->get_service_name());
-      return false;
-    }
+/// Invokes a transition
+/**
+ * We send a Service request and indicate
+ * that we want to invoke transition with
+ * the id "transition".
+ * By default, these transitions are
+ * - configure
+ * - activate
+ * - cleanup
+ * - shutdown
+ * \param transition id specifying which
+ * transition to invoke
+ * \param time_out Duration in seconds specifying
+ * how long we wait for a response before returning
+ * unknown state
+ */
+bool
+LifecycleServiceClient::change_state(std::uint8_t transition, std::chrono::seconds time_out)
+{
+  auto request = std::make_shared<lifecycle_msgs::srv::ChangeState::Request>();
+  request->transition.id = transition;
 
-    // We send the request with the transition we want to invoke.
-    auto future_result = client_change_state_->async_send_request(request);
-
-    // Let's wait until we have the answer from the node.
-    // If the request times out, we return an unknown state.
-    auto future_status = wait_for_result(future_result, time_out);
-
-    if (future_status != std::future_status::ready) {
-      RCLCPP_ERROR(
-        get_logger(), "Server time out while getting current state for node %s", lifecycle_node);
-      return false;
-    }
-
-    // We have an answer, let's print our success.
-    if (future_result.get()->success) {
-      RCLCPP_INFO(
-        get_logger(), "Transition %d successfully triggered.", static_cast<int>(transition));
-      return true;
-    } else {
-      RCLCPP_WARN(
-        get_logger(), "Failed to trigger transition %u", static_cast<unsigned int>(transition));
-      return false;
-    }
+  if (!client_change_state_->wait_for_service(time_out)) {
+    RCLCPP_ERROR(
+      this->get_logger(),
+      "Service %s is not available.",
+      client_change_state_->get_service_name());
+    return false;
   }
 
-private:
-  std::shared_ptr<rclcpp::Client<lifecycle_msgs::srv::GetState>> client_get_state_;
-  std::shared_ptr<rclcpp::Client<lifecycle_msgs::srv::ChangeState>> client_change_state_;
-};
+  // We send the request with the transition we want to invoke.
+  auto future_result = client_change_state_->async_send_request(request);
+
+  // Let's wait until we have the answer from the node.
+  // If the request times out, we return an unknown state.
+  auto future_status = wait_for_result(future_result, time_out);
+
+  if (future_status != std::future_status::ready) {
+    RCLCPP_ERROR(
+      this->get_logger(), "Server time out while getting current state for node %s",
+      lifecycle_node);
+    return false;
+  }
+
+  // We have an answer, let's print our success.
+  if (future_result.get()->success) {
+    RCLCPP_INFO(
+      this->get_logger(), "Transition %d successfully triggered.", static_cast<int>(transition));
+    return true;
+  } else {
+    RCLCPP_WARN(
+      this->get_logger(), "Failed to trigger transition %u", static_cast<unsigned int>(transition));
+    return false;
+  }
+}
 
 /**
  * This is a little independent

--- a/lifecycle/src/lifecycle_talker.cpp
+++ b/lifecycle/src/lifecycle_talker.cpp
@@ -13,24 +13,10 @@
 // limitations under the License.
 #include "lifecycle/lifecycle_talker.hpp"
 
-#include <chrono>
-#include <iostream>
 #include <memory>
 #include <string>
-#include <thread>
 #include <utility>
 
-#include "lifecycle_msgs/msg/transition.hpp"
-
-#include "rclcpp/rclcpp.hpp"
-#include "rclcpp/publisher.hpp"
-
-#include "rclcpp_lifecycle/lifecycle_node.hpp"
-#include "rclcpp_lifecycle/lifecycle_publisher.hpp"
-
-#include "std_msgs/msg/string.hpp"
-
-using namespace std::chrono_literals;
 
 /// LifecycleTalker constructor
 /**
@@ -134,7 +120,7 @@ LifecycleTalker::on_activate(const rclcpp_lifecycle::State &)
   // Let's sleep for 2 seconds.
   // We emulate we are doing important
   // work in the activating phase.
-  std::this_thread::sleep_for(2s);
+  std::this_thread::sleep_for(std::chrono::seconds(2));
 
   // We return a success and hence invoke the transition to the next
   // step: "active".

--- a/lifecycle/src/lifecycle_talker.cpp
+++ b/lifecycle/src/lifecycle_talker.cpp
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#include "lifecycle/lifecycle_talker.hpp"
 
 #include <chrono>
 #include <iostream>
@@ -27,255 +28,218 @@
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "rclcpp_lifecycle/lifecycle_publisher.hpp"
 
-#include "rcutils/logging_macros.h"
-
 #include "std_msgs/msg/string.hpp"
 
 using namespace std::chrono_literals;
 
-/// LifecycleTalker inheriting from rclcpp_lifecycle::LifecycleNode
+/// LifecycleTalker constructor
 /**
- * The lifecycle talker does not like the regular "talker" node
- * inherit from node, but rather from lifecyclenode. This brings
- * in a set of callbacks which are getting invoked depending on
- * the current state of the node.
- * Every lifecycle node has a set of services attached to it
- * which make it controllable from the outside and invoke state
- * changes.
- * Available Services as for Beta1:
- * - <node_name>__get_state
- * - <node_name>__change_state
- * - <node_name>__get_available_states
- * - <node_name>__get_available_transitions
- * Additionally, a publisher for state change notifications is
- * created:
- * - <node_name>__transition_event
+ * The lifecycletalker/lifecyclenode constructor has the same
+ * arguments a regular node.
  */
-class LifecycleTalker : public rclcpp_lifecycle::LifecycleNode
+LifecycleTalker::LifecycleTalker(const std::string & node_name, bool intra_process_comms)
+: rclcpp_lifecycle::LifecycleNode(node_name,
+    rclcpp::NodeOptions().use_intra_process_comms(intra_process_comms))
+{}
+
+/// Callback for walltimer in order to publish the message.
+/**
+ * Callback for walltimer. This function gets invoked by the timer
+ * and executes the publishing.
+ * For this demo, we ask the node for its current state. If the
+ * lifecycle publisher is not activate, we still invoke publish, but
+ * the communication is blocked so that no messages is actually transferred.
+ */
+void
+LifecycleTalker::publish()
 {
-public:
-  /// LifecycleTalker constructor
-  /**
-   * The lifecycletalker/lifecyclenode constructor has the same
-   * arguments a regular node.
-   */
-  explicit LifecycleTalker(const std::string & node_name, bool intra_process_comms = false)
-  : rclcpp_lifecycle::LifecycleNode(node_name,
-      rclcpp::NodeOptions().use_intra_process_comms(intra_process_comms))
-  {}
+  static size_t count = 0;
+  auto msg = std::make_unique<std_msgs::msg::String>();
+  msg->data = "Lifecycle HelloWorld #" + std::to_string(++count);
 
-  /// Callback for walltimer in order to publish the message.
-  /**
-   * Callback for walltimer. This function gets invoked by the timer
-   * and executes the publishing.
-   * For this demo, we ask the node for its current state. If the
-   * lifecycle publisher is not activate, we still invoke publish, but
-   * the communication is blocked so that no messages is actually transferred.
-   */
-  void
-  publish()
-  {
-    static size_t count = 0;
-    auto msg = std::make_unique<std_msgs::msg::String>();
-    msg->data = "Lifecycle HelloWorld #" + std::to_string(++count);
-
-    // Print the current state for demo purposes
-    if (!pub_->is_activated()) {
-      RCLCPP_INFO(
-        get_logger(), "Lifecycle publisher is currently inactive. Messages are not published.");
-    } else {
-      RCLCPP_INFO(
-        get_logger(), "Lifecycle publisher is active. Publishing: [%s]", msg->data.c_str());
-    }
-
-    // We independently from the current state call publish on the lifecycle
-    // publisher.
-    // Only if the publisher is in an active state, the message transfer is
-    // enabled and the message actually published.
-    pub_->publish(std::move(msg));
+  // Print the current state for demo purposes
+  if (!pub_->is_activated()) {
+    RCLCPP_INFO(
+      this->get_logger(), "Lifecycle publisher is currently inactive. Messages are not published.");
+  } else {
+    RCLCPP_INFO(
+      this->get_logger(), "Lifecycle publisher is active. Publishing: [%s]", msg->data.c_str());
   }
 
-  /// Transition callback for state configuring
-  /**
-   * on_configure callback is being called when the lifecycle node
-   * enters the "configuring" state.
-   * Depending on the return value of this function, the state machine
-   * either invokes a transition to the "inactive" state or stays
-   * in "unconfigured".
-   * TRANSITION_CALLBACK_SUCCESS transitions to "inactive"
-   * TRANSITION_CALLBACK_FAILURE transitions to "unconfigured"
-   * TRANSITION_CALLBACK_ERROR or any uncaught exceptions to "errorprocessing"
-   */
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_configure(const rclcpp_lifecycle::State &)
-  {
-    // This callback is supposed to be used for initialization and
-    // configuring purposes.
-    // We thus initialize and configure our publishers and timers.
-    // The lifecycle node API does return lifecycle components such as
-    // lifecycle publishers. These entities obey the lifecycle and
-    // can comply to the current state of the node.
-    // As of the beta version, there is only a lifecycle publisher
-    // available.
-    pub_ = this->create_publisher<std_msgs::msg::String>("lifecycle_chatter", 10);
-    timer_ = this->create_wall_timer(
-      1s, std::bind(&LifecycleTalker::publish, this));
+  // We independently from the current state call publish on the lifecycle
+  // publisher.
+  // Only if the publisher is in an active state, the message transfer is
+  // enabled and the message actually published.
+  pub_->publish(std::move(msg));
+}
 
-    RCLCPP_INFO(get_logger(), "on_configure() is called.");
+/// Transition callback for state configuring
+/**
+ * on_configure callback is being called when the lifecycle node
+ * enters the "configuring" state.
+ * Depending on the return value of this function, the state machine
+ * either invokes a transition to the "inactive" state or stays
+ * in "unconfigured".
+ * TRANSITION_CALLBACK_SUCCESS transitions to "inactive"
+ * TRANSITION_CALLBACK_FAILURE transitions to "unconfigured"
+ * TRANSITION_CALLBACK_ERROR or any uncaught exceptions to "errorprocessing"
+ */
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+LifecycleTalker::on_configure(const rclcpp_lifecycle::State &)
+{
+  // This callback is supposed to be used for initialization and
+  // configuring purposes.
+  // We thus initialize and configure our publishers and timers.
+  // The lifecycle node API does return lifecycle components such as
+  // lifecycle publishers. These entities obey the lifecycle and
+  // can comply to the current state of the node.
+  // As of the beta version, there is only a lifecycle publisher
+  // available.
+  pub_ = this->create_publisher<std_msgs::msg::String>("lifecycle_chatter", 10);
+  timer_ = this->create_wall_timer(
+    std::chrono::seconds(1), std::bind(&LifecycleTalker::publish, this));
 
-    // We return a success and hence invoke the transition to the next
-    // step: "inactive".
-    // If we returned TRANSITION_CALLBACK_FAILURE instead, the state machine
-    // would stay in the "unconfigured" state.
-    // In case of TRANSITION_CALLBACK_ERROR or any thrown exception within
-    // this callback, the state machine transitions to state "errorprocessing".
-    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
-  }
+  RCLCPP_INFO(this->get_logger(), "on_configure() is called.");
 
-  /// Transition callback for state activating
-  /**
-   * on_activate callback is being called when the lifecycle node
-   * enters the "activating" state.
-   * Depending on the return value of this function, the state machine
-   * either invokes a transition to the "active" state or stays
-   * in "inactive".
-   * TRANSITION_CALLBACK_SUCCESS transitions to "active"
-   * TRANSITION_CALLBACK_FAILURE transitions to "inactive"
-   * TRANSITION_CALLBACK_ERROR or any uncaught exceptions to "errorprocessing"
-   */
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_activate(const rclcpp_lifecycle::State &)
-  {
-    // We explicitly activate the lifecycle publisher.
-    // Starting from this point, all messages are no longer
-    // ignored but sent into the network.
-    pub_->on_activate();
+  // We return a success and hence invoke the transition to the next
+  // step: "inactive".
+  // If we returned TRANSITION_CALLBACK_FAILURE instead, the state machine
+  // would stay in the "unconfigured" state.
+  // In case of TRANSITION_CALLBACK_ERROR or any thrown exception within
+  // this callback, the state machine transitions to state "errorprocessing".
+  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
 
-    RCUTILS_LOG_INFO_NAMED(get_name(), "on_activate() is called.");
+/// Transition callback for state activating
+/**
+ * on_activate callback is being called when the lifecycle node
+ * enters the "activating" state.
+ * Depending on the return value of this function, the state machine
+ * either invokes a transition to the "active" state or stays
+ * in "inactive".
+ * TRANSITION_CALLBACK_SUCCESS transitions to "active"
+ * TRANSITION_CALLBACK_FAILURE transitions to "inactive"
+ * TRANSITION_CALLBACK_ERROR or any uncaught exceptions to "errorprocessing"
+ */
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+LifecycleTalker::on_activate(const rclcpp_lifecycle::State &)
+{
+  // We explicitly activate the lifecycle publisher.
+  // Starting from this point, all messages are no longer
+  // ignored but sent into the network.
+  pub_->on_activate();
 
-    // Let's sleep for 2 seconds.
-    // We emulate we are doing important
-    // work in the activating phase.
-    std::this_thread::sleep_for(2s);
+  RCLCPP_INFO(this->get_logger(), "on_activate() is called.");
 
-    // We return a success and hence invoke the transition to the next
-    // step: "active".
-    // If we returned TRANSITION_CALLBACK_FAILURE instead, the state machine
-    // would stay in the "inactive" state.
-    // In case of TRANSITION_CALLBACK_ERROR or any thrown exception within
-    // this callback, the state machine transitions to state "errorprocessing".
-    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
-  }
+  // Let's sleep for 2 seconds.
+  // We emulate we are doing important
+  // work in the activating phase.
+  std::this_thread::sleep_for(2s);
 
-  /// Transition callback for state deactivating
-  /**
-   * on_deactivate callback is being called when the lifecycle node
-   * enters the "deactivating" state.
-   * Depending on the return value of this function, the state machine
-   * either invokes a transition to the "inactive" state or stays
-   * in "active".
-   * TRANSITION_CALLBACK_SUCCESS transitions to "inactive"
-   * TRANSITION_CALLBACK_FAILURE transitions to "active"
-   * TRANSITION_CALLBACK_ERROR or any uncaught exceptions to "errorprocessing"
-   */
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_deactivate(const rclcpp_lifecycle::State &)
-  {
-    // We explicitly deactivate the lifecycle publisher.
-    // Starting from this point, all messages are no longer
-    // sent into the network.
-    pub_->on_deactivate();
+  // We return a success and hence invoke the transition to the next
+  // step: "active".
+  // If we returned TRANSITION_CALLBACK_FAILURE instead, the state machine
+  // would stay in the "inactive" state.
+  // In case of TRANSITION_CALLBACK_ERROR or any thrown exception within
+  // this callback, the state machine transitions to state "errorprocessing".
+  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
 
-    RCUTILS_LOG_INFO_NAMED(get_name(), "on_deactivate() is called.");
+/// Transition callback for state deactivating
+/**
+ * on_deactivate callback is being called when the lifecycle node
+ * enters the "deactivating" state.
+ * Depending on the return value of this function, the state machine
+ * either invokes a transition to the "inactive" state or stays
+ * in "active".
+ * TRANSITION_CALLBACK_SUCCESS transitions to "inactive"
+ * TRANSITION_CALLBACK_FAILURE transitions to "active"
+ * TRANSITION_CALLBACK_ERROR or any uncaught exceptions to "errorprocessing"
+ */
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+LifecycleTalker::on_deactivate(const rclcpp_lifecycle::State &)
+{
+  // We explicitly deactivate the lifecycle publisher.
+  // Starting from this point, all messages are no longer
+  // sent into the network.
+  pub_->on_deactivate();
 
-    // We return a success and hence invoke the transition to the next
-    // step: "inactive".
-    // If we returned TRANSITION_CALLBACK_FAILURE instead, the state machine
-    // would stay in the "active" state.
-    // In case of TRANSITION_CALLBACK_ERROR or any thrown exception within
-    // this callback, the state machine transitions to state "errorprocessing".
-    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
-  }
+  RCLCPP_INFO(this->get_logger(), "on_deactivate() is called.");
 
-  /// Transition callback for state cleaningup
-  /**
-   * on_cleanup callback is being called when the lifecycle node
-   * enters the "cleaningup" state.
-   * Depending on the return value of this function, the state machine
-   * either invokes a transition to the "unconfigured" state or stays
-   * in "inactive".
-   * TRANSITION_CALLBACK_SUCCESS transitions to "unconfigured"
-   * TRANSITION_CALLBACK_FAILURE transitions to "inactive"
-   * TRANSITION_CALLBACK_ERROR or any uncaught exceptions to "errorprocessing"
-   */
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_cleanup(const rclcpp_lifecycle::State &)
-  {
-    // In our cleanup phase, we release the shared pointers to the
-    // timer and publisher. These entities are no longer available
-    // and our node is "clean".
-    timer_.reset();
-    pub_.reset();
+  // We return a success and hence invoke the transition to the next
+  // step: "inactive".
+  // If we returned TRANSITION_CALLBACK_FAILURE instead, the state machine
+  // would stay in the "active" state.
+  // In case of TRANSITION_CALLBACK_ERROR or any thrown exception within
+  // this callback, the state machine transitions to state "errorprocessing".
+  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
 
-    RCUTILS_LOG_INFO_NAMED(get_name(), "on cleanup is called.");
+/// Transition callback for state cleaningup
+/**
+ * on_cleanup callback is being called when the lifecycle node
+ * enters the "cleaningup" state.
+ * Depending on the return value of this function, the state machine
+ * either invokes a transition to the "unconfigured" state or stays
+ * in "inactive".
+ * TRANSITION_CALLBACK_SUCCESS transitions to "unconfigured"
+ * TRANSITION_CALLBACK_FAILURE transitions to "inactive"
+ * TRANSITION_CALLBACK_ERROR or any uncaught exceptions to "errorprocessing"
+ */
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+LifecycleTalker::on_cleanup(const rclcpp_lifecycle::State &)
+{
+  // In our cleanup phase, we release the shared pointers to the
+  // timer and publisher. These entities are no longer available
+  // and our node is "clean".
+  timer_.reset();
+  pub_.reset();
 
-    // We return a success and hence invoke the transition to the next
-    // step: "unconfigured".
-    // If we returned TRANSITION_CALLBACK_FAILURE instead, the state machine
-    // would stay in the "inactive" state.
-    // In case of TRANSITION_CALLBACK_ERROR or any thrown exception within
-    // this callback, the state machine transitions to state "errorprocessing".
-    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
-  }
+  RCLCPP_INFO(this->get_logger(), "on cleanup is called.");
 
-  /// Transition callback for state shutting down
-  /**
-   * on_shutdown callback is being called when the lifecycle node
-   * enters the "shuttingdown" state.
-   * Depending on the return value of this function, the state machine
-   * either invokes a transition to the "finalized" state or stays
-   * in its current state.
-   * TRANSITION_CALLBACK_SUCCESS transitions to "finalized"
-   * TRANSITION_CALLBACK_FAILURE transitions to current state
-   * TRANSITION_CALLBACK_ERROR or any uncaught exceptions to "errorprocessing"
-   */
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
-  on_shutdown(const rclcpp_lifecycle::State & state)
-  {
-    // In our shutdown phase, we release the shared pointers to the
-    // timer and publisher. These entities are no longer available
-    // and our node is "clean".
-    timer_.reset();
-    pub_.reset();
+  // We return a success and hence invoke the transition to the next
+  // step: "unconfigured".
+  // If we returned TRANSITION_CALLBACK_FAILURE instead, the state machine
+  // would stay in the "inactive" state.
+  // In case of TRANSITION_CALLBACK_ERROR or any thrown exception within
+  // this callback, the state machine transitions to state "errorprocessing".
+  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
 
-    RCUTILS_LOG_INFO_NAMED(
-      get_name(),
-      "on shutdown is called from state %s.",
-      state.label().c_str());
+/// Transition callback for state shutting down
+/**
+ * on_shutdown callback is being called when the lifecycle node
+ * enters the "shuttingdown" state.
+ * Depending on the return value of this function, the state machine
+ * either invokes a transition to the "finalized" state or stays
+ * in its current state.
+ * TRANSITION_CALLBACK_SUCCESS transitions to "finalized"
+ * TRANSITION_CALLBACK_FAILURE transitions to current state
+ * TRANSITION_CALLBACK_ERROR or any uncaught exceptions to "errorprocessing"
+ */
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+LifecycleTalker::on_shutdown(const rclcpp_lifecycle::State & state)
+{
+  // In our shutdown phase, we release the shared pointers to the
+  // timer and publisher. These entities are no longer available
+  // and our node is "clean".
+  timer_.reset();
+  pub_.reset();
 
-    // We return a success and hence invoke the transition to the next
-    // step: "finalized".
-    // If we returned TRANSITION_CALLBACK_FAILURE instead, the state machine
-    // would stay in the current state.
-    // In case of TRANSITION_CALLBACK_ERROR or any thrown exception within
-    // this callback, the state machine transitions to state "errorprocessing".
-    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
-  }
+  RCLCPP_INFO(
+    this->get_logger(),
+    "on shutdown is called from state %s.",
+    state.label().c_str());
 
-private:
-  // We hold an instance of a lifecycle publisher. This lifecycle publisher
-  // can be activated or deactivated regarding on which state the lifecycle node
-  // is in.
-  // By default, a lifecycle publisher is inactive by creation and has to be
-  // activated to publish messages into the ROS world.
-  std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::String>> pub_;
+  // We return a success and hence invoke the transition to the next
+  // step: "finalized".
+  // If we returned TRANSITION_CALLBACK_FAILURE instead, the state machine
+  // would stay in the current state.
+  // In case of TRANSITION_CALLBACK_ERROR or any thrown exception within
+  // this callback, the state machine transitions to state "errorprocessing".
+  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
 
-  // We hold an instance of a timer which periodically triggers the publish function.
-  // As for the beta version, this is a regular timer. In a future version, a
-  // lifecycle timer will be created which obeys the same lifecycle management as the
-  // lifecycle publisher.
-  std::shared_ptr<rclcpp::TimerBase> timer_;
-};
 
 /**
  * A lifecycle node has the same node API

--- a/lifecycle/test/test_lifecycle.py
+++ b/lifecycle/test/test_lifecycle.py
@@ -37,7 +37,7 @@ def generate_test_description():
     )
     listener_node = launch_ros.actions.Node(
         package='lifecycle', executable='lifecycle_listener',
-        name='listener', output='screen'
+        name='listener', namespace='', output='screen'
     )
     return launch.LaunchDescription([
         talker_node, listener_node,


### PR DESCRIPTION
this PR does a few things:
- separate `lifecycle` package to headers and source structure (add `include` directory)
- use `ament_auto` macros to help keep dependencies in check

These are the two big ones, and should help most users get a better grasp of how to implement `LifecycleNodes` going forward, as well as a more "standard" way of writing them.