### PR TITLE
Change all ROS2 -> ROS 2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,3 @@
 This repository contains source code for demos mentioned in the official ROS 2 documentation [Tutorials](https://docs.ros.org/en/rolling/Tutorials.html).
 
 Each ROS 2 package consists of its own self-contained demonstration(s) with its respective `README.md` showing how things work.
-

--- a/action_tutorials/README.md
+++ b/action_tutorials/README.md
@@ -1,4 +1,4 @@
-# ROS2 Action Tutorials
+# ROS 2 Action Tutorials
 
 This tutorial demonstrates implementing ROS action servers and action clients.
 
@@ -7,10 +7,10 @@ $$F_0 = 0$$
 $$F_1 = 1$$
 $$F_{order}=F_{order-1} + F_{order-2}$$
 
-The action server calculates each number in the sequence one at a time and returns a partial sequence as feedback at each iteration. 
+The action server calculates each number in the sequence one at a time and returns a partial sequence as feedback at each iteration.
 If the action is cancelled before the entire sequence is calculated, the server stops calculating the sequence and no result is returned.
 The action client in this tutorial sends a goal to the action server with an order of 10.
-It logs each partial sequence returned as feedback. 
+It logs each partial sequence returned as feedback.
 Once the action is finished executing, the action client logs the resulting sequence.
 
 ## Packages

--- a/action_tutorials/action_tutorials_cpp/README.md
+++ b/action_tutorials/action_tutorials_cpp/README.md
@@ -29,7 +29,7 @@ The `handle_accepted` callback is called following the action server's acceptanc
 std::thread{std::bind(&FibonacciActionServer::execute, this, _1), goal_handle}.detach();
 ```
 
-The execution thread calculates the Fibonacci sequence up to *order* and publishes partial sequences as feedback as each item is added to the sequence. 
+The execution thread calculates the Fibonacci sequence up to *order* and publishes partial sequences as feedback as each item is added to the sequence.
 
 A `rclcpp::Rate` object is used to sleep between the calculation of each item in order to represent a long-running task.
 
@@ -46,7 +46,7 @@ this->client_ptr_ = rclcpp_action::create_client<Fibonacci>(
       "fibonacci");
 ```
 
-A goal of type `Fibonacci` is created with order 10. 
+A goal of type `Fibonacci` is created with order 10.
 The goal is sent asynchronously with callbacks registered for the goal response, the feedback, and the goal result:
 
 ```cpp

--- a/action_tutorials/action_tutorials_interfaces/README.md
+++ b/action_tutorials/action_tutorials_interfaces/README.md
@@ -1,4 +1,4 @@
-# Action Tutorials ROS2 Interface
+# Action Tutorials ROS 2 Interface
 
 This tutorial defines the Fibonacci action for use with the action tutorials.
 There are three parts of the action:

--- a/composition/README.md
+++ b/composition/README.md
@@ -20,7 +20,7 @@ colcon build --packages-up-to composition
 
 ### Manual Composition
 
-Running `manual_composition` compiles an executable that runs the following 4 components: 
+Running `manual_composition` compiles an executable that runs the following 4 components:
 
 - **Talker**: A ROS 2 component that publishes a string
 - **Listener**: A ROS 2 component that prints the received string from **Talker**
@@ -33,7 +33,7 @@ ros2 run composition manual_composition
 
 ### DlOpen Composition
 
-This runs `dlopen_composition` which is an alternative to run-time composition by creating a generic container process and explicitly passing the libraries to load without using ROS interfaces. 
+This runs `dlopen_composition` which is an alternative to run-time composition by creating a generic container process and explicitly passing the libraries to load without using ROS interfaces.
 
 The process will open each library and create one instance of each “rclcpp::Node” class in the library.
 
@@ -119,7 +119,7 @@ INFO] [1674529118.496557668] [dlopen_composition]: Load library /opt/ros/rolling
 When executed correctly, strings should be printed to terminal similar to what is shown below:
 
 ```bash
-[INFO] [1674528568.091949637] [linktime_composition]: Load library 
+[INFO] [1674528568.091949637] [linktime_composition]: Load library
 [INFO] [1674528568.091995119] [linktime_composition]: Instantiate class rclcpp_components::NodeFactoryTemplate<composition::Client>
 [INFO] [1674528568.098833910] [linktime_composition]: Instantiate class rclcpp_components::NodeFactoryTemplate<composition::Listener>
 [INFO] [1674528568.100669644] [linktime_composition]: Instantiate class rclcpp_components::NodeFactoryTemplate<composition::Server>

--- a/demo_nodes_cpp/README.md
+++ b/demo_nodes_cpp/README.md
@@ -4,28 +4,28 @@ This package provides several examples that demonstrate various inter-node commu
 
 This package consists of the following examples:
 1. `add_two_ints_client`
-2. `listener_serialized_message` 
+2. `listener_serialized_message`
 3. `reuse_timer`
-4. `add_two_ints_client_async` 
-5. `list_parameters` 
+4. `add_two_ints_client_async`
+5. `list_parameters`
 6. `set_and_get_parameters`
-7. `add_two_ints_server` 
-8. `list_parameters_async` 
+7. `add_two_ints_server`
+8. `list_parameters_async`
 9. `set_and_get_parameters_async`
-10. `allocator_tutorial` 
-11. `one_off_timer` 
+10. `allocator_tutorial`
+11. `one_off_timer`
 12. `set_parameters_callback`
-13. `content_filtering_publisher` 
-14. `parameter_blackboard` 
+13. `content_filtering_publisher`
+14. `parameter_blackboard`
 15. `talker`
 16. `content_filtering_subscriber`
 17. `parameter_event_handler`
 18. `talker_loaned_message`
-19. `even_parameters_node` 
+19. `even_parameters_node`
 20. `parameter_events`
 21. `talker_serialized_message`
 22. `listener`
-23. `parameter_events_async` 
+23. `parameter_events_async`
 24. `listener_best_effort`
 25. `matched_event_detect`
 
@@ -74,7 +74,7 @@ ros2 run demo_nodes_cpp listener_best_effort
 
 ### Basic Server & Client
 
-This runs a ROS 2 server that provides a service to process two integers, outputting the sum back to ROS 2 client node. 
+This runs a ROS 2 server that provides a service to process two integers, outputting the sum back to ROS 2 client node.
 
 #### Server
 
@@ -104,7 +104,7 @@ ros2 run demo_nodes_cpp add_two_ints_client_async
 This runs `one_off_timer` that runs a periodic timer callback that **cancels** and **creates** a **Wall Timer** every **3 callbacks**.
 
 ```bash
-ros2 run demo_nodes_cpp one_off_timer 
+ros2 run demo_nodes_cpp one_off_timer
 ```
 
 ![](img/one_off_timer.png)
@@ -126,7 +126,7 @@ This runs `talker_serialized_message` ROS 2 node that publishes a manual CDR ser
 ros2 run demo_nodes_cpp talker_serialized_message
 ```
 
-This runs `listener_serialized_message` ROS2 2 node that subscribes and prints out the serialized string message published by `talker_serialized_message`. 
+This runs `listener_serialized_message` ROS 2 node that subscribes and prints out the serialized string message published by `talker_serialized_message`.
 ```bash
 # Open new terminal
 ros2 run demo_nodes_cpp listener_serialized_message
@@ -200,7 +200,7 @@ ros2 run demo_nodes_cpp allocator_tutorial
 
 ### Parameter Events
 
-This runs `parameter_events`/`parameters_events_async` ROS2 node(s) which initiates 10 parameter events which changes an example string parameter.
+This runs `parameter_events`/`parameters_events_async` ROS 2 node(s) which initiates 10 parameter events which changes an example string parameter.
 
 > foo -> bar -> baz -> foobar -> foo -> bar -> baz -> foobar -> foo -> bar
 
@@ -277,9 +277,9 @@ ros2 run demo_nodes_cpp talker_loaned_message
 
 ### Matched Event Detect
 
-This runs 3 ROS2 nodes.  
-`matched_event_detect_node` node that set matched event callback for publisher and subscription separately to output connection or disconnection information.  
-`multi_sub_node` create/destroy subscriptions which connect the publisher of `matched_event_detect_node`.  
+This runs 3 ROS 2 nodes.
+`matched_event_detect_node` node that set matched event callback for publisher and subscription separately to output connection or disconnection information.
+`multi_sub_node` create/destroy subscriptions which connect the publisher of `matched_event_detect_node`.
 `multi_pub_node` create/destroy publishers which connect the subscription of `matched_event_detect_node`.
 
 ```bash
@@ -362,7 +362,7 @@ When executed correctly, strings should be printed to terminal similar to what i
 #...
 ```
 
-> Notice how 
+> Notice how
 > the timer is reset only after two callback iterations.
 
 ### Reuse Timer
@@ -394,11 +394,11 @@ When executed correctly, strings should be printed to terminal similar to what i
 ROS message:
 Hello World:1
 serialized message:
-00 01 00 00 0e 00 00 00 48 65 6c 6c 6f 20 57 6f 72 6c 64 3a 31 00 
+00 01 00 00 0e 00 00 00 48 65 6c 6c 6f 20 57 6f 72 6c 64 3a 31 00
 ROS message:
 Hello World:2
 serialized message:
-00 01 00 00 0e 00 00 00 48 65 6c 6c 6f 20 57 6f 72 6c 64 3a 32 00 
+00 01 00 00 0e 00 00 00 48 65 6c 6c 6f 20 57 6f 72 6c 64 3a 32 00
 ROS message:
 Hello World:3
 serialized message:
@@ -446,7 +446,7 @@ When executed correctly, strings should be printed to terminal similar to what i
 ```bash
 [INFO] [1674563905.346022942] [list_paramters]: Setting parameters...
 [INFO] [1674563905.347158439] [list_paramters]: Listing parameters...
-[INFO] [1674563905.347570888] [list_paramters]: 
+[INFO] [1674563905.347570888] [list_paramters]:
 Parameter names:
  bar
  foo
@@ -461,7 +461,7 @@ Parameter prefixes:
 When executed correctly, strings should be printed to terminal similar to what is shown below:
 
 ```bash
-[INFO] [1674564137.057616328] [set_and_get_parameters]: 
+[INFO] [1674564137.057616328] [set_and_get_parameters]:
 Parameter name: foo
 Parameter value (integer): 2
 Parameter name: baz
@@ -488,7 +488,7 @@ deallocations that happened during the program.
 Intra-process pipeline is OFF.
 ```
 
-Run `ros2 topic echo /allocator_tutorial` to see the output in the ROS2 topic, `/allocator_tutorial`:
+Run `ros2 topic echo /allocator_tutorial` to see the output in the ROS 2 topic, `/allocator_tutorial`:
 ```bash
 # Open new terminal
 data: 224
@@ -512,70 +512,70 @@ data: 235
 When executed correctly, strings should be printed to terminal similar to what is shown below:
 
 ```bash
-[INFO] [1674565202.370104660] [parameter_events]: 
+[INFO] [1674565202.370104660] [parameter_events]:
 Parameter event:
  new parameters:
   foo
  changed parameters:
  deleted parameters:
 
-[INFO] [1674565202.370241604] [parameter_events]: 
+[INFO] [1674565202.370241604] [parameter_events]:
 Parameter event:
  new parameters:
   bar
  changed parameters:
  deleted parameters:
 
-[INFO] [1674565202.370303487] [parameter_events]: 
+[INFO] [1674565202.370303487] [parameter_events]:
 Parameter event:
  new parameters:
   baz
  changed parameters:
  deleted parameters:
 
-[INFO] [1674565202.370355113] [parameter_events]: 
+[INFO] [1674565202.370355113] [parameter_events]:
 Parameter event:
  new parameters:
   foobar
  changed parameters:
  deleted parameters:
 
-[INFO] [1674565202.370398069] [parameter_events]: 
+[INFO] [1674565202.370398069] [parameter_events]:
 Parameter event:
  new parameters:
  changed parameters:
   foo
  deleted parameters:
 
-[INFO] [1674565202.370424143] [parameter_events]: 
+[INFO] [1674565202.370424143] [parameter_events]:
 Parameter event:
  new parameters:
  changed parameters:
   bar
  deleted parameters:
 
-[INFO] [1674565202.370447765] [parameter_events]: 
+[INFO] [1674565202.370447765] [parameter_events]:
 Parameter event:
  new parameters:
  changed parameters:
   baz
  deleted parameters:
 
-[INFO] [1674565202.370470405] [parameter_events]: 
+[INFO] [1674565202.370470405] [parameter_events]:
 Parameter event:
  new parameters:
  changed parameters:
   foobar
  deleted parameters:
 
-[INFO] [1674565202.370492871] [parameter_events]: 
+[INFO] [1674565202.370492871] [parameter_events]:
 Parameter event:
  new parameters:
  changed parameters:
   foo
  deleted parameters:
 
-[INFO] [1674565202.370515168] [parameter_events]: 
+[INFO] [1674565202.370515168] [parameter_events]:
 Parameter event:
  new parameters:
  changed parameters:
@@ -709,7 +709,7 @@ When executed correctly, strings should be printed to terminal similar to what i
 
 ## **FAQ**
 
-`Q`: Encountered the following error in terminal when running **Loaned Message Talker**: 
+`Q`: Encountered the following error in terminal when running **Loaned Message Talker**:
 
 ```bash
 [INFO] [1674570146.112148792] [rclcpp]: Currently used middleware can't loan messages. Local allocator will be used.
@@ -720,5 +720,5 @@ When executed correctly, strings should be printed to terminal similar to what i
 ## **References**
 
 1. [Zero-Copy via Loaned Messages](https://design.ros2.org/articles/zero_copy.html)
-2. [ROS2 Quality of Service Policies](https://design.ros2.org/articles/qos.html)
+2. [ROS 2 Quality of Service Policies](https://design.ros2.org/articles/qos.html)
 3. [Creating a content filtering subscription](https://docs.ros.org/en/rolling/Tutorials/Demos/Content-Filtering-Subscription.html)

--- a/demo_nodes_cpp/src/topics/listener_serialized_message.cpp
+++ b/demo_nodes_cpp/src/topics/listener_serialized_message.cpp
@@ -53,13 +53,13 @@ public:
         }
         printf("\n");
 
-        // In order to deserialize the message we have to manually create a ROS2
+        // In order to deserialize the message we have to manually create a ROS 2
         // message in which we want to convert the serialized data.
         using MessageT = std_msgs::msg::String;
         MessageT string_msg;
         auto serializer = rclcpp::Serialization<MessageT>();
         serializer.deserialize_message(msg.get(), &string_msg);
-        // Finally print the ROS2 message data
+        // Finally print the ROS 2 message data
         std::cout << "serialized data after deserialization: " << string_msg.data << std::endl;
       };
     // Create a subscription to the topic which can be matched with one or more compatible ROS

--- a/demo_nodes_cpp/src/topics/talker_serialized_message.cpp
+++ b/demo_nodes_cpp/src/topics/talker_serialized_message.cpp
@@ -73,7 +73,7 @@ public:
         static rclcpp::Serialization<std_msgs::msg::String> serializer;
         serializer.serialize_message(string_msg.get(), &serialized_msg_);
 
-        // For demonstration we print the ROS2 message format
+        // For demonstration we print the ROS 2 message format
         printf("ROS message:\n");
         printf("%s\n", string_msg->data.c_str());
         // And after the corresponding binary representation

--- a/demo_nodes_cpp_native/README.md
+++ b/demo_nodes_cpp_native/README.md
@@ -1,6 +1,6 @@
 ## **What Is This?**
 
-This demo provides an example of further **Quality-Of-Service (QoS) configurability** as well as **Publication Modes** in a ROS 2 node via the use of `rmw_fastrtps_cpp` Application Programming Interface (API). 
+This demo provides an example of further **Quality-Of-Service (QoS) configurability** as well as **Publication Modes** in a ROS 2 node via the use of `rmw_fastrtps_cpp` Application Programming Interface (API).
 
 The example utilitises `eprosima::fastdds::statistics::dds::DomainParticipant` as well as `eprosima::fastdds::dds::DataWriter`.
 

--- a/demo_nodes_py/README.md
+++ b/demo_nodes_py/README.md
@@ -264,7 +264,7 @@ Running `ros2 run demo_nodes_cpp parameter_blackboard` should print the output t
 
 ### Serialized Subscriber
 
-Running `ros2 run demo_nodes_py talker` should print output to the terminal similar to the following: 
+Running `ros2 run demo_nodes_py talker` should print output to the terminal similar to the following:
 
 ```bash
 # In terminal running listener_serialized

--- a/dummy_robot/dummy_map_server/README.md
+++ b/dummy_robot/dummy_map_server/README.md
@@ -1,6 +1,6 @@
 ## **What Is This?**
 
-This demo creates and runs a ROS2 **node**, `dummy_map_server`, that publishes `nav_msgs::msg::OccupancyGrid` on a ROS2 publisher topic, `/map`.
+This demo creates and runs a ROS 2 **node**, `dummy_map_server`, that publishes `nav_msgs::msg::OccupancyGrid` on a ROS 2 publisher topic, `/map`.
 
 **dummy_map_server** is also a dependency of **dummy_robot_bringup**.
 
@@ -87,4 +87,4 @@ data:
 
 ## **References**
 
-- `nav_msgs::msg::OccupancyGrid` Message Format: https://github.com/ros2/common_interfaces/blob/rolling/nav_msgs/msg/OccupancyGrid.msg 
+- `nav_msgs::msg::OccupancyGrid` Message Format: https://github.com/ros2/common_interfaces/blob/rolling/nav_msgs/msg/OccupancyGrid.msg

--- a/intra_process_demo/README.md
+++ b/intra_process_demo/README.md
@@ -2,7 +2,7 @@
 
 The demos in this package are designed to showcase how developers can **manually compose ROS 2 nodes** by **defining them separately** but **combining them in varied process layouts**.
 
-These can be done while avoiding code overhauls or performance restrictions. 
+These can be done while avoiding code overhauls or performance restrictions.
 
 This package consists of the following ROS 2 nodes:
 
@@ -16,7 +16,7 @@ This package consists of the following ROS 2 nodes:
 
 Through the use of **intra-process** (as opposed to **inter-process**) node communication, lower latency and thus **higher efficiency** is observed for ROS 2 topologies that utilizes this manner of communication.
 
-The improvements in latency reduction are even **more pronounced when applied to ROS 2 systems with more complex topologies**. 
+The improvements in latency reduction are even **more pronounced when applied to ROS 2 systems with more complex topologies**.
 
 ## Build
 
@@ -89,7 +89,7 @@ ros2 run intra_process_demo image_view_node
 
 Please ensure you have a camera connected to your workstation.
 
-Similar to the **Image Pipeline All In One**, running `image_pipeline_with_two_image_views` will display the image process through intra-process communications. 
+Similar to the **Image Pipeline All In One**, running `image_pipeline_with_two_image_views` will display the image process through intra-process communications.
 
 However, it now instantiates 2 `image_view_node` ROS 2 nodes.
 

--- a/pendulum_msgs/README.md
+++ b/pendulum_msgs/README.md
@@ -1,6 +1,6 @@
 ## **What Is This?**
 
-The **pendulum_msgs** ROS 2 package is a dependency of **pendulum_control** ROS 2 package. 
+The **pendulum_msgs** ROS 2 package is a dependency of **pendulum_control** ROS 2 package.
 It contains `JointCommand.msg`, `JointState.msg` and `RttestResults.msg`
 
 Please refer to [pendulum_control](https://github.com/ros2/demos/tree/rolling/pendulum_control) for more details.
@@ -31,7 +31,7 @@ uint64 cur_latency
 float64 mean_latency
 uint64 min_latency
 uint64 max_latency
-uint64 minor_pagefaults 
+uint64 minor_pagefaults
 uint64 major_pagefaults
 ```
 

--- a/quality_of_service_demo/rclpy/setup.py
+++ b/quality_of_service_demo/rclpy/setup.py
@@ -22,7 +22,7 @@ setup(
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],
-    description='Python nodes to demonstrate ROS2 QoS policies.',
+    description='Python nodes to demonstrate ROS 2 QoS policies.',
     license='Apache License, Version 2.0',
     tests_require=['pytest'],
     entry_points={


### PR DESCRIPTION
This meets our standards.
While we are in here, also remove trailing whitespace from README files.