### PR TITLE
Fix two small bugs in the fibonacci C++ tutorial.

### DIFF
--- a/action_tutorials/action_tutorials_cpp/src/fibonacci_action_client.cpp
+++ b/action_tutorials/action_tutorials_cpp/src/fibonacci_action_client.cpp
@@ -85,6 +85,7 @@ private:
   {
     if (!goal_handle) {
       RCLCPP_ERROR(this->get_logger(), "Goal was rejected by server");
+      rclcpp::shutdown();
     } else {
       RCLCPP_INFO(this->get_logger(), "Goal accepted by server, waiting for result");
     }

--- a/action_tutorials/action_tutorials_cpp/src/fibonacci_action_server.cpp
+++ b/action_tutorials/action_tutorials_cpp/src/fibonacci_action_server.cpp
@@ -55,10 +55,12 @@ private:
     const rclcpp_action::GoalUUID & uuid,
     std::shared_ptr<const Fibonacci::Goal> goal)
   {
-    RCLCPP_INFO(this->get_logger(), "Received goal request with order %d", goal->order);
     (void)uuid;
-    // Let's reject sequences that are over 9000
-    if (goal->order > 9000) {
+    RCLCPP_INFO(this->get_logger(), "Received goal request with order %d", goal->order);
+    // The Fibonacci action uses int32 for the return of sequences, which means it can only
+    // hold 2^31-1 (2147483647) before wrapping negative in two's complement.  Based on empirical
+    // tests, that means that an order of > 46 will cause wrapping, so we don't allow that here.
+    if (goal->order > 46) {
       return rclcpp_action::GoalResponse::REJECT;
     }
     return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;


### PR DESCRIPTION
The first bug has to do with the action client, and what happens
if the server rejects the goal.  In the current code, the
client would just hang around forever.  If the server rejects
the goal, make sure the client shuts down.

The second bug has to do with the size that the action server
can support.  The code has more information, but essentially
because of the Fibonacci action message, we can only support
sequences up to order 46; anything larger than that will cause
integer wrapping.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>