### PR TITLE
Cleanup demo_nodes_cpp CMake and dependencies

### DIFF
--- a/demo_nodes_cpp/CMakeLists.txt
+++ b/demo_nodes_cpp/CMakeLists.txt
@@ -23,18 +23,44 @@ find_package(rcutils REQUIRED)
 find_package(rmw REQUIRED)
 find_package(std_msgs REQUIRED)
 
-include_directories(include)
-
 function(custom_executable subfolder target)
+  cmake_parse_arguments(ARG "" "" "DEPENDENCIES" ${ARGN})
   add_executable(${target} src/${subfolder}/${target}.cpp)
-  ament_target_dependencies(${target}
-    "example_interfaces"
-    "rclcpp"
-    "rcutils"
-    "std_msgs")
+  target_include_directories(${target} PRIVATE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+  target_link_libraries(${target} PRIVATE
+    ${ARG_DEPENDENCIES}
+  )
   install(TARGETS ${target}
-  DESTINATION lib/${PROJECT_NAME})
+    DESTINATION lib/${PROJECT_NAME})
 endfunction()
+
+custom_executable(topics allocator_tutorial
+  DEPENDENCIES rclcpp::rclcpp ${std_msgs_TARGETS})
+
+custom_executable(services add_two_ints_client
+  DEPENDENCIES ${example_interfaces_TARGETS} rclcpp::rclcpp)
+
+custom_executable(parameters list_parameters_async
+  DEPENDENCIES rclcpp::rclcpp)
+
+custom_executable(parameters parameter_events
+  DEPENDENCIES ${rcl_interfaces_TARGETS} rclcpp::rclcpp)
+
+custom_executable(parameters parameter_event_handler
+  DEPENDENCIES ${rcl_interfaces_TARGETS} rclcpp::rclcpp)
+
+custom_executable(parameters set_and_get_parameters_async
+  DEPENDENCIES rclcpp::rclcpp)
+
+custom_executable(events matched_event_detect
+  DEPENDENCIES rclcpp::rclcpp ${std_msgs_TARGETS})
+
+custom_executable(logging use_logger_service
+  DEPENDENCIES ${rcl_interfaces_TARGETS} rclcpp::rclcpp ${std_msgs_TARGETS})
+
+include_directories(include)
 
 function(add_demo_dependencies library)
   target_compile_definitions(${library}
@@ -47,23 +73,6 @@ function(add_demo_dependencies library)
     "rcutils"
     "std_msgs")
 endfunction()
