### PR TITLE
Fixed typo executor -> executors

### DIFF
--- a/demo_nodes_py/demo_nodes_py/topics/listener.py
+++ b/demo_nodes_py/demo_nodes_py/topics/listener.py
@@ -15,7 +15,7 @@
 import sys
 
 import rclpy
-from rclpy.executor import ExternalShutdownException
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 from std_msgs.msg import String


### PR DESCRIPTION
quick fix of a typo which prevented the `listener` node from running.