### PR TITLE
More quality of service demo cleanup

### DIFF
--- a/quality_of_service_demo/rclcpp/src/liveliness.cpp
+++ b/quality_of_service_demo/rclcpp/src/liveliness.cpp
@@ -125,13 +125,14 @@ int main(int argc, char * argv[])
 
   auto listener = std::make_shared<Listener>(qos_profile, topic);
   listener->get_options().event_callbacks.liveliness_callback =
-    [](rclcpp::QOSLivelinessChangedInfo & event)
+    [listener](rclcpp::QOSLivelinessChangedInfo & event)
     {
-      printf("Liveliness changed event: \n");
-      printf("  alive_count: %d\n", event.alive_count);
-      printf("  not_alive_count: %d\n", event.not_alive_count);
-      printf("  alive_count_change: %d\n", event.alive_count_change);
-      printf("  not_alive_count_change: %d\n", event.not_alive_count_change);
+      RCLCPP_INFO(listener->get_logger(), "Liveliness changed event:");
+      RCLCPP_INFO(listener->get_logger(), "  alive_count: %d", event.alive_count);
+      RCLCPP_INFO(listener->get_logger(), "  not_alive_count: %d", event.not_alive_count);
+      RCLCPP_INFO(listener->get_logger(), "  alive_count_change: %d", event.alive_count_change);
+      RCLCPP_INFO(
+        listener->get_logger(), "  not_alive_count_change: %d", event.not_alive_count_change);
     };
 
   talker->initialize();

--- a/quality_of_service_demo/rclpy/quality_of_service_demo_py/common_nodes.py
+++ b/quality_of_service_demo/rclpy/quality_of_service_demo_py/common_nodes.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from rclpy.node import Node
 from std_msgs.msg import String
 

--- a/quality_of_service_demo/rclpy/quality_of_service_demo_py/deadline.py
+++ b/quality_of_service_demo/rclpy/quality_of_service_demo_py/deadline.py
@@ -11,7 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import argparse
+import sys
 
 from quality_of_service_demo_py.common_nodes import Listener
 from quality_of_service_demo_py.common_nodes import Talker
@@ -84,6 +86,8 @@ def main(args=None):
     finally:
         rclpy.try_shutdown()
 
+    return 0
+
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/quality_of_service_demo/rclpy/quality_of_service_demo_py/incompatible_qos.py
+++ b/quality_of_service_demo/rclpy/quality_of_service_demo_py/incompatible_qos.py
@@ -110,7 +110,7 @@ def main(args=None):
     else:
         print('{name} not recognised.'.format(name=qos_policy_name))
         parser.print_help()
-        return 0
+        return 1
 
     # Initialization and configuration
     rclpy.init(args=args)

--- a/quality_of_service_demo/rclpy/quality_of_service_demo_py/incompatible_qos.py
+++ b/quality_of_service_demo/rclpy/quality_of_service_demo_py/incompatible_qos.py
@@ -117,10 +117,23 @@ def main(args=None):
     topic = 'incompatible_qos_chatter'
     num_msgs = 5
 
-    publisher_callbacks = PublisherEventCallbacks(
-        incompatible_qos=lambda event: get_logger('Talker').info(str(event)))
+    def sub_incompatible_qos_event(event):
+        count = event.total_count
+        delta = event.total_count_change
+        policy = event.last_policy_kind
+        get_logger('listener').info(
+            f'Requested incompatible qos - total {count} delta {delta} last_policy_kind: {policy}')
+
+    def pub_incompatible_qos_event(event):
+        count = event.total_count
+        delta = event.total_count_change
+        policy = event.last_policy_kind
+        get_logger('talker').info(
+            f'Offered incompatible qos - total {count} delta {delta} last_policy_kind: {policy}')
+
+    publisher_callbacks = PublisherEventCallbacks(incompatible_qos=pub_incompatible_qos_event)
     subscription_callbacks = SubscriptionEventCallbacks(
-        incompatible_qos=lambda event: get_logger('Listener').info(str(event)))
+        incompatible_qos=sub_incompatible_qos_event)
 
     try:
         talker = Talker(

--- a/quality_of_service_demo/rclpy/quality_of_service_demo_py/lifespan.py
+++ b/quality_of_service_demo/rclpy/quality_of_service_demo_py/lifespan.py
@@ -11,13 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import argparse
+import sys
 
 from quality_of_service_demo_py.common_nodes import Listener
 from quality_of_service_demo_py.common_nodes import Talker
 
 import rclpy
 from rclpy.duration import Duration
+from rclpy.executors import ExternalShutdownException
 from rclpy.executors import SingleThreadedExecutor
 from rclpy.qos import QoSDurabilityPolicy
 from rclpy.qos import QoSProfile
@@ -69,10 +72,15 @@ def main(args=None):
     executor = SingleThreadedExecutor()
     executor.add_node(listener)
     executor.add_node(talker)
-    executor.spin()
+    try:
+        executor.spin()
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
+    finally:
+        rclpy.try_shutdown()
 
-    rclpy.shutdown()
+    return 0
 
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/quality_of_service_demo/rclpy/quality_of_service_demo_py/liveliness.py
+++ b/quality_of_service_demo/rclpy/quality_of_service_demo_py/liveliness.py
@@ -11,7 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import argparse
+import sys
 
 from quality_of_service_demo_py.common_nodes import Listener
 from quality_of_service_demo_py.common_nodes import Talker
@@ -20,6 +22,7 @@ import rclpy
 from rclpy.duration import Duration
 from rclpy.event_handler import PublisherEventCallbacks
 from rclpy.event_handler import SubscriptionEventCallbacks
+from rclpy.executors import ExternalShutdownException
 from rclpy.executors import SingleThreadedExecutor
 from rclpy.logging import get_logger
 from rclpy.qos import QoSLivelinessPolicy
@@ -91,10 +94,15 @@ def main(args=None):
 
     executor.add_node(listener)
     executor.add_node(talker)
-    executor.spin()
+    try:
+        executor.spin()
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
+    finally:
+        rclpy.try_shutdown()
 
-    rclpy.shutdown()
+    return 0
 
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/quality_of_service_demo/rclpy/quality_of_service_demo_py/liveliness.py
+++ b/quality_of_service_demo/rclpy/quality_of_service_demo_py/liveliness.py
@@ -66,12 +66,24 @@ def main(args=None):
         liveliness=liveliness_policy,
         liveliness_lease_duration=liveliness_lease_duration)
 
