### PR TITLE
Switch to using RCLCPP logging macros in the lifecycle package.

### DIFF
--- a/demo_nodes_cpp/src/topics/talker.cpp
+++ b/demo_nodes_cpp/src/topics/talker.cpp
@@ -45,7 +45,6 @@ public:
         msg_ = std::make_unique<std_msgs::msg::String>();
         msg_->data = "Hello World: " + std::to_string(count_++);
         RCLCPP_INFO(this->get_logger(), "Publishing: '%s'", msg_->data.c_str());
-        RCUTILS_LOG_INFO("RCUTILS_LOG_INFO: publishing");
         // Put the message into a queue to be processed by the middleware.
         // This call is non-blocking.
         pub_->publish(std::move(msg_));

--- a/lifecycle/src/lifecycle_talker.cpp
+++ b/lifecycle/src/lifecycle_talker.cpp
@@ -83,11 +83,9 @@ public:
     if (!pub_->is_activated()) {
       RCLCPP_INFO(
         get_logger(), "Lifecycle publisher is currently inactive. Messages are not published.");
-      RCUTILS_LOG_INFO("RCUTILS_LOG_INFO: inactive");
     } else {
       RCLCPP_INFO(
         get_logger(), "Lifecycle publisher is active. Publishing: [%s]", msg->data.c_str());
-      RCUTILS_LOG_INFO("RCUTILS_LOG_INFO: publishing");
     }
 
     // We independently from the current state call publish on the lifecycle
@@ -154,7 +152,7 @@ public:
     // Overriding this method is optional, a lot of times the default is enough.
     LifecycleNode::on_activate(state);
 
-    RCUTILS_LOG_INFO_NAMED(get_name(), "on_activate() is called.");
+    RCLCPP_INFO(get_logger(), "on_activate() is called.");
 
     // Let's sleep for 2 seconds.
     // We emulate we are doing important
@@ -190,7 +188,7 @@ public:
     // Overriding this method is optional, a lot of times the default is enough.
     LifecycleNode::on_deactivate(state);
 
-    RCUTILS_LOG_INFO_NAMED(get_name(), "on_deactivate() is called.");
+    RCLCPP_INFO(get_logger(), "on_deactivate() is called.");
 
     // We return a success and hence invoke the transition to the next
     // step: "inactive".
@@ -221,7 +219,7 @@ public:
     timer_.reset();
     pub_.reset();
 
-    RCUTILS_LOG_INFO_NAMED(get_name(), "on cleanup is called.");
+    RCLCPP_INFO(get_logger(), "on cleanup is called.");
 
     // We return a success and hence invoke the transition to the next
     // step: "unconfigured".
@@ -252,10 +250,7 @@ public:
     timer_.reset();
     pub_.reset();
 
-    RCUTILS_LOG_INFO_NAMED(
-      get_name(),
-      "on shutdown is called from state %s.",
-      state.label().c_str());
+    RCLCPP_INFO(get_logger(), "on shutdown is called from state %s.", state.label().c_str());
 
     // We return a success and hence invoke the transition to the next
     // step: "finalized".


### PR DESCRIPTION
This ensures that the logging will go out to rosout and to disk (if configured like that).