### PR TITLE
Dramatically speed up the demo_nodes_cpp tests

### DIFF
--- a/demo_nodes_cpp/CMakeLists.txt
+++ b/demo_nodes_cpp/CMakeLists.txt
@@ -159,7 +159,7 @@ if(BUILD_TESTING)
   # Add each test case.  Multi-executable tests can be specified in
   # semicolon-separated strings, like  exe1;exe2.
   set(tutorial_tests
-    "content_filtering_publisher:content_filtering_subscriber"
+    "content_filtering_publisher@publish_ms=100:content_filtering_subscriber"
     list_parameters_async
     list_parameters
     parameter_events_async

--- a/demo_nodes_cpp/CMakeLists.txt
+++ b/demo_nodes_cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12)
 
 project(demo_nodes_cpp)
 
@@ -168,7 +168,8 @@ if(BUILD_TESTING)
     set_and_get_parameters
     matched_event_detect
     use_logger_service
-    "talker:listener")
+    "talker:listener"
+  )
   set(service_tutorial_tests
     "add_two_ints_server:add_two_ints_client"
     "add_two_ints_server:add_two_ints_client_async"
@@ -179,18 +180,45 @@ if(BUILD_TESTING)
     list(APPEND tutorial_tests_to_test ${service_tutorial_tests})
 
     foreach(tutorial_test ${tutorial_tests_to_test})
-      string(REPLACE ":" ";" tutorial_executables "${tutorial_test}")
       set(DEMO_NODES_CPP_EXPECTED_OUTPUT "")
-      foreach(executable ${tutorial_executables})
-        list(APPEND DEMO_NODES_CPP_EXPECTED_OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/test/${executable}")
-      endforeach()
-
       set(DEMO_NODES_CPP_EXECUTABLE "")
-      foreach(executable ${tutorial_executables})
-        list(APPEND DEMO_NODES_CPP_EXECUTABLE "$<TARGET_FILE:${executable}>")
-      endforeach()
+      set(exe_list "")
 
-      string(REPLACE ";" "_" exe_list_underscore "${tutorial_executables}")
+      # We're expecting each tutorial_test to be of the form:
+      #
+      # exe1[@param1=value1@param2=value2][:exe2[@param3=value3@param4=value4]]
+      #
+      # That is, you can have one or more executables, and each of those
+      # executables can be passed zero or more parameters.
+      #
+      # Unfortunately, we need to parse this list here in CMake since we need
+      # to know the executable name so we can generate an absolute path.
+
+      # Convert the colon-separated list we were given to a semi-colon
+      # separated one so we can iterate over it in CMake.
+      string(REPLACE ":" ";" exes_and_params "${tutorial_test}")
+      foreach(exe_and_params ${exes_and_params})
+        string(REPLACE "@" ";" params ${exe_and_params})
+        # It is expected that the first variable is the executable
+        list(GET params 0 executable)
+        list(APPEND DEMO_NODES_CPP_EXPECTED_OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/test/${executable}")
+        list(APPEND exe_list ${executable})
+        set(target_file "$<TARGET_FILE:${executable}>")
+
+        # If there is anything left in the list at this time, assume they
+        # are parameters.
+        list(LENGTH params list_length)
+        if(${list_length} GREATER 1)
+          list(SUBLIST params 1 -1 params_only)
+          string(JOIN "@" target_file ${target_file} ${params_only})
+        endif()
+
+        # This is what will get substituted into test_executables_tutorial.py.in below.
+        # It looks exactly the same as exes_and_params, with the exception
+        # that the executable names have been substituted for the absolute paths.
+        list(APPEND DEMO_NODES_CPP_EXECUTABLE ${target_file})
+      endforeach()
+      string(REPLACE ";" "_" exe_list_underscore "${exe_list}")
       configure_file(
         test/test_executables_tutorial.py.in
         test_${exe_list_underscore}${target_suffix}.py.configured
@@ -209,7 +237,7 @@ if(BUILD_TESTING)
         RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
         RMW_IMPLEMENTATION=${rmw_implementation}
       )
-      foreach(executable ${tutorial_executables})
+      foreach(executable ${exe_list})
         set_property(
           TEST test_tutorial_${exe_list_underscore}${target_suffix}
           APPEND PROPERTY DEPENDS ${executable}${target_suffix})

--- a/demo_nodes_cpp/CMakeLists.txt
+++ b/demo_nodes_cpp/CMakeLists.txt
@@ -171,8 +171,8 @@ if(BUILD_TESTING)
     "talker:listener"
   )
   set(service_tutorial_tests
-    "add_two_ints_server:add_two_ints_client"
-    "add_two_ints_server:add_two_ints_client_async"
+    "add_two_ints_server@one_shot=True:add_two_ints_client"
+    "add_two_ints_server@one_shot=True:add_two_ints_client_async"
   )
 
   macro(tests)

--- a/demo_nodes_cpp/src/timers/one_off_timer.cpp
+++ b/demo_nodes_cpp/src/timers/one_off_timer.cpp
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 #include <chrono>
-#include <cstdio>
-#include <memory>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
@@ -26,24 +24,23 @@ using namespace std::chrono_literals;
 namespace demo_nodes_cpp
 {
 
-class OneOffTimerNode : public rclcpp::Node
+class OneOffTimerNode final : public rclcpp::Node
 {
 public:
   DEMO_NODES_CPP_PUBLIC
   explicit OneOffTimerNode(const rclcpp::NodeOptions & options)
-  : Node("one_off_timer", options), count(0)
+  : Node("one_off_timer", options), count_(0)
   {
-    setvbuf(stdout, NULL, _IONBF, BUFSIZ);
-    periodic_timer = this->create_wall_timer(
+    periodic_timer_ = this->create_wall_timer(
       2s,
       [this]() {
         RCLCPP_INFO(this->get_logger(), "in periodic_timer callback");
-        if (this->count++ % 3 == 0) {
+        if (this->count_++ % 3 == 0) {
           RCLCPP_INFO(this->get_logger(), "  resetting one off timer");
-          this->one_off_timer = this->create_wall_timer(
+          this->one_off_timer_ = this->create_wall_timer(
             1s, [this]() {
               RCLCPP_INFO(this->get_logger(), "in one_off_timer callback");
-              this->one_off_timer->cancel();
+              this->one_off_timer_->cancel();
             });
         } else {
           RCLCPP_INFO(this->get_logger(), "  not resetting one off timer");
@@ -51,9 +48,10 @@ public:
       });
   }
 
-  rclcpp::TimerBase::SharedPtr periodic_timer;
-  rclcpp::TimerBase::SharedPtr one_off_timer;
-  size_t count;
+private:
+  rclcpp::TimerBase::SharedPtr periodic_timer_;
+  rclcpp::TimerBase::SharedPtr one_off_timer_;
+  size_t count_;
 };
 
 }  // namespace demo_nodes_cpp

--- a/demo_nodes_cpp/src/timers/reuse_timer.cpp
+++ b/demo_nodes_cpp/src/timers/reuse_timer.cpp
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 #include <chrono>
-#include <cstdio>
-#include <memory>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
@@ -25,39 +23,39 @@ using namespace std::chrono_literals;
 namespace demo_nodes_cpp
 {
 
-class ReuseTimerNode : public rclcpp::Node
+class ReuseTimerNode final : public rclcpp::Node
 {
 public:
   DEMO_NODES_CPP_PUBLIC
   explicit ReuseTimerNode(const rclcpp::NodeOptions & options)
-  : Node("reuse_timer", options), count(0)
+  : Node("reuse_timer", options), count_(0)
   {
-    setvbuf(stdout, NULL, _IONBF, BUFSIZ);
-    one_off_timer = this->create_wall_timer(
+    one_off_timer_ = this->create_wall_timer(
       1s,
       [this]() {
         RCLCPP_INFO(this->get_logger(), "in one_off_timer callback");
-        this->one_off_timer->cancel();
+        this->one_off_timer_->cancel();
       });
     // cancel immediately to prevent it running the first time.
-    one_off_timer->cancel();
+    one_off_timer_->cancel();
 
-    periodic_timer = this->create_wall_timer(
+    periodic_timer_ = this->create_wall_timer(
       2s,
       [this]() {
         RCLCPP_INFO(this->get_logger(), "in periodic_timer callback");
-        if (this->count++ % 3 == 0) {
+        if (this->count_++ % 3 == 0) {
           RCLCPP_INFO(this->get_logger(), "  resetting one off timer");
-          this->one_off_timer->reset();
+          this->one_off_timer_->reset();
         } else {
           RCLCPP_INFO(this->get_logger(), "  not resetting one off timer");
         }
       });
   }
 
-  rclcpp::TimerBase::SharedPtr periodic_timer;
-  rclcpp::TimerBase::SharedPtr one_off_timer;
-  size_t count;
+private:
+  rclcpp::TimerBase::SharedPtr periodic_timer_;
+  rclcpp::TimerBase::SharedPtr one_off_timer_;
+  size_t count_;
 };
 
 }  // namespace demo_nodes_cpp

--- a/demo_nodes_cpp/src/topics/content_filtering_publisher.cpp
+++ b/demo_nodes_cpp/src/topics/content_filtering_publisher.cpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <array>
 #include <chrono>
-#include <cstdio>
 #include <memory>
 #include <utility>
 
@@ -24,8 +24,6 @@
 
 #include "demo_nodes_cpp/visibility_control.h"
 
-using namespace std::chrono_literals;
-
 namespace demo_nodes_cpp
 {
 // The simulated temperature data starts from -100.0 and ends at 150.0 with a step size of 10.0
@@ -33,7 +31,7 @@ constexpr std::array<float, 3> TEMPERATURE_SETTING {-100.0f, 150.0f, 10.0f};
 
 // Create a ContentFilteringPublisher class that subclasses the generic rclcpp::Node base class.
 // The main function below will instantiate the class as a ROS node.
-class ContentFilteringPublisher : public rclcpp::Node
+class ContentFilteringPublisher final : public rclcpp::Node
 {
 public:
   DEMO_NODES_CPP_PUBLIC
@@ -41,7 +39,6 @@ public:
   : Node("content_filtering_publisher", options)
   {
     // Create a function for when messages are to be sent.
-    setvbuf(stdout, NULL, _IONBF, BUFSIZ);
     auto publish_message =
       [this]() -> void
       {
@@ -63,8 +60,10 @@ public:
     rclcpp::QoS qos(rclcpp::KeepLast{7});
     pub_ = this->create_publisher<std_msgs::msg::Float32>("temperature", qos);
 
+    int64_t publish_ms = this->declare_parameter("publish_ms", 1000);
+
     // Use a timer to schedule periodic message publishing.
-    timer_ = this->create_wall_timer(1s, publish_message);
+    timer_ = this->create_wall_timer(std::chrono::milliseconds(publish_ms), publish_message);
   }
 
 private:

--- a/demo_nodes_cpp/src/topics/content_filtering_subscriber.cpp
+++ b/demo_nodes_cpp/src/topics/content_filtering_subscriber.cpp
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <array>
+#include <string>
+
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
 #include "rcpputils/join.hpp"
@@ -34,7 +37,6 @@ public:
   explicit ContentFilteringSubscriber(const rclcpp::NodeOptions & options)
   : Node("content_filtering_subscriber", options)
   {
-    setvbuf(stdout, NULL, _IONBF, BUFSIZ);
     // Create a callback function for when messages are received.
     auto callback =
       [this](const std_msgs::msg::Float32 & msg) -> void

--- a/demo_nodes_cpp/test/test_executables_tutorial.py.in
+++ b/demo_nodes_cpp/test/test_executables_tutorial.py.in
@@ -2,6 +2,7 @@
 # generated code does not contain a copyright notice
 
 import os
+import time
 
 import unittest
 
@@ -17,7 +18,6 @@ import launch_testing_ros
 
 def generate_test_description():
     env = os.environ.copy()
-    env['OSPL_VERBOSITY'] = '8'  # 8 = OS_NONE
     # bare minimum formatting for console output matching
     env['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '{message}'
 
@@ -63,11 +63,12 @@ class TestExecutablesTutorial(unittest.TestCase):
                     path=output_file
                 ), process=process, output_filter=output_filter, timeout=30
             )
-        # TODO(hidmic): either make the underlying executables resilient to
-        # interruptions close/during shutdown OR adapt the testing suite to
-        # better cope with it.
-        import time
-        time.sleep(5)
+
+            # Wait up to 5 seconds for the process to quit cleanly
+            tries = 50
+            while process.return_code is None and tries > 0:
+                time.sleep(0.1)
+                tries -= 1
 
 @launch_testing.post_shutdown_test()
 class TestExecutablesTutorialAfterShutdown(unittest.TestCase):

--- a/demo_nodes_cpp/test/test_executables_tutorial.py.in
+++ b/demo_nodes_cpp/test/test_executables_tutorial.py.in
@@ -22,14 +22,27 @@ def generate_test_description():
     env['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '{message}'
 
     launch_description = LaunchDescription()
-    processes_under_test = [
-        ExecuteProcess(
-            cmd=[executable],
-            name='test_executable_' + str(i),
-            output='screen',
-            env=env)
-        for i, executable in enumerate('@DEMO_NODES_CPP_EXECUTABLE@'.split(';'))
-    ]
+
+    processes_under_test = []
+    exes_and_params = '@DEMO_NODES_CPP_EXECUTABLE@'.split(';')
+    for i, exe_and_params in enumerate(exes_and_params):
+        tmp = exe_and_params.split('@')
+        cmd = [tmp[0]]
+        if len(tmp) > 1:
+            cmd.append('--ros-args')
+            for p in tmp[1:]:
+                cmd.append('-p')
+                cmd.append(p.replace('=', ':='))
+
+        processes_under_test.append(
+            ExecuteProcess(
+                cmd=cmd,
+                name='test_executable_' + str(i),
+                output='screen',
+                env=env,
+            )
+        )
+
     for process in processes_under_test:
         launch_description.add_action(process)
     launch_description.add_action(launch_testing.util.KeepAliveProc())


### PR DESCRIPTION
The purpose of this PR is to speed up the demo_nodes_cpp tests.  On my local machine, prior to this PR, the tests took ~5 minutes to run.  After this PR, they take ~1 minute.

To achieve this, this PR does a number of different things:
1.  Instead of waiting an unconditional 5 seconds for each process to quit, it runs a loop checking every 100 milliseconds for the process to quit, and doing this for up to 5 seconds.
2.  Change it so that we can pass parameters into the individual tests as we are running them.  This required work both in CMakeList.txt and in the test launcher, but facilitates the rest of the changes.
3.  Add parameters to `talker`, `listener`, `content_filtering_publisher`, and `add_two_ints_server` to control their behavior.  The major goal here is to keep their default behavior the same, but add in alternate modes to dramatically speed up tests.

The individual commits have more information about each change and why I made it.

This is still a draft because I want to run extensive CI on it, particularly on Windows.