### PR TITLE
Reduce the number of OpenCV libraries image_tools links against.

### DIFF
--- a/image_tools/CMakeLists.txt
+++ b/image_tools/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
-find_package(OpenCV REQUIRED)
+find_package(OpenCV REQUIRED COMPONENTS core highgui imgcodecs imgproc videoio)
 
 include_directories(include)
 

--- a/image_tools/include/image_tools/cv_mat_sensor_msgs_image_type_adapter.hpp
+++ b/image_tools/include/image_tools/cv_mat_sensor_msgs_image_type_adapter.hpp
@@ -19,7 +19,8 @@
 #include <memory>
 #include <variant>  // NOLINT[build/include_order]
 
-#include "opencv2/opencv.hpp"
+#include "opencv2/core/mat.hpp"
+
 #include "rclcpp/type_adapter.hpp"
 #include "sensor_msgs/msg/image.hpp"
 

--- a/image_tools/src/burger.cpp
+++ b/image_tools/src/burger.cpp
@@ -22,7 +22,12 @@
 #include <vector>
 
 #include "./burger.hpp"
-#include "opencv2/imgproc/imgproc.hpp"
+
+#include "opencv2/core.hpp"
+#include "opencv2/core/mat.hpp"
+#include "opencv2/core/types.hpp"
+#include "opencv2/imgcodecs.hpp"
+#include "opencv2/imgproc.hpp"
 
 using burger::Burger;  // i've always wanted to write that
 

--- a/image_tools/src/burger.hpp
+++ b/image_tools/src/burger.hpp
@@ -17,7 +17,7 @@
 
 #include <vector>
 
-#include "opencv2/highgui/highgui.hpp"
+#include "opencv2/core/mat.hpp"
 
 #include "image_tools/visibility_control.h"
 

--- a/image_tools/src/cam2image.cpp
+++ b/image_tools/src/cam2image.cpp
@@ -19,7 +19,10 @@
 #include <utility>
 #include <vector>
 
-#include "opencv2/highgui/highgui.hpp"
+#include "opencv2/core/mat.hpp"
+#include "opencv2/core.hpp"
+#include "opencv2/highgui.hpp"
+#include "opencv2/videoio.hpp"
 
 #include "rcl_interfaces/msg/parameter_descriptor.hpp"
 #include "rclcpp/rclcpp.hpp"

--- a/image_tools/src/cv_mat_sensor_msgs_image_type_adapter.cpp
+++ b/image_tools/src/cv_mat_sensor_msgs_image_type_adapter.cpp
@@ -18,6 +18,8 @@
 #include <utility>
 #include <variant>  // NOLINT[build/include_order]
 
+#include "opencv2/core/mat.hpp"
+
 #include "sensor_msgs/msg/image.hpp"
 #include "std_msgs/msg/header.hpp"
 

--- a/image_tools/src/showimage.cpp
+++ b/image_tools/src/showimage.cpp
@@ -17,8 +17,9 @@
 #include <string>
 #include <vector>
 
-#include "opencv2/highgui/highgui.hpp"
-#include "opencv2/imgproc/imgproc.hpp"
+#include "opencv2/core/mat.hpp"
+#include "opencv2/highgui.hpp"
+#include "opencv2/imgproc.hpp"
 
 #include "rcl_interfaces/msg/parameter_descriptor.hpp"
 #include "rclcpp/rclcpp.hpp"


### PR DESCRIPTION
By using the OpenCV components, we only pull in the parts we
need, slightly speeding things up.  While we are in here, we
also only include the headers we need, and use the "newer"
name of the headers instead of the legacy ones.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>