### PR TITLE
Install the launch file for lifecycle_py.

### DIFF
--- a/lifecycle_py/setup.py
+++ b/lifecycle_py/setup.py
@@ -1,3 +1,6 @@
+import glob
+import os
+
 from setuptools import find_packages
 from setuptools import setup
 
@@ -11,6 +14,8 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
+        ('share/lifecycle_py/launch',
+            glob.glob(os.path.join('launch', '*.launch.py'))),
     ],
     install_requires=['setuptools'],
     zip_safe=True,


### PR DESCRIPTION
It wasn't being installed previously, which means it couldn't be used with 'ros2 launch'

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>