### PR TITLE
Make lifecycle demo automatically exit when done

### DIFF
--- a/lifecycle/launch/lifecycle_demo.launch.py
+++ b/lifecycle/launch/lifecycle_demo.launch.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from launch import LaunchDescription
+from launch.actions import Shutdown
 from launch_ros.actions import LifecycleNode
 from launch_ros.actions import Node
 
@@ -22,5 +23,6 @@ def generate_launch_description():
         LifecycleNode(package='lifecycle', executable='lifecycle_talker',
                       name='lc_talker', namespace='', output='screen'),
         Node(package='lifecycle', executable='lifecycle_listener', output='screen'),
-        Node(package='lifecycle', executable='lifecycle_service_client', output='screen')
+        Node(package='lifecycle', executable='lifecycle_service_client', output='screen',
+             on_exit=Shutdown()),
     ])


### PR DESCRIPTION
Fixes #504

This makes the lifecyle demo automatically exit when it's completed. First this PR fixes a bug in `lifecycle_service_client` where it's stuck waiting for the future to complete forever because of ros2/rclcpp#1916. Next this PR adds a `Shutdown` action to the `on_exit` argument of the `lifecycle_service_client` `Node` so that when it shuts down the other nodes are killed too.