### PR TITLE
ambigulity: unknown type name 'nullptr_t'

### DIFF
--- a/image_tools/include/image_tools/cv_mat_sensor_msgs_image_type_adapter.hpp
+++ b/image_tools/include/image_tools/cv_mat_sensor_msgs_image_type_adapter.hpp
@@ -87,7 +87,7 @@ class ROSCvMatContainer
 
 public:
   using SensorMsgsImageStorageType = std::variant<
-    nullptr_t,
+    std::nullptr_t,
     std::unique_ptr<sensor_msgs::msg::Image>,
     std::shared_ptr<sensor_msgs::msg::Image>
   >;

--- a/image_tools/include/image_tools/cv_mat_sensor_msgs_image_type_adapter.hpp
+++ b/image_tools/include/image_tools/cv_mat_sensor_msgs_image_type_adapter.hpp
@@ -15,6 +15,7 @@
 #ifndef IMAGE_TOOLS__CV_MAT_SENSOR_MSGS_IMAGE_TYPE_ADAPTER_HPP_
 #define IMAGE_TOOLS__CV_MAT_SENSOR_MSGS_IMAGE_TYPE_ADAPTER_HPP_
 
+#include <cstddef>
 #include <memory>
 #include <variant>  // NOLINT[build/include_order]
 

--- a/image_tools/src/cv_mat_sensor_msgs_image_type_adapter.cpp
+++ b/image_tools/src/cv_mat_sensor_msgs_image_type_adapter.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstddef>
 #include <memory>
 #include <string>
 #include <utility>

--- a/image_tools/src/cv_mat_sensor_msgs_image_type_adapter.cpp
+++ b/image_tools/src/cv_mat_sensor_msgs_image_type_adapter.cpp
@@ -122,7 +122,7 @@ ROSCvMatContainer::ROSCvMatContainer(
 bool
 ROSCvMatContainer::is_owning() const
 {
-  return std::holds_alternative<nullptr_t>(storage_);
+  return std::holds_alternative<std::nullptr_t>(storage_);
 }
 
 const cv::Mat &


### PR DESCRIPTION
Signed-off-by: xwnb <xwnbzc@outlook.com>

When build `ros2/demos image_tools on` Ubuntu, a compile error occurred (using `clang`). Looks like the nullptr_t causes ambiguous between `std::nullptr_t` and `cv::nullptr_t`.

error: 

> error: unknown type name 'nullptr_t'

compile command:

> colcon build --cmake-force-configure --symlink-install

system version:

> Linux version 5.8.0-59-generic (buildd@lcy01-amd64-022) (gcc (Ubuntu 9.3.0-17ubuntu1\~20.04) 9.3.0, GNU ld (GNU Binutils for Ubuntu) 2.34) #66\~20.04.1-Ubuntu SMP Thu Jun 17 11:14:10 UTC 2021

clang version:

> clang version 10.0.0-4ubuntu1 
> Target: x86_64-pc-linux-gnu
> Thread model: posix
> InstalledDir: /usr/bin