### PR TITLE
Switch to file-content launch substitution

### DIFF
--- a/dummy_robot/dummy_robot_bringup/launch/dummy_robot_bringup_launch.py
+++ b/dummy_robot/dummy_robot_bringup/launch/dummy_robot_bringup_launch.py
@@ -15,6 +15,7 @@
 import os
 
 from launch import LaunchDescription
+from launch.substitutions import FileContent
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
@@ -22,8 +23,7 @@ from launch_ros.substitutions import FindPackageShare
 def generate_launch_description():
     pkg_share = FindPackageShare('dummy_robot_bringup').find('dummy_robot_bringup')
     urdf_file = os.path.join(pkg_share, 'launch', 'single_rrbot.urdf')
-    with open(urdf_file, 'r') as infp:
-        robot_desc = infp.read()
+    robot_desc = FileContent(urdf_file)
     rsp_params = {'robot_description': robot_desc}
 
     return LaunchDescription([

--- a/dummy_robot/dummy_robot_bringup/launch/dummy_robot_bringup_launch.xml
+++ b/dummy_robot/dummy_robot_bringup/launch/dummy_robot_bringup_launch.xml
@@ -1,7 +1,7 @@
 <launch>
   <node pkg="dummy_map_server" exec="dummy_map_server" output="screen" />
   <node pkg="robot_state_publisher" exec="robot_state_publisher" output="screen" >
-    <param name="robot_description" value="$(command 'cat $(find-pkg-share dummy_robot_bringup)/launch/single_rrbot.urdf')"/>
+    <param name="robot_description" value="$(file-content '$(find-pkg-share dummy_robot_bringup)/launch/single_rrbot.urdf')"/>
   </node>
   <node pkg="dummy_sensors" exec="dummy_joint_states" output="screen"/>
   <node pkg="dummy_sensors" exec="dummy_laser" output="screen"/>

--- a/dummy_robot/dummy_robot_bringup/launch/dummy_robot_bringup_launch.yaml
+++ b/dummy_robot/dummy_robot_bringup/launch/dummy_robot_bringup_launch.yaml
@@ -9,7 +9,7 @@ launch:
     output: screen
     param:
       - name: robot_description
-        value: $(command 'cat $(find-pkg-share dummy_robot_bringup)/launch/single_rrbot.urdf')
+        value: $(file-content '$(find-pkg-share dummy_robot_bringup)/launch/single_rrbot.urdf')
 - node:
     pkg: dummy_sensors
     exec: dummy_joint_states


### PR DESCRIPTION
This new substitution provides a portable way to read file contents when the launch file is run (rather than when it is read).

This is a reference implementation of ros2/launch#708