### PR TITLE
Enable document generation using rosdoc2

### DIFF
--- a/demo_nodes_py/package.xml
+++ b/demo_nodes_py/package.xml
@@ -18,6 +18,7 @@
   <author email="michael@openrobotics.org">Michael Carroll</author>
   <author>Mikael Arguedas</author>
 
+  <exec_depend>ament_index_python</exec_depend>
   <exec_depend>example_interfaces</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rcl_interfaces</exec_depend>

--- a/lifecycle_py/lifecycle_py/talker.py
+++ b/lifecycle_py/lifecycle_py/talker.py
@@ -66,10 +66,10 @@ class LifecycleTalker(Node):
         enters the "configuring" state.
 
         :return: The state machine either invokes a transition to the "inactive" state or stays
-        in "unconfigured" depending on the return value.
-          TransitionCallbackReturn.SUCCESS transitions to "inactive".
-          TransitionCallbackReturn.FAILURE transitions to "unconfigured".
-          TransitionCallbackReturn.ERROR or any uncaught exceptions to "errorprocessing"
+            in "unconfigured" depending on the return value.
+            TransitionCallbackReturn.SUCCESS transitions to "inactive".
+            TransitionCallbackReturn.FAILURE transitions to "unconfigured".
+            TransitionCallbackReturn.ERROR or any uncaught exceptions to "errorprocessing"
         """
         self._pub = self.create_lifecycle_publisher(std_msgs.msg.String, 'lifecycle_chatter', 10)
         self._timer = self.create_timer(1.0, self.publish)
@@ -106,10 +106,10 @@ class LifecycleTalker(Node):
         enters the "cleaning up" state.
 
         :return: The state machine either invokes a transition to the "unconfigured" state or stays
-        in "inactive" depending on the return value.
-          TransitionCallbackReturn.SUCCESS transitions to "unconfigured".
-          TransitionCallbackReturn.FAILURE transitions to "inactive".
-          TransitionCallbackReturn.ERROR or any uncaught exceptions to "errorprocessing"
+            in "inactive" depending on the return value.
+            TransitionCallbackReturn.SUCCESS transitions to "unconfigured".
+            TransitionCallbackReturn.FAILURE transitions to "inactive".
+            TransitionCallbackReturn.ERROR or any uncaught exceptions to "errorprocessing"
         """
         self.destroy_timer(self._timer)
         self.destroy_publisher(self._pub)
@@ -125,10 +125,10 @@ class LifecycleTalker(Node):
         enters the "shutting down" state.
 
         :return: The state machine either invokes a transition to the "finalized" state or stays
-        in the current state depending on the return value.
-          TransitionCallbackReturn.SUCCESS transitions to "unconfigured".
-          TransitionCallbackReturn.FAILURE transitions to "inactive".
-          TransitionCallbackReturn.ERROR or any uncaught exceptions to "errorprocessing"
+            in the current state depending on the return value.
+            TransitionCallbackReturn.SUCCESS transitions to "unconfigured".
+            TransitionCallbackReturn.FAILURE transitions to "inactive".
+            TransitionCallbackReturn.ERROR or any uncaught exceptions to "errorprocessing"
         """
         self.destroy_timer(self._timer)
         self.destroy_publisher(self._pub)

--- a/quality_of_service_demo/rclpy/package.xml
+++ b/quality_of_service_demo/rclpy/package.xml
@@ -16,6 +16,7 @@
   <author email="mabel@openrobotics.org">Mabel Zhang</author>
 
   <exec_depend>rclpy</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_copyright</test_depend>


### PR DESCRIPTION
Fix missing `exec_depends` in `package.xmls` and docstrings to generate documentation without any warnings using `autodoc`