### PR TITLE
Cleanup the interactive quality of service demos.

### DIFF
--- a/quality_of_service_demo/rclcpp/src/interactive_publisher.cpp
+++ b/quality_of_service_demo/rclcpp/src/interactive_publisher.cpp
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
 #include <iomanip>
 #include <iostream>
 #include <memory>
 #include <string>
+#include <thread>
 
 #include "std_msgs/msg/string.hpp"
 #include "rcutils/cmdline_parser.h"
@@ -33,7 +35,9 @@ static constexpr char OPTION_DEADLINE_PERIOD[] = "--deadline";
 static constexpr char OPTION_LIVELINESS_KIND[] = "--liveliness";
 static constexpr char OPTION_LEASE_DURATION[] = "--lease";
 
-void print_usage(const char * progname)
+static bool running = true;
+
+static void print_usage(const char * progname)
 {
   std::cout << progname << " [OPTIONS]" << std::endl <<
     std::endl << "Options when starting the demo:" << std::endl <<
@@ -61,39 +65,10 @@ void print_usage(const char * progname)
     std::endl;
 }
 
-class PublisherCommandHandler : public CommandGetter
+static void quit(void)
 {
-public:
-  PublisherCommandHandler(
-    rclcpp::executors::SingleThreadedExecutor & exec,
-    std::weak_ptr<Talker> publisher)
-  : exec_(exec), publisher_(publisher) {}
-
-  void handle_cmd(const char command) const override
-  {
-    const char cmd = tolower(command);
-    if (cmd == 'x') {
-      // signal program exit
-      exec_.cancel();
-      std::cout << "exiting the demo..." << std::endl;
-    } else if (auto publisher = publisher_.lock()) {
-      if (cmd == 'p') {
-        // manually assert liveliness of publisher
-        publisher->assert_publisher_liveliness();
-      } else if (cmd == 's') {
-        // toggle publishing of messages
-        publisher->toggle_publish();
-      } else if (cmd == 'q') {
-        // print the qos settings
-        publisher->print_qos();
-      }
-    }
-  }
-
-private:
-  rclcpp::executors::SingleThreadedExecutor & exec_;
-  std::weak_ptr<Talker> publisher_;
-};
+  running = false;
+}
 
 int main(int argc, char * argv[])
 {
@@ -153,16 +128,48 @@ int main(int argc, char * argv[])
         event.total_count, event.total_count_change);
     };
 
-  PublisherCommandHandler cmd_handler(exec, talker);
-
   talker->initialize();
   talker->print_qos();
 
-  cmd_handler.start();
+  install_ctrl_handler(quit);
+
   exec.add_node(talker);
-  exec.spin();
+  std::thread t([&exec] {
+      while (running) {
+        exec.spin_some();
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+      }
+    });
+
+  KeyboardReader input;
+  char c;
+  while (running) {
+    try {
+      c = input.readOne();
+    } catch (const std::runtime_error &) {
+      running = false;
+      break;
+    }
+
+    switch (tolower(c)) {
+      case 'x':
+        running = false;
+        break;
+      case 'p':
+        talker->assert_publisher_liveliness();
+        break;
+      case 's':
+        talker->toggle_publish();
+        break;
+      case 'q':
+        talker->print_qos();
+        break;
+    }
+  }
+
+  t.join();
+
   exec.remove_node(talker);
-  cmd_handler.stop();
 
   rclcpp::shutdown();
 

--- a/quality_of_service_demo/rclcpp/src/utils.hpp
+++ b/quality_of_service_demo/rclcpp/src/utils.hpp
@@ -15,8 +15,8 @@
 #ifndef UTILS_HPP_
 #define UTILS_HPP_
 
-#include <atomic>
-#include <thread>
+#include <functional>
+#include <memory>
 
 #include "rclcpp/qos.hpp"
 #include "rmw/types.h"
@@ -29,30 +29,22 @@ rmw_time_to_seconds(const rmw_time_t & time);
 void
 print_qos(const rclcpp::QoS & qos);
 
-class CommandGetter
+void
+install_ctrl_handler(std::function<void(void)> ctrl_handler);
+
+class KeyboardReader final
 {
 public:
-  /// Whether or not the command getter is currently expecting listening for user inputs.
-  bool is_active() const;
+  KeyboardReader();
 
-  /// Start listening for user inputs (character key presses).
-  void start();
+  char readOne();
 
-  /// Stop listening for user inputs.
-  void stop();
-
-  /// Function prototype for handling user inputs.
-  virtual void handle_cmd(const char cmd) const = 0;
-
-  /// Helper function with event loop for the command getting thread.
-  void operator()() const;
+  ~KeyboardReader();
 
 private:
-  /// Get a key press from running terminal
-  char getch() const;
+  class KeyboardReaderImpl;
 
-  std::thread thread_;
-  std::atomic<bool> run_;
+  std::unique_ptr<KeyboardReaderImpl> pimpl_;
 };
 
 #endif  // UTILS_HPP_


### PR DESCRIPTION
The interactive demos are supposed to listen for commands on stdin and do particular actions.  And for the most part they do that, except for 'x'.  That command is supposed to quit the program, but doesn't currently do so.

What we do here is to revamp the keyboard handling so that it works in all situations.  This involves taking the executor and putting it into a thread, and then having the main thread do stdin handling.  We also install a signal handler.

With all of that in place, then, we can either catch the signal from a Ctrl-C or type 'x' to have things quit.  This then quits the keyboard handling loop, which then goes on to cancel the executor, join the thread, and shutdown rclcpp.

This fixes #633.