### PR TITLE
counter starts from 1, not 2.

### DIFF
--- a/demo_nodes_cpp/src/topics/talker_loaned_message.cpp
+++ b/demo_nodes_cpp/src/topics/talker_loaned_message.cpp
@@ -55,7 +55,6 @@ public:
     auto publish_message =
       [this]() -> void
       {
-        count_++;
         // We loan a message here and don't allocate the memory on the stack.
         // For middlewares which support message loaning, this means the middleware
         // completely owns the memory for this message.
@@ -82,6 +81,7 @@ public:
         non_pod_loaned_msg.get().data = non_pod_msg_data;
         RCLCPP_INFO(this->get_logger(), "Publishing: '%s'", non_pod_msg_data.c_str());
         non_pod_pub_->publish(std::move(non_pod_loaned_msg));
+        count_++;
       };
 
     // Create a publisher with a custom Quality of Service profile.


### PR DESCRIPTION
- before

```bash
root@tomoyafujita:~/ros2_ws/colcon_ws# ros2 run demo_nodes_cpp talker_loaned_message
[INFO] [1652204561.364158816] [loaned_message_talker]: Publishing: '2.000000'
[INFO] [1652204561.364556243] [rclcpp]: Currently used middleware can't loan messages. Local allocator will be used.
[INFO] [1652204561.364600686] [loaned_message_talker]: Publishing: 'Hello World: 2'
...<snip>
```

- after

```bash
root@tomoyafujita:~/ros2_ws/colcon_ws# ros2 run demo_nodes_cpp talker_loaned_message
[INFO] [1652205700.592875942] [loaned_message_talker]: Publishing: '1.000000'
[INFO] [1652205700.593295376] [rclcpp]: Currently used middleware can't loan messages. Local allocator will be used.
[INFO] [1652205700.593366279] [loaned_message_talker]: Publishing: 'Hello World: 1'
[INFO] [1652205701.592808672] [loaned_message_talker]: Publishing: '2.000000'
[INFO] [1652205701.592999875] [loaned_message_talker]: Publishing: 'Hello World: 2'
...<snip>
```

Signed-off-by: Tomoya Fujita <Tomoya.Fujita@sony.com>