### PR TITLE
Fix the set_parameters_callback example program.

### DIFF
--- a/demo_nodes_cpp/src/parameters/set_parameters_callback.cpp
+++ b/demo_nodes_cpp/src/parameters/set_parameters_callback.cpp
@@ -60,14 +60,23 @@ public:
     auto on_set_parameter_callback =
       [this](std::vector<rclcpp::Parameter> parameters) {
         rcl_interfaces::msg::SetParametersResult result;
+        result.successful = true;
+
         for (const auto & param : parameters) {
           if (param.get_name() == "param1") {
-            result.successful = true;
-            result.reason = "success param1";
-          }
-          if (param.get_name() == "param2") {
-            result.successful = true;
-            result.reason = "success param2";
+            // Arbitrarily reject updates setting param1 > 5.0
+            if (param.get_value<double>() > 5.0) {
+              result.successful = false;
+              result.reason = "cannot set param1 > 5.0";
+              break;
+            }
+          } else if (param.get_name() == "param2") {
+            // Arbitrarily reject updates setting param2 < -5.0
+            if (param.get_value<double>() < -5.0) {
+              result.successful = false;
+              result.reason = "cannot set param2 < -5.0";
+              break;
+            }
           }
         }
 
@@ -95,6 +104,13 @@ public:
       on_set_parameter_callback);
     post_set_parameters_callback_handle_ = this->add_post_set_parameters_callback(
       post_set_parameter_callback);
+
+    printf("This node shows off parameter callbacks.");
+    printf("To do that, it exhibits the following behavior:\n");
+    printf(" * Two parameters of type double are declared on the node, param1 and param2\n");
+    printf(" * param1 cannot be set to a value > 5.0\n");
+    printf(" * param2 cannot be set to a value < -5.0\n");
+    printf(" * any time param1 is set, param2 is automatically set to 4.0\n");
   }
 
 private:


### PR DESCRIPTION
In particular, the 'on_set_parameter_callback' callback was checking for undeclared parameters, but that could not have been a problem since 'allow_undeclared_parameters' is set to false by default.

Instead, change the logic in that callback to arbitrarily reject parameters > 5.0 (for param1) or < -5.0 (for param2). That is a much better demonstration of what this node should do.

Also add in a print during the constructor, telling the user what to expect.