### PR TITLE
Use sizeof(char) in place for sizeof(void)

### DIFF
--- a/demo_nodes_cpp/src/topics/allocator_tutorial.cpp
+++ b/demo_nodes_cpp/src/topics/allocator_tutorial.cpp
@@ -16,6 +16,7 @@
 #include <list>
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <utility>
 
 #include "rclcpp/rclcpp.hpp"
@@ -56,7 +57,10 @@ public:
       return nullptr;
     }
     num_allocs++;
-    return static_cast<T *>(std::malloc(size * sizeof(T)));
+    // Use sizeof(char) in place for sizeof(void)
+    constexpr size_t value_size = sizeof(
+      typename std::conditional<!std::is_void<T>::value, T, char>::type);
+    return static_cast<T *>(std::malloc(size * value_size));
   }
 
   void deallocate(T * ptr, size_t size)


### PR DESCRIPTION
The latter is invalid C++, even though gcc accepts it as an extension. Connected to https://github.com/ros2/rclcpp/pull/1647.

CI up to `rclcpp` and `demo_nodes_cpp`:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=14524)](http://ci.ros2.org/job/ci_linux/14524/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=9281)](http://ci.ros2.org/job/ci_linux-aarch64/9281/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=12190)](http://ci.ros2.org/job/ci_osx/12190/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=14630)](http://ci.ros2.org/job/ci_windows/14630/)


