### PR TITLE
Add opencv_imgproc dependency for cv::putText

### DIFF
--- a/intra_process_demo/CMakeLists.txt
+++ b/intra_process_demo/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(rmw REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 
-find_package(OpenCV REQUIRED COMPONENTS core highgui videoio)
+find_package(OpenCV REQUIRED COMPONENTS core highgui imgproc videoio)
 
 include_directories(include)
 # TODO(sloretz) stop exporting old-style CMake variables in the future
@@ -70,7 +70,8 @@ target_link_libraries(camera_node
   ${builtin_interfaces_TARGETS}
   ${sensor_msgs_TARGETS}
   opencv_core
-  opencv_highgui)
+  opencv_highgui
+  opencv_imgproc)
 
 # A stand alone node which adds some text to an image using OpenCV before passing it along.
 add_executable(watermark_node


### PR DESCRIPTION
This is an attempt to fix https://ci.ros2.org/view/packaging/job/packaging_windows/2367/console

I don't yet understand why this wasn't caught in CI https://github.com/ros2/demos/pull/548#issuecomment-1017745553