-# Tutorials of Publish/Subscribe with Topics
-custom_executable(topics allocator_tutorial)
-
-# Tutorials of Request/Response with Services
-custom_executable(services add_two_ints_client)
-
-# Tutorials of Parameters with Asynchronous and Synchronous
-custom_executable(parameters list_parameters_async)
-custom_executable(parameters parameter_events)
-custom_executable(parameters parameter_event_handler)
-custom_executable(parameters set_and_get_parameters_async)
-
-# Tutorials of events
-custom_executable(events matched_event_detect)
-
-# Tutorials of logger service
-custom_executable(logging use_logger_service)
 
 add_library(timers_library SHARED
   src/timers/one_off_timer.cpp

--- a/demo_nodes_cpp/CMakeLists.txt
+++ b/demo_nodes_cpp/CMakeLists.txt
@@ -60,122 +60,94 @@ custom_executable(events matched_event_detect
 custom_executable(logging use_logger_service
   DEPENDENCIES ${rcl_interfaces_TARGETS} rclcpp::rclcpp ${std_msgs_TARGETS})
 
-include_directories(include)
-
-function(add_demo_dependencies library)
+function(create_demo_library plugin executable)
+  cmake_parse_arguments(ARG "" "" "FILES;DEPENDENCIES" ${ARGN})
+  set(library ${executable}_library)
+  add_library(${library} SHARED ${ARG_FILES})
   target_compile_definitions(${library}
     PRIVATE "DEMO_NODES_CPP_BUILDING_DLL")
-  ament_target_dependencies(${library}
-    "example_interfaces"
-    "rclcpp"
-    "rclcpp_components"
-    "rcl_interfaces"
-    "rcutils"
-    "std_msgs")
+  target_include_directories(${library} PRIVATE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+  target_link_libraries(${library} PRIVATE
+    ${ARG_DEPENDENCIES}
+  )
+  install(TARGETS ${library}
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin)
+  rclcpp_components_register_node(${library}
+    PLUGIN ${plugin}
+    EXECUTABLE ${executable})
 endfunction()
 
-add_library(timers_library SHARED
-  src/timers/one_off_timer.cpp
-  src/timers/reuse_timer.cpp)
-add_library(services_library SHARED
-  src/services/add_two_ints_server.cpp
-  src/services/add_two_ints_client.cpp
-  src/services/add_two_ints_client_async.cpp
-  src/services/introspection_service.cpp
-  src/services/introspection_client.cpp)
-add_library(parameters_library SHARED
-  src/parameters/list_parameters.cpp
-  src/parameters/parameter_blackboard.cpp
-  src/parameters/set_and_get_parameters.cpp
-  src/parameters/parameter_events_async.cpp
-  src/parameters/even_parameters_node.cpp
-  src/parameters/set_parameters_callback.cpp)
-add_library(topics_library SHARED
-  src/topics/content_filtering_publisher.cpp
-  src/topics/content_filtering_subscriber.cpp
-  src/topics/talker.cpp
-  src/topics/talker_loaned_message.cpp
-  src/topics/talker_serialized_message.cpp
-  src/topics/listener.cpp
-  src/topics/listener_serialized_message.cpp
-  src/topics/listener_best_effort.cpp)
-add_demo_dependencies(timers_library)
-add_demo_dependencies(services_library)
-add_demo_dependencies(parameters_library)
-add_demo_dependencies(topics_library)
+# Timers
+create_demo_library("demo_nodes_cpp::OneOffTimerNode" one_off_timer
+  FILES src/timers/one_off_timer.cpp
+  DEPENDENCIES rclcpp::rclcpp rclcpp_components::component)
+create_demo_library("demo_nodes_cpp::ReuseTimerNode" reuse_timer
+  FILES src/timers/reuse_timer.cpp
+  DEPENDENCIES rclcpp::rclcpp rclcpp_components::component)
 
-rclcpp_components_register_node(timers_library
-  PLUGIN "demo_nodes_cpp::OneOffTimerNode"
-  EXECUTABLE one_off_timer)
-rclcpp_components_register_node(timers_library
-  PLUGIN "demo_nodes_cpp::ReuseTimerNode"
-  EXECUTABLE reuse_timer)
+# Parameters
+create_demo_library("demo_nodes_cpp::ListParameters" list_parameters
+  FILES src/parameters/list_parameters.cpp
+  DEPENDENCIES rclcpp::rclcpp rclcpp_components::component)
+create_demo_library("demo_nodes_cpp::ParameterBlackboard" parameter_blackboard
+  FILES src/parameters/parameter_blackboard.cpp
+  DEPENDENCIES ${rcl_interfaces_TARGETS} rclcpp::rclcpp rclcpp_components::component)
+create_demo_library("demo_nodes_cpp::SetAndGetParameters" set_and_get_parameters
+  FILES src/parameters/set_and_get_parameters.cpp
+  DEPENDENCIES rclcpp::rclcpp rclcpp_components::component)
+create_demo_library("demo_nodes_cpp::ParameterEventsAsyncNode" parameter_events_async
+  FILES src/parameters/parameter_events_async.cpp
+  DEPENDENCIES ${rcl_interfaces_TARGETS} rclcpp::rclcpp rclcpp_components::component)
+create_demo_library("demo_nodes_cpp::EvenParameterNode" event_parameters_node
+  FILES src/parameters/even_parameters_node.cpp
+  DEPENDENCIES ${rcl_interfaces_TARGETS} rclcpp::rclcpp rclcpp_components::component)
+create_demo_library("demo_nodes_cpp::SetParametersCallback" set_parameters_callback
+  FILES src/parameters/set_parameters_callback.cpp
+  DEPENDENCIES ${rcl_interfaces_TARGETS} rclcpp::rclcpp rclcpp_components::component)
 
-rclcpp_components_register_node(services_library
-  PLUGIN "demo_nodes_cpp::ServerNode"
-  EXECUTABLE add_two_ints_server)
-rclcpp_components_register_node(services_library
-  PLUGIN "demo_nodes_cpp::ClientNode"
-  EXECUTABLE add_two_ints_client_async)
-rclcpp_components_register_node(services_library
-  PLUGIN "demo_nodes_cpp::IntrospectionServiceNode"
-  EXECUTABLE introspection_service)
-rclcpp_components_register_node(services_library
-  PLUGIN "demo_nodes_cpp::IntrospectionClientNode"
-  EXECUTABLE introspection_client)
+# Services
+create_demo_library("demo_nodes_cpp::ServerNode" add_two_ints_server
+  FILES src/services/add_two_ints_server.cpp
+  DEPENDENCIES ${example_interfaces_TARGETS} rclcpp::rclcpp rclcpp_components::component)
+create_demo_library("demo_nodes_cpp::ClientNode" add_two_ints_client_async
+  FILES src/services/add_two_ints_client_async.cpp
+  DEPENDENCIES ${example_interfaces_TARGETS} rclcpp::rclcpp rclcpp_components::component)
+create_demo_library("demo_nodes_cpp::IntrospectionServiceNode" introspection_service
+  FILES src/services/introspection_service.cpp
+  DEPENDENCIES ${example_interfaces_TARGETS} ${rcl_interfaces_TARGETS} rcl::rcl rclcpp::rclcpp rclcpp_components::component)
+create_demo_library("demo_nodes_cpp::IntrospectionCLientNode" introspection_client
+  FILES src/services/introspection_client.cpp
+  DEPENDENCIES ${example_interfaces_TARGETS} ${rcl_interfaces_TARGETS} rcl::rcl rclcpp::rclcpp rclcpp_components::component)
 
-rclcpp_components_register_node(parameters_library
-  PLUGIN "demo_nodes_cpp::ListParameters"
-  EXECUTABLE list_parameters)
-rclcpp_components_register_node(parameters_library
-  PLUGIN "demo_nodes_cpp::ParameterBlackboard"
-  EXECUTABLE parameter_blackboard)
-rclcpp_components_register_node(parameters_library
-  PLUGIN "demo_nodes_cpp::SetAndGetParameters"
-  EXECUTABLE set_and_get_parameters)
-rclcpp_components_register_node(parameters_library
-  PLUGIN "demo_nodes_cpp::ParameterEventsAsyncNode"
-  EXECUTABLE parameter_events_async)
-rclcpp_components_register_node(parameters_library
-  PLUGIN "demo_nodes_cpp::EvenParameterNode"
-  EXECUTABLE even_parameters_node)
-rclcpp_components_register_node(parameters_library
-  PLUGIN "demo_nodes_cpp::SetParametersCallback"
-  EXECUTABLE set_parameters_callback)
-
-rclcpp_components_register_node(topics_library
-  PLUGIN "demo_nodes_cpp::ContentFilteringPublisher"
-  EXECUTABLE content_filtering_publisher)
-rclcpp_components_register_node(topics_library
-  PLUGIN "demo_nodes_cpp::ContentFilteringSubscriber"
-  EXECUTABLE content_filtering_subscriber)
-rclcpp_components_register_node(topics_library
-  PLUGIN "demo_nodes_cpp::Talker"
-  EXECUTABLE talker)
-rclcpp_components_register_node(topics_library
-  PLUGIN "demo_nodes_cpp::LoanedMessageTalker"
-  EXECUTABLE talker_loaned_message)
-rclcpp_components_register_node(topics_library
-  PLUGIN "demo_nodes_cpp::SerializedMessageTalker"
-  EXECUTABLE talker_serialized_message)
-rclcpp_components_register_node(topics_library
-  PLUGIN "demo_nodes_cpp::Listener"
-  EXECUTABLE listener)
-rclcpp_components_register_node(topics_library
-  PLUGIN "demo_nodes_cpp::SerializedMessageListener"
-  EXECUTABLE listener_serialized_message)
-rclcpp_components_register_node(topics_library
-  PLUGIN "demo_nodes_cpp::ListenerBestEffort"
-  EXECUTABLE listener_best_effort)
-
-install(TARGETS
-  timers_library
-  services_library
-  parameters_library
-  topics_library
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin)
+# Topics
+create_demo_library("demo_nodes_cpp::ContentFilteringPublisher" content_filtering_publisher
+  FILES src/topics/content_filtering_publisher.cpp
+  DEPENDENCIES rclcpp::rclcpp rclcpp_components::component ${std_msgs_TARGETS})
+create_demo_library("demo_nodes_cpp::ContentFilteringSubscriber" content_filtering_subscriber
+  FILES src/topics/content_filtering_subscriber.cpp
+  DEPENDENCIES rclcpp::rclcpp rclcpp_components::component rcpputils::rcpputils ${std_msgs_TARGETS})
+create_demo_library("demo_nodes_cpp::Talker" talker
+  FILES src/topics/talker.cpp
+  DEPENDENCIES rclcpp::rclcpp rclcpp_components::component ${std_msgs_TARGETS})
+create_demo_library("demo_nodes_cpp::LoanedMessageTalker" talker_loaned_message
+  FILES src/topics/talker_loaned_message.cpp
+  DEPENDENCIES rclcpp::rclcpp rclcpp_components::component ${std_msgs_TARGETS})
+create_demo_library("demo_nodes_cpp::SerializedMessageTalker" talker_serialized_message
+  FILES src/topics/talker_serialized_message.cpp
+  DEPENDENCIES rclcpp::rclcpp rclcpp_components::component ${std_msgs_TARGETS})
+create_demo_library("demo_nodes_cpp::Listener" listener
+  FILES src/topics/listener.cpp
+  DEPENDENCIES rclcpp::rclcpp rclcpp_components::component ${std_msgs_TARGETS})
+create_demo_library("demo_nodes_cpp::SerializedMessageListener" listener_serialized_message
+  FILES src/topics/listener_serialized_message.cpp
+  DEPENDENCIES rclcpp::rclcpp rclcpp_components::component ${std_msgs_TARGETS})
+create_demo_library("demo_nodes_cpp::ListenerBestEffort" listener_best_effort
+  FILES src/topics/listener_best_effort.cpp
+  DEPENDENCIES rclcpp::rclcpp rclcpp_components::component ${std_msgs_TARGETS})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/demo_nodes_cpp/CMakeLists.txt
+++ b/demo_nodes_cpp/CMakeLists.txt
@@ -14,9 +14,12 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(example_interfaces REQUIRED)
+find_package(rcl REQUIRED)
+find_package(rcl_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
-find_package(rcutils)
+find_package(rcpputils REQUIRED)
+find_package(rcutils REQUIRED)
 find_package(rmw REQUIRED)
 find_package(std_msgs REQUIRED)
 

--- a/demo_nodes_cpp/package.xml
+++ b/demo_nodes_cpp/package.xml
@@ -19,20 +19,23 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>example_interfaces</build_depend>
+  <build_depend>rcl</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>rclcpp_components</build_depend>
   <build_depend>rcl_interfaces</build_depend>
+  <build_depend>rcpputils</build_depend>
   <build_depend>rcutils</build_depend>
   <build_depend>rmw</build_depend>
-  <build_depend>rmw_implementation_cmake</build_depend>
   <build_depend>std_msgs</build_depend>
 
   <exec_depend>example_interfaces</exec_depend>
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>launch_xml</exec_depend>
+  <exec_depend>rcl</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclcpp_components</exec_depend>
   <exec_depend>rcl_interfaces</exec_depend>
+  <exec_depend>rcpputils</exec_depend>
   <exec_depend>rcutils</exec_depend>
   <exec_depend>rmw</exec_depend>
   <exec_depend>std_msgs</exec_depend>

--- a/demo_nodes_cpp/src/parameters/even_parameters_node.cpp
+++ b/demo_nodes_cpp/src/parameters/even_parameters_node.cpp
@@ -14,6 +14,7 @@
 
 #include <vector>
 
+#include "rcl_interfaces/msg/set_parameters_result.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
 

--- a/demo_nodes_cpp/src/parameters/parameter_event_handler.cpp
+++ b/demo_nodes_cpp/src/parameters/parameter_event_handler.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 
+#include "rcl_interfaces/msg/parameter_event.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 // A utility class to assist in spinning a separate node

--- a/demo_nodes_cpp/src/parameters/parameter_events.cpp
+++ b/demo_nodes_cpp/src/parameters/parameter_events.cpp
@@ -19,6 +19,7 @@
 #include <sstream>
 #include <utility>
 
+#include "rcl_interfaces/msg/parameter_event.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 using namespace std::chrono_literals;

--- a/demo_nodes_cpp/src/parameters/parameter_events_async.cpp
+++ b/demo_nodes_cpp/src/parameters/parameter_events_async.cpp
@@ -18,6 +18,8 @@
 #include <sstream>
 #include <vector>
 
+#include "rcl_interfaces/msg/parameter_event.hpp"
+#include "rcl_interfaces/msg/set_parameters_result.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
 

--- a/demo_nodes_cpp/src/topics/listener_serialized_message.cpp
+++ b/demo_nodes_cpp/src/topics/listener_serialized_message.cpp
@@ -12,17 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdio>
 #include <iostream>
 #include <memory>
 
-#include "rcl/types.h"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/serialization.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
 
 #include "std_msgs/msg/string.hpp"
-
-#include "rosidl_typesupport_cpp/message_type_support.hpp"
 
 #include "demo_nodes_cpp/visibility_control.h"
 

--- a/demo_nodes_cpp/src/topics/talker_loaned_message.cpp
+++ b/demo_nodes_cpp/src/topics/talker_loaned_message.cpp
@@ -19,7 +19,6 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
-#include "rcutils/cmdline_parser.h"
 
 #include "std_msgs/msg/float64.hpp"
 #include "std_msgs/msg/string.hpp"

--- a/demo_nodes_cpp/src/topics/talker_serialized_message.cpp
+++ b/demo_nodes_cpp/src/topics/talker_serialized_message.cpp
@@ -19,8 +19,6 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
 
-#include "rcutils/allocator.h"
-
 #include "std_msgs/msg/string.hpp"
 
 #include "rclcpp/serialization.hpp"


### PR DESCRIPTION
I was looking at demo_nodes_cpp, and I noticed a few different things:

1.  The includes in the various source files weren't always correct.  We were missing some includes, and we had some other includes that weren't actually being used.
2.  The dependencies weren't correctly specified, in that we were missing a couple.
3.  We don't really need to use `ament_target_dependencies` in the CMakeLists.txt; we can instead use `target_link_libraries`.
4.  There was actually quite a bit of duplication in the various install targets.  We could probably use a function to reduce duplication.

This PR fixes all of that, and removes about 10 lines of code in the process.