### PR TITLE
Install includes to include/${PROJECT_NAME}

### DIFF
--- a/image_tools/CMakeLists.txt
+++ b/image_tools/CMakeLists.txt
@@ -18,8 +18,6 @@ find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(OpenCV REQUIRED COMPONENTS core highgui imgcodecs imgproc videoio)
 
-include_directories(include)
-
 add_library(${PROJECT_NAME} SHARED
   src/burger.cpp
   src/cam2image.cpp
@@ -30,13 +28,13 @@ target_compile_definitions(${PROJECT_NAME}
   PRIVATE "IMAGE_TOOLS_BUILDING_DLL")
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>")
-ament_target_dependencies(${PROJECT_NAME}
-  "rclcpp"
-  "sensor_msgs"
-  "std_msgs"
-  "rclcpp_components"
-  "OpenCV")
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+target_link_libraries(${PROJECT_NAME}
+  rclcpp::rclcpp
+  ${sensor_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+  rclcpp_components::component
+  ${OpenCV_LIBS})
 rclcpp_components_register_node(${PROJECT_NAME} PLUGIN "image_tools::Cam2Image" EXECUTABLE cam2image)
 rclcpp_components_register_node(${PROJECT_NAME} PLUGIN "image_tools::ShowImage" EXECUTABLE showimage)
 
@@ -46,12 +44,8 @@ install(
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)
 
-install(
-  DIRECTORY include/
-  DESTINATION include
-)
+install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 
-ament_export_libraries(${PROJECT_NAME})
 ament_export_targets(${PROJECT_NAME})
 
 ament_export_dependencies(rclcpp_components)

--- a/image_tools/CMakeLists.txt
+++ b/image_tools/CMakeLists.txt
@@ -46,6 +46,9 @@ install(
 
 install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 
+# TODO(sloretz) stop exporting old-style CMake variables in the future
+ament_export_libraries(${PROJECT_NAME})
+
 ament_export_targets(${PROJECT_NAME})
 
 ament_export_dependencies(rclcpp_components)

--- a/intra_process_demo/CMakeLists.txt
+++ b/intra_process_demo/CMakeLists.txt
@@ -12,15 +12,15 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(builtin_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rmw REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 
-find_package(OpenCV REQUIRED)
+find_package(OpenCV REQUIRED COMPONENTS core highgui videoio)
 
 include_directories(include)
-ament_export_include_directories(include)
 
 ##
 ## Demos
@@ -29,56 +29,66 @@ ament_export_include_directories(include)
 # Simple example of using unique_ptr to minimize copies.
 add_executable(two_node_pipeline
   src/two_node_pipeline/two_node_pipeline.cpp)
-ament_target_dependencies(two_node_pipeline
-  "rclcpp"
-  "std_msgs")
+target_link_libraries(two_node_pipeline
+  rclcpp::rclcpp
+  ${std_msgs_TARGETS})
 
   # Simple example of a cyclic pipeline which uses no allocation while iterating.
 add_executable(cyclic_pipeline
   src/cyclic_pipeline/cyclic_pipeline.cpp)
-ament_target_dependencies(cyclic_pipeline
-  "rclcpp"
-  "std_msgs")
+target_link_libraries(cyclic_pipeline
+  rclcpp::rclcpp
+  ${std_msgs_TARGETS})
 
 # A single program with one of each of the image pipeline demo nodes.
 add_executable(image_pipeline_all_in_one
   src/image_pipeline/image_pipeline_all_in_one.cpp)
-ament_target_dependencies(image_pipeline_all_in_one
-  "rclcpp"
-  "sensor_msgs"
-  "OpenCV")
+target_link_libraries(image_pipeline_all_in_one
+  rclcpp::rclcpp
+  ${builtin_interfaces_TARGETS}
+  ${sensor_msgs_TARGETS}
+  opencv_core
+  opencv_highgui)
 
 # A single program with one of each of the image pipeline demo nodes, but two image views.
 add_executable(image_pipeline_with_two_image_view
   src/image_pipeline/image_pipeline_with_two_image_view.cpp)
-ament_target_dependencies(image_pipeline_with_two_image_view
-  "rclcpp"
-  "sensor_msgs"
-  "OpenCV")
+target_link_libraries(image_pipeline_with_two_image_view
+  rclcpp::rclcpp
+  ${builtin_interfaces_TARGETS}
+  ${sensor_msgs_TARGETS}
+  opencv_core
+  opencv_highgui)
 
 # A stand alone node which produces images from a camera using OpenCV.
 add_executable(camera_node
   src/image_pipeline/camera_node.cpp)
-ament_target_dependencies(camera_node
-  "rclcpp"
-  "sensor_msgs"
-  "OpenCV")
+target_link_libraries(camera_node
+  rclcpp::rclcpp
+  ${builtin_interfaces_TARGETS}
+  ${sensor_msgs_TARGETS}
+  opencv_core
+  opencv_highgui)
 
 # A stand alone node which adds some text to an image using OpenCV before passing it along.
 add_executable(watermark_node
   src/image_pipeline/watermark_node.cpp)
-ament_target_dependencies(watermark_node
-  "rclcpp"
-  "sensor_msgs"
-  "OpenCV")
+target_link_libraries(watermark_node
+  rclcpp::rclcpp
+  ${builtin_interfaces_TARGETS}
+  ${sensor_msgs_TARGETS}
+  opencv_core
+  opencv_videoio)
 
 # A stand alone node which consumes images and displays them using OpenCV.
 add_executable(image_view_node
   src/image_pipeline/image_view_node.cpp)
-ament_target_dependencies(image_view_node
-  "rclcpp"
-  "sensor_msgs"
-  "OpenCV")
+target_link_libraries(image_view_node
+  rclcpp::rclcpp
+  ${builtin_interfaces_TARGETS}
+  ${sensor_msgs_TARGETS}
+  opencv_core
+  opencv_highgui)
 
 install(TARGETS
   two_node_pipeline
@@ -90,10 +100,7 @@ install(TARGETS
   image_view_node
   DESTINATION lib/${PROJECT_NAME})
 
-install(
-  DIRECTORY include/
-  DESTINATION include
-)
+install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/intra_process_demo/CMakeLists.txt
+++ b/intra_process_demo/CMakeLists.txt
@@ -21,6 +21,8 @@ find_package(std_msgs REQUIRED)
 find_package(OpenCV REQUIRED COMPONENTS core highgui videoio)
 
 include_directories(include)
+# TODO(sloretz) stop exporting old-style CMake variables in the future
+ament_export_include_directories("include/${PROJECT_NAME}")
 
 ##
 ## Demos

--- a/quality_of_service_demo/rclcpp/CMakeLists.txt
+++ b/quality_of_service_demo/rclcpp/CMakeLists.txt
@@ -20,7 +20,8 @@ find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 
 include_directories(include)
-
+# TODO(sloretz) stop exporting old-style CMake variables in the future
+ament_export_include_directories("include/${PROJECT_NAME}")
 
 function(qos_demo_executable target)
   add_executable(${target}

--- a/quality_of_service_demo/rclcpp/CMakeLists.txt
+++ b/quality_of_service_demo/rclcpp/CMakeLists.txt
@@ -20,18 +20,17 @@ find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 
 include_directories(include)
-ament_export_include_directories(include)
+
 
 function(qos_demo_executable target)
   add_executable(${target}
     src/${target}.cpp
     src/common_nodes.cpp
     src/utils.cpp)
-  ament_target_dependencies(${target}
-    "rclcpp"
-    "rcutils"
-    "std_msgs"
-  )
+  target_link_libraries(${target}
+    rclcpp::rclcpp
+    rcutils::rcutils
+    ${std_msgs_TARGETS})
   install(TARGETS ${target} DESTINATION lib/${PROJECT_NAME})
 endfunction()
 
@@ -45,12 +44,11 @@ qos_demo_executable(incompatible_qos)
 add_library(message_lost SHARED
   src/message_lost_listener.cpp
   src/message_lost_talker.cpp)
-ament_target_dependencies(message_lost
-  "rclcpp"
-  "rclcpp_components"
-  "rcutils"
-  "sensor_msgs"
-)
+target_link_libraries(message_lost
+  rclcpp::rclcpp
+  rclcpp_components::component
+  rcutils::rcutils
+  ${sensor_msgs_TARGETS})
 target_compile_definitions(message_lost
   PRIVATE "QUALITY_OF_SERVICE_DEMO_BUILDING_DLL")
 rclcpp_components_register_node(message_lost
@@ -64,12 +62,11 @@ add_library(qos_overrides SHARED
   src/qos_overrides_listener.cpp
   src/qos_overrides_talker.cpp
 )
-ament_target_dependencies(qos_overrides
-  "rclcpp"
-  "rclcpp_components"
-  "rcutils"
-  "sensor_msgs"
-)
+target_link_libraries(qos_overrides
+  rclcpp::rclcpp
+  rclcpp_components::component
+  rcutils::rcutils
+  ${sensor_msgs_TARGETS})
 target_compile_definitions(qos_overrides
   PRIVATE "QUALITY_OF_SERVICE_DEMO_BUILDING_DLL")
 rclcpp_components_register_node(qos_overrides

--- a/topic_statistics_demo/CMakeLists.txt
+++ b/topic_statistics_demo/CMakeLists.txt
@@ -18,18 +18,18 @@ find_package(sensor_msgs REQUIRED)
 find_package(statistics_msgs REQUIRED)
 
 include_directories(include)
-ament_export_include_directories(include)
+
 
 add_executable(display_topic_statistics
   src/imu_talker_listener_nodes.cpp
   src/display_topic_statistics.cpp
   src/string_talker_listener_nodes.cpp
   src/topic_statistics_listener.cpp)
-ament_target_dependencies(display_topic_statistics
-  "rclcpp"
-  "rcutils"
-  "sensor_msgs"
-  "statistics_msgs")
+target_link_libraries(display_topic_statistics
+  rclcpp::rclcpp
+  rcutils::rcutils
+  ${sensor_msgs_TARGETS}
+  ${statistics_msgs_TARGETS})
 install(TARGETS display_topic_statistics DESTINATION lib/${PROJECT_NAME})
 
 if(BUILD_TESTING)

--- a/topic_statistics_demo/CMakeLists.txt
+++ b/topic_statistics_demo/CMakeLists.txt
@@ -18,7 +18,8 @@ find_package(sensor_msgs REQUIRED)
 find_package(statistics_msgs REQUIRED)
 
 include_directories(include)
-
+# TODO(sloretz) stop exporting old-style CMake variables in the future
+ament_export_include_directories("include/${PROJECT_NAME}")
 
 add_executable(display_topic_statistics
   src/imu_talker_listener_nodes.cpp


### PR DESCRIPTION
Part of ros2/ros2#1150

This installs includes to `include/${PROJECT_NAME}` to mitigate include directory search order issues when overriding packages in desktop.

~Part of ament/ament_cmake#365~

~This removes `ament_export_libraries` and `ament_export_include_directories` as they're redundant with the exported CMake targets.~ **Edit: Added back old-style CMake variables to minimize disruption**

Part of ament/ament_cmake#292

This replaces `ament_target_dependencies()` calls with `target_link_libraries()`.


Requires ros2/rclcpp#1855 for the `rclcpp_components::component` target.
