### PR TITLE
Revert "Use sizeof(char) in place for sizeof(void) (#515)"

### DIFF
--- a/demo_nodes_cpp/src/topics/allocator_tutorial.cpp
+++ b/demo_nodes_cpp/src/topics/allocator_tutorial.cpp
@@ -16,7 +16,6 @@
 #include <list>
 #include <memory>
 #include <string>
-#include <type_traits>
 #include <utility>
 
 #include "rclcpp/rclcpp.hpp"
@@ -57,10 +56,7 @@ public:
       return nullptr;
     }
     num_allocs++;
-    // Use sizeof(char) in place for sizeof(void)
-    constexpr size_t value_size = sizeof(
-      typename std::conditional<!std::is_void<T>::value, T, char>::type);
-    return static_cast<T *>(std::malloc(size * value_size));
+    return static_cast<T *>(std::malloc(size * sizeof(T)));
   }
 
   void deallocate(T * ptr, size_t size)


### PR DESCRIPTION
This reverts commit c3769dd063e6c16b6fe1d3f2943408a40ff58ec6.

I was wrong. `void` allocators shouldn't behave like `char` allocators. See https://github.com/ros2/rclcpp/pull/1657.