### PR TITLE
Use rosidl_get_typesupport_target()

### DIFF
--- a/logging_demo/CMakeLists.txt
+++ b/logging_demo/CMakeLists.txt
@@ -31,8 +31,8 @@ target_compile_definitions(logger_config_component
 ament_target_dependencies(logger_config_component
   "rclcpp"
   "rclcpp_components")
-rosidl_target_interfaces(logger_config_component
-  ${PROJECT_NAME} "rosidl_typesupport_cpp")
+rosidl_get_typesupport_target(cpp_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_cpp")
+target_link_libraries(logger_config_component "${cpp_typesupport_target}")
 rclcpp_components_register_nodes(logger_config_component "logging_demo::LoggerConfig")
 
 add_library(logger_usage_component SHARED


### PR DESCRIPTION
Part of ros2/rosidl#606 which deprecates `rosidl_target_interfaces()` in favor of `rosidl_get_typesupport_target()`