### PR TITLE
Updated deprecated use of scripts_dir and install_scripts

### DIFF
--- a/action_tutorials/action_tutorials_py/setup.cfg
+++ b/action_tutorials/action_tutorials_py/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script_dir=$base/lib/action_tutorials_py
+script-dir=$base/lib/action_tutorials_py
 [install]
-install_scripts=$base/lib/action_tutorials_py
+install-scripts=$base/lib/action_tutorials_py

--- a/demo_nodes_py/setup.cfg
+++ b/demo_nodes_py/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script_dir=$base/lib/demo_nodes_py
+script-dir=$base/lib/demo_nodes_py
 [install]
-install_scripts=$base/lib/demo_nodes_py
+install-scripts=$base/lib/demo_nodes_py

--- a/quality_of_service_demo/rclpy/setup.cfg
+++ b/quality_of_service_demo/rclpy/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script_dir=$base/lib/quality_of_service_demo_py
+script-dir=$base/lib/quality_of_service_demo_py
 [install]
-install_scripts=$base/lib/quality_of_service_demo_py
+install-scripts=$base/lib/quality_of_service_demo_py

--- a/topic_monitor/setup.cfg
+++ b/topic_monitor/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script_dir=$base/lib/topic_monitor
+script-dir=$base/lib/topic_monitor
 [install]
-install_scripts=$base/lib/topic_monitor
+install-scripts=$base/lib/topic_monitor


### PR DESCRIPTION
Compiling this package in ROS 2 Galactic on macOS with Python 3.9 yields a deprecation warning about the use of `scripts_dir` and `install_scripts`. For newer versions of Python and `setuptools`, the correct usage is `scripts-dir` and `install-scripts`.