### PR TITLE
[image_tools] Update ROSCVMatContainer and do not convert color space of frames

### DIFF
--- a/image_tools/src/cv_mat_sensor_msgs_image_type_adapter.cpp
+++ b/image_tools/src/cv_mat_sensor_msgs_image_type_adapter.cpp
@@ -100,21 +100,25 @@ ROSCvMatContainer::ROSCvMatContainer(
 ROSCvMatContainer::ROSCvMatContainer(
   const cv::Mat & mat_frame,
   const std_msgs::msg::Header & header,
-  bool is_bigendian)
+  bool is_bigendian,
+  std::optional<std::string> encoding_override)
 : header_(header),
   frame_(mat_frame),
   storage_(nullptr),
-  is_bigendian_(is_bigendian)
+  is_bigendian_(is_bigendian),
+  encoding_override_(encoding_override)
 {}
 
 ROSCvMatContainer::ROSCvMatContainer(
   cv::Mat && mat_frame,
   const std_msgs::msg::Header & header,
-  bool is_bigendian)
+  bool is_bigendian,
+  std::optional<std::string> encoding_override)
 : header_(header),
   frame_(std::forward<cv::Mat>(mat_frame)),
   storage_(nullptr),
-  is_bigendian_(is_bigendian)
+  is_bigendian_(is_bigendian),
+  encoding_override_(encoding_override)
 {}
 
 ROSCvMatContainer::ROSCvMatContainer(
@@ -175,21 +179,28 @@ ROSCvMatContainer::get_sensor_msgs_msg_image_copy(
 {
   sensor_msgs_image.height = frame_.rows;
   sensor_msgs_image.width = frame_.cols;
-  switch (frame_.type()) {
-    case CV_8UC1:
-      sensor_msgs_image.encoding = "mono8";
-      break;
-    case CV_8UC3:
-      sensor_msgs_image.encoding = "bgr8";
-      break;
-    case CV_16SC1:
-      sensor_msgs_image.encoding = "mono16";
-      break;
-    case CV_8UC4:
-      sensor_msgs_image.encoding = "rgba8";
-      break;
-    default:
-      throw std::runtime_error("unsupported encoding type");
+  if (encoding_override_.has_value() && !encoding_override_.value().empty())
+  {
+    sensor_msgs_image.encoding = encoding_override_.value();
+  }
+  else
+  {
+    switch (frame_.type()) {
+      case CV_8UC1:
+        sensor_msgs_image.encoding = "mono8";
+        break;
+      case CV_8UC3:
+        sensor_msgs_image.encoding = "bgr8";
+        break;
+      case CV_16SC1:
+        sensor_msgs_image.encoding = "mono16";
+        break;
+      case CV_8UC4:
+        sensor_msgs_image.encoding = "rgba8";
+        break;
+      default:
+        throw std::runtime_error("unsupported encoding type");
+    }
   }
   sensor_msgs_image.step = static_cast<sensor_msgs::msg::Image::_step_type>(frame_.step);
   size_t size = frame_.step * frame_.rows;
@@ -202,6 +213,12 @@ bool
 ROSCvMatContainer::is_bigendian() const
 {
   return is_bigendian_;
+}
+
+std::optional<std::string>
+ROSCvMatContainer::encoding_override() const
+{
+  return encoding_override_;
 }
 
 }  // namespace image_tools

--- a/image_tools/src/showimage.cpp
+++ b/image_tools/src/showimage.cpp
@@ -179,12 +179,12 @@ private:
     if (show_image) {
       cv::Mat frame = container.cv_mat();
 
-      if (frame.type() == CV_8UC3 /* rgb8 */) {
-        cv::cvtColor(frame, frame, cv::COLOR_RGB2BGR);
-      } else if (frame.type() == CV_8UC2) {
-        container.is_bigendian() ? cv::cvtColor(frame, frame, cv::COLOR_YUV2BGR_UYVY) :
-        cv::cvtColor(frame, frame, cv::COLOR_YUV2BGR_YUYV);
-      }
+      // if (frame.type() == CV_8UC3 /* rgb8 */) {
+      //   cv::cvtColor(frame, frame, cv::COLOR_RGB2BGR);
+      // } else if (frame.type() == CV_8UC2) {
+      //   container.is_bigendian() ? cv::cvtColor(frame, frame, cv::COLOR_YUV2BGR_UYVY) :
+      //   cv::cvtColor(frame, frame, cv::COLOR_YUV2BGR_YUYV);
+      // }
 
       // Show the image in a window
       cv::imshow(window_name_, frame);


### PR DESCRIPTION
Fix https://github.com/ros2/demos/issues/612

This PR
* Updates the ROSCvMatContainer to allow users to specify and override of the encoding string passed to sensor_msgs::Image. This is mostly for accurate visualization with rviz. Also updates `cam2image` appropriately.
* Updates `showimage` to not perform any color space conversions to the frame. This is the actual fix to the issue

TODO: Test with hardware, remove comments and update tutorial doc