### PR TITLE
Fixing deprecated subscriber callback warnings

### DIFF
--- a/composition/src/listener_component.cpp
+++ b/composition/src/listener_component.cpp
@@ -32,7 +32,7 @@ Listener::Listener(const rclcpp::NodeOptions & options)
   // Create a callback function for when messages are received.
   // Variations of this function also exist using, for example, UniquePtr for zero-copy transport.
   auto callback =
-    [this](const typename std_msgs::msg::String::SharedPtr msg) -> void
+    [this](const typename std_msgs::msg::String::ConstSharedPtr msg) -> void
     {
       RCLCPP_INFO(this->get_logger(), "I heard: [%s]", msg->data.c_str());
       std::flush(std::cout);

--- a/composition/src/node_like_listener_component.cpp
+++ b/composition/src/node_like_listener_component.cpp
@@ -38,7 +38,7 @@ NodeLikeListener::NodeLikeListener(const rclcpp::NodeOptions & options)
   // Create a callback function for when messages are received.
   // Variations of this function also exist using, for example, UniquePtr for zero-copy transport.
   auto callback =
-    [this](const typename std_msgs::msg::String::SharedPtr msg) -> void
+    [this](const typename std_msgs::msg::String::ConstSharedPtr msg) -> void
     {
       RCLCPP_INFO(this->node_->get_logger(), "I heard: [%s]", msg->data.c_str());
       std::flush(std::cout);

--- a/demo_nodes_cpp/src/parameters/parameter_events.cpp
+++ b/demo_nodes_cpp/src/parameters/parameter_events.cpp
@@ -24,7 +24,7 @@
 using namespace std::chrono_literals;
 
 bool on_parameter_event(
-  const rcl_interfaces::msg::ParameterEvent::SharedPtr event, rclcpp::Logger logger)
+  rcl_interfaces::msg::ParameterEvent::UniquePtr event, rclcpp::Logger logger)
 {
   // TODO(wjwwood): The message should have an operator<<, which would replace all of this.
   std::stringstream ss;
@@ -86,10 +86,10 @@ int main(int argc, char ** argv)
   // Setup callback for changes to parameters.
   auto sub = parameters_client->on_parameter_event(
     [node, promise = std::move(events_received_promise)](
-      const rcl_interfaces::msg::ParameterEvent::SharedPtr event) -> void
+      rcl_interfaces::msg::ParameterEvent::UniquePtr event) -> void
     {
       static size_t n_times_called = 0u;
-      if (on_parameter_event(event, node->get_logger())) {
+      if (on_parameter_event(std::move(event), node->get_logger())) {
         ++n_times_called;
       }
       if (10u == n_times_called) {

--- a/demo_nodes_cpp/src/parameters/parameter_events_async.cpp
+++ b/demo_nodes_cpp/src/parameters/parameter_events_async.cpp
@@ -41,7 +41,7 @@ public:
     parameters_client_ = std::make_shared<rclcpp::AsyncParametersClient>(this);
 
     auto on_parameter_event_callback =
-      [this](const rcl_interfaces::msg::ParameterEvent::SharedPtr event) -> void
+      [this](rcl_interfaces::msg::ParameterEvent::UniquePtr event) -> void
       {
         // ignore qos overrides
         event->new_parameters.erase(

--- a/demo_nodes_cpp/src/topics/allocator_tutorial.cpp
+++ b/demo_nodes_cpp/src/topics/allocator_tutorial.cpp
@@ -177,7 +177,7 @@ int main(int argc, char ** argv)
   }
 
   uint32_t counter = 0;
-  auto callback = [&counter](std_msgs::msg::UInt32::SharedPtr msg) -> void
+  auto callback = [&counter](std_msgs::msg::UInt32::ConstSharedPtr msg) -> void
     {
       (void)msg;
       ++counter;

--- a/demo_nodes_cpp/src/topics/listener.cpp
+++ b/demo_nodes_cpp/src/topics/listener.cpp
@@ -34,7 +34,7 @@ public:
     // Variations of this function also exist using, for example UniquePtr for zero-copy transport.
     setvbuf(stdout, NULL, _IONBF, BUFSIZ);
     auto callback =
-      [this](const std_msgs::msg::String::SharedPtr msg) -> void
+      [this](const std_msgs::msg::String::ConstSharedPtr msg) -> void
       {
         RCLCPP_INFO(this->get_logger(), "I heard: [%s]", msg->data.c_str());
       };

--- a/demo_nodes_cpp/src/topics/listener_best_effort.cpp
+++ b/demo_nodes_cpp/src/topics/listener_best_effort.cpp
@@ -32,7 +32,7 @@ public:
   {
     setvbuf(stdout, NULL, _IONBF, BUFSIZ);
     auto callback =
-      [this](const typename std_msgs::msg::String::SharedPtr msg) -> void
+      [this](const typename std_msgs::msg::String::ConstSharedPtr msg) -> void
       {
         RCLCPP_INFO(this->get_logger(), "I heard: [%s]", msg->data.c_str());
       };

--- a/image_tools/src/cam2image.cpp
+++ b/image_tools/src/cam2image.cpp
@@ -82,7 +82,7 @@ private:
 
     // Subscribe to a message that will toggle flipping or not flipping, and manage the state in a
     // callback
-    auto callback = [this](const std_msgs::msg::Bool::SharedPtr msg) -> void
+    auto callback = [this](const std_msgs::msg::Bool::ConstSharedPtr msg) -> void
       {
         this->is_flipped_ = msg->data;
         RCLCPP_INFO(this->get_logger(), "Set flip mode to: %s", this->is_flipped_ ? "on" : "off");

--- a/intra_process_demo/include/image_pipeline/image_view_node.hpp
+++ b/intra_process_demo/include/image_pipeline/image_view_node.hpp
@@ -37,12 +37,12 @@ public:
     sub_ = this->create_subscription<sensor_msgs::msg::Image>(
       input,
       rclcpp::SensorDataQoS(),
-      [node_name, watermark](const sensor_msgs::msg::Image::SharedPtr msg) {
+      [node_name, watermark](const sensor_msgs::msg::Image::ConstSharedPtr msg) {
         // Create a cv::Mat from the image message (without copying).
         cv::Mat cv_mat(
           msg->height, msg->width,
           encoding2mat_type(msg->encoding),
-          msg->data.data());
+          const_cast<unsigned char *>(msg->data.data()));
         if (watermark) {
           // Annotate with the pid and pointer address.
           std::stringstream ss;

--- a/lifecycle/src/lifecycle_listener.cpp
+++ b/lifecycle/src/lifecycle_listener.cpp
@@ -51,12 +51,12 @@ public:
       std::bind(&LifecycleListener::notification_callback, this, std::placeholders::_1));
   }
 
-  void data_callback(const std_msgs::msg::String::SharedPtr msg)
+  void data_callback(const std_msgs::msg::String::ConstSharedPtr msg)
   {
     RCLCPP_INFO(get_logger(), "data_callback: %s", msg->data.c_str());
   }
 
-  void notification_callback(const lifecycle_msgs::msg::TransitionEvent::SharedPtr msg)
+  void notification_callback(const lifecycle_msgs::msg::TransitionEvent::ConstSharedPtr msg)
   {
     RCLCPP_INFO(
       get_logger(), "notify callback: Transition from state %s to %s",

--- a/quality_of_service_demo/rclcpp/src/common_nodes.cpp
+++ b/quality_of_service_demo/rclcpp/src/common_nodes.cpp
@@ -159,7 +159,7 @@ Listener::start_listening()
     subscription_ = create_subscription<std_msgs::msg::String>(
       topic_name_,
       qos_profile_,
-      [this](const typename std_msgs::msg::String::SharedPtr msg) -> void
+      [this](const typename std_msgs::msg::String::ConstSharedPtr msg) -> void
       {
         RCLCPP_INFO(get_logger(), "Listener heard: [%s]", msg->data.c_str());
       },

--- a/quality_of_service_demo/rclcpp/src/message_lost_listener.cpp
+++ b/quality_of_service_demo/rclcpp/src/message_lost_listener.cpp
@@ -30,7 +30,7 @@ public:
   {
     // Callback that will be used when a message is received.
     auto callback =
-      [this](const sensor_msgs::msg::Image::SharedPtr msg) -> void
+      [this](const sensor_msgs::msg::Image::ConstSharedPtr msg) -> void
       {
         rclcpp::Time now = this->get_clock()->now();
         auto diff = now - msg->header.stamp;

--- a/quality_of_service_demo/rclcpp/src/qos_overrides_listener.cpp
+++ b/quality_of_service_demo/rclcpp/src/qos_overrides_listener.cpp
@@ -31,7 +31,7 @@ public:
   {
     // Callback that will be used when a message is received.
     auto callback =
-      [this](const sensor_msgs::msg::Image::SharedPtr msg) -> void
+      [this](const sensor_msgs::msg::Image::ConstSharedPtr msg) -> void
       {
         rclcpp::Time now = this->get_clock()->now();
         auto diff = now - msg->header.stamp;

--- a/topic_statistics_demo/src/imu_talker_listener_nodes.cpp
+++ b/topic_statistics_demo/src/imu_talker_listener_nodes.cpp
@@ -81,7 +81,7 @@ void ImuListener::start_listening()
     subscription_ = create_subscription<sensor_msgs::msg::Imu>(
       topic_name_,
       10,  /* QoS history_depth */
-      [this](const typename sensor_msgs::msg::Imu::SharedPtr msg) -> void
+      [this](const typename sensor_msgs::msg::Imu::ConstSharedPtr msg) -> void
       {
         RCLCPP_DEBUG(get_logger(), "Listener heard: %u", msg->header.stamp.nanosec);
       },

--- a/topic_statistics_demo/src/string_talker_listener_nodes.cpp
+++ b/topic_statistics_demo/src/string_talker_listener_nodes.cpp
@@ -70,7 +70,7 @@ void StringListener::start_listening()
     subscription_ = create_subscription<std_msgs::msg::String>(
       topic_name_,
       10,  /**QoS history_depth */
-      [this](const typename std_msgs::msg::String::SharedPtr msg) -> void
+      [this](const typename std_msgs::msg::String::ConstSharedPtr msg) -> void
       {
         RCLCPP_DEBUG(get_logger(), "Listener heard: [%s]", msg->data.c_str());
       },

--- a/topic_statistics_demo/src/topic_statistics_listener.cpp
+++ b/topic_statistics_demo/src/topic_statistics_listener.cpp
@@ -36,7 +36,7 @@ void TopicStatisticsListener::start_listening()
     subscription_ = create_subscription<statistics_msgs::msg::MetricsMessage>(
       topic_name_,
       10,  /* QoS history_depth */
-      [this](const typename statistics_msgs::msg::MetricsMessage::SharedPtr msg) -> void
+      [this](const typename statistics_msgs::msg::MetricsMessage::ConstSharedPtr msg) -> void
       {
         RCLCPP_INFO(get_logger(), "Statistics heard:\n%s", MetricsMessageToString(*msg).c_str());
       },


### PR DESCRIPTION
ros2/rclcpp#1713 deprecates the void shared_ptr<T> subscription callback signatures, so this PR migrates away from said signatures.

This patch affects the following packages:
- Composition
- Intra process
- Lifecycle
- Topic statistics
- Quality of services
- Image tools
- Demo nodes C++

Signed-off-by: Abrar Rahman Protyasha <abrar@openrobotics.org>