-    subscription_callbacks = SubscriptionEventCallbacks(
-        liveliness=lambda event: get_logger('Listener').info(str(event)))
+    def sub_liveliness_event(event):
+        get_logger('listener').info('Liveliness changed event:')
+        get_logger('listener').info(f'  alive_count: {event.alive_count}')
+        get_logger('listener').info(f'  not_alive_count: {event.not_alive_count}')
+        get_logger('listener').info(f'  alive_count_change: {event.alive_count_change}')
+        get_logger('listener').info(f'  not_alive_count_change: {event.not_alive_count_change}')
+
+    subscription_callbacks = SubscriptionEventCallbacks(liveliness=sub_liveliness_event)
     listener = Listener(topic, qos_profile, event_callbacks=subscription_callbacks)
 
-    publisher_callbacks = PublisherEventCallbacks(
-        liveliness=lambda event: get_logger('Talker').info(str(event)))
+    def pub_liveliness_event(event):
+        get_logger('talker').info('Liveliness changed event:')
+        get_logger('talker').info(f'  alive_count: {event.alive_count}')
+        get_logger('talker').info(f'  not_alive_count: {event.not_alive_count}')
+        get_logger('talker').info(f'  alive_count_change: {event.alive_count_change}')
+        get_logger('talker').info(f'  not_alive_count_change: {event.not_alive_count_change}')
+
+    publisher_callbacks = PublisherEventCallbacks(liveliness=pub_liveliness_event)
     talker = Talker(
         topic, qos_profile,
         event_callbacks=publisher_callbacks,

--- a/quality_of_service_demo/rclpy/quality_of_service_demo_py/message_lost_listener.py
+++ b/quality_of_service_demo/rclpy/quality_of_service_demo_py/message_lost_listener.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 import rclpy
 from rclpy.event_handler import SubscriptionEventCallbacks
 from rclpy.executors import ExternalShutdownException
@@ -58,8 +60,8 @@ class MessageLostListener(Node):
         )
 
 
-def main():
-    rclpy.init(args=None)
+def main(args=None):
+    rclpy.init(args=args)
 
     listener = MessageLostListener()
     executor = SingleThreadedExecutor()
@@ -72,6 +74,8 @@ def main():
     finally:
         rclpy.try_shutdown()
 
+    return 0
+
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/quality_of_service_demo/rclpy/quality_of_service_demo_py/qos_overrides_listener.py
+++ b/quality_of_service_demo/rclpy/quality_of_service_demo_py/qos_overrides_listener.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 import rclpy
 from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
@@ -54,9 +56,11 @@ def main(args=None):
     except (KeyboardInterrupt, ExternalShutdownException):
         pass
     finally:
-        rclpy.try_shutdown()
         node.destroy_node()
+        rclpy.try_shutdown()
+
+    return 0
 
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/quality_of_service_demo/rclpy/quality_of_service_demo_py/qos_overrides_talker.py
+++ b/quality_of_service_demo/rclpy/quality_of_service_demo_py/qos_overrides_talker.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
 import rclpy
 from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
@@ -62,9 +64,11 @@ def main(args=None):
     except (KeyboardInterrupt, ExternalShutdownException):
         pass
     finally:
-        rclpy.try_shutdown()
         node.destroy_node()
+        rclpy.try_shutdown()
+
+    return 0
 
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())


### PR DESCRIPTION
Based on the testing in https://github.com/osrf/ros2_test_cases/issues/783, this PR does further cleanup on the quality of service demos.  There are 3 commits in here, to do the following things:

1.  Make the teardown sequence in all of the Python examples the same.  This means we won't throw an exception on shutdown in any of them anymore.
2. Make the output of the liveliness demos more consistent.  For the Python one, print out object data rather than the reference, and for the C++ one have it use a logger.
3. Make the incompatible_qos python demo print out structure members.