### PR TITLE
Remove action_msgs dependency

### DIFF
--- a/action_tutorials/action_tutorials_interfaces/package.xml
+++ b/action_tutorials/action_tutorials_interfaces/package.xml
@@ -16,8 +16,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
-  <depend>action_msgs</depend>
-
   <exec_depend>rosidl_default_runtime</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
It is now properly included in the rosidl dependency chain.

Depends on https://github.com/ros2/rosidl_defaults/pull/22