### PR TITLE
Cleanups in demo_nodes_py.

### DIFF
--- a/demo_nodes_py/demo_nodes_py/services/add_two_ints_client.py
+++ b/demo_nodes_py/demo_nodes_py/services/add_two_ints_client.py
@@ -36,7 +36,7 @@ def main(args=None):
         node.get_logger().error('Exception while calling service: %r' % future.exception())
 
     node.destroy_node()
-    rclpy.shutdown()
+    rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/demo_nodes_py/demo_nodes_py/services/add_two_ints_client_async.py
+++ b/demo_nodes_py/demo_nodes_py/services/add_two_ints_client_async.py
@@ -41,7 +41,7 @@ def main(args=None):
             break
 
     node.destroy_node()
-    rclpy.shutdown()
+    rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/demo_nodes_py/demo_nodes_py/services/add_two_ints_server.py
+++ b/demo_nodes_py/demo_nodes_py/services/add_two_ints_server.py
@@ -48,8 +48,8 @@ def main(args=None):
     finally:
         # Destroy the node explicitly
         # (optional - Done automatically when node is garbage collected)
-        rclpy.try_shutdown()
         node.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/demo_nodes_py/demo_nodes_py/topics/listener_qos.py
+++ b/demo_nodes_py/demo_nodes_py/topics/listener_qos.py
@@ -16,6 +16,7 @@ import argparse
 import sys
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from rclpy.qos import qos_profile_sensor_data
 from rclpy.qos import QoSProfile
@@ -63,12 +64,17 @@ def main(argv=sys.argv[1:]):
     node = ListenerQos(custom_qos_profile)
 
     cycle_count = 0
-    while rclpy.ok() and cycle_count < args.number_of_cycles:
-        rclpy.spin_once(node)
-        cycle_count += 1
-
-    node.destroy_node()
-    rclpy.shutdown()
+    try:
+        while rclpy.ok() and cycle_count < args.number_of_cycles:
+            rclpy.spin_once(node)
+            cycle_count += 1
+    except KeyboardInterrupt:
+        pass
+    except ExternalShutdownException:
+        sys.exit(1)
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/demo_nodes_py/demo_nodes_py/topics/listener_serialized.py
+++ b/demo_nodes_py/demo_nodes_py/topics/listener_serialized.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 from std_msgs.msg import String
@@ -38,13 +41,18 @@ def main(args=None):
 
     serialized_subscriber = SerializedSubscriber()
 
-    rclpy.spin(serialized_subscriber)
-
-    # Destroy the node explicitly
-    # (optional - otherwise it will be done automatically
-    # when the garbage collector destroys the node object)
-    serialized_subscriber.destroy_node()
-    rclpy.shutdown()
+    try:
+        rclpy.spin(serialized_subscriber)
+    except KeyboardInterrupt:
+        pass
+    except ExternalShutdownException:
+        sys.exit(1)
+    finally:
+        # Destroy the node explicitly
+        # (optional - otherwise it will be done automatically
+        # when the garbage collector destroys the node object)
+        serialized_subscriber.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/demo_nodes_py/demo_nodes_py/topics/talker.py
+++ b/demo_nodes_py/demo_nodes_py/topics/talker.py
@@ -50,8 +50,8 @@ def main(args=None):
     except ExternalShutdownException:
         sys.exit(1)
     finally:
-        rclpy.try_shutdown()
         node.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/demo_nodes_py/demo_nodes_py/topics/talker_qos.py
+++ b/demo_nodes_py/demo_nodes_py/topics/talker_qos.py
@@ -16,6 +16,7 @@ import argparse
 import sys
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from rclpy.qos import qos_profile_sensor_data
 from rclpy.qos import QoSProfile
@@ -70,12 +71,17 @@ def main(argv=sys.argv[1:]):
     node = TalkerQos(custom_qos_profile)
 
     cycle_count = 0
-    while rclpy.ok() and cycle_count < args.number_of_cycles:
-        rclpy.spin_once(node)
-        cycle_count += 1
-
-    node.destroy_node()
-    rclpy.shutdown()
+    try:
+        while rclpy.ok() and cycle_count < args.number_of_cycles:
+            rclpy.spin_once(node)
+            cycle_count += 1
+    except KeyboardInterrupt:
+        pass
+    except ExternalShutdownException:
+        sys.exit(1)
+    finally:
+        node.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The following fixes are made:

* Ensure that the node is destroyed before calling rclpy.shutdown()
* Make sure that shutdown always uses rclpy.try_shutdown()
* Make sure to catch KeyboardInterrupt errors everywhere

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Fixes #553 