### PR TITLE
avoid unstable LaserScan status for rviz2

### DIFF
--- a/dummy_robot/dummy_sensors/README.md
+++ b/dummy_robot/dummy_sensors/README.md
@@ -27,7 +27,7 @@ ros2 run dummy_sensors dummy_laser
 # Terminal Output
 [INFO] [1658564972.776089023] [dummy_laser]: angle inc:	0.004363
 [INFO] [1658564972.776138078] [dummy_laser]: scan size:	1081
-[INFO] [1658564972.776148752] [dummy_laser]: scan time increment: 	0.000028
+[INFO] [1658564972.776148752] [dummy_laser]: scan time increment: 	0.000000
 ```
 
 ### **2 - dummy_joint_states**

--- a/dummy_robot/dummy_sensors/src/dummy_laser.cpp
+++ b/dummy_robot/dummy_sensors/src/dummy_laser.cpp
@@ -58,8 +58,9 @@ int main(int argc, char * argv[])
   }
   msg.ranges.resize(static_cast<int>(num_values));
 
-  msg.time_increment =
-    static_cast<float>((angle_resolution / 10000.0) / 360.0 / (scan_frequency / 100.0));
+  // Set `time_increment` with 0 to avoid unstable status shown in the `LaserScan` display of rviz2
+  // while looking up transform with a forward time value.
+  msg.time_increment = 0.0f;
   msg.angle_increment = static_cast<float>(angle_resolution / 10000.0 * DEG2RAD);
   msg.angle_min = static_cast<float>(start_angle / 10000.0 * DEG2RAD - M_PI / 2);
   msg.angle_max = static_cast<float>(stop_angle / 10000.0 * DEG2RAD - M_PI / 2);


### PR DESCRIPTION
IDK whether it's a correct fix.
After referring to the [gazebo](https://github.com/ros-simulation/gazebo_ros_pkgs/blob/21e28c14d47035bc77ebd81aba5dfe04666b6809/gazebo_ros/include/gazebo_ros/conversions/sensor_msgs.hpp#L65) to set `time_increment` with zero, the rviz2 issue reported in https://github.com/osrf/ros2_test_cases/issues/868 works well.