### PR TITLE
Change dependency from 'rosidl_cmake' to 'rosidl_default_generators'

### DIFF
--- a/logging_demo/package.xml
+++ b/logging_demo/package.xml
@@ -20,7 +20,7 @@
   <build_depend>rclcpp</build_depend>
   <build_depend>rclcpp_components</build_depend>
   <build_depend>rcutils</build_depend>
-  <build_depend>rosidl_cmake</build_depend>
+  <build_depend>rosidl_default_generators</build_depend>
   <build_depend>std_msgs</build_depend>
 
   <exec_depend>rclcpp</exec_depend>


### PR DESCRIPTION
This is the recommendation from the ROS 2 tutorials.