### PR TITLE
Add lifecycle subscriber example and test

### DIFF
--- a/lifecycle/CMakeLists.txt
+++ b/lifecycle/CMakeLists.txt
@@ -35,6 +35,14 @@ ament_target_dependencies(lifecycle_listener
   "rclcpp_lifecycle"
   "std_msgs"
 )
+add_executable(lifecycle_node_listener
+  src/lifecycle_node_listener.cpp)
+ament_target_dependencies(lifecycle_node_listener
+  "lifecycle_msgs"
+  "rclcpp"
+  "rclcpp_lifecycle"
+  "std_msgs"
+)
 add_executable(lifecycle_service_client
   src/lifecycle_service_client.cpp)
 ament_target_dependencies(lifecycle_service_client
@@ -45,6 +53,7 @@ ament_target_dependencies(lifecycle_service_client
 install(TARGETS
   lifecycle_talker
   lifecycle_listener
+  lifecycle_node_listener
   lifecycle_service_client
   DESTINATION lib/${PROJECT_NAME})
 

--- a/lifecycle/CMakeLists.txt
+++ b/lifecycle/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(lifecycle_listener
 ament_target_dependencies(lifecycle_listener
   "lifecycle_msgs"
   "rclcpp"
+  "rclcpp_lifecycle"
   "std_msgs"
 )
 add_executable(lifecycle_service_client

--- a/lifecycle/src/lifecycle_node_listener.cpp
+++ b/lifecycle/src/lifecycle_node_listener.cpp
@@ -60,27 +60,12 @@ public:
     return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
   }
 
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_activate(
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_shutdown(
     const rclcpp_lifecycle::State & state)
   {
-    RCLCPP_INFO(get_logger(), "on_activate() is called.");
-    LifecycleNode::on_activate(state);
-    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
-  }
-
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_deactivate(
-    const rclcpp_lifecycle::State & state)
-  {
-    RCLCPP_INFO(get_logger(), "on_deactivate() is called.");
-    LifecycleNode::on_deactivate(state);
-    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
-  }
-
-  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_cleanup(
-    const rclcpp_lifecycle::State & state)
-  {
-    RCLCPP_INFO(get_logger(), "on_cleanup() is called.");
-    LifecycleNode::on_cleanup(state);
+    sub_data_.reset();
+    sub_notification_.reset();
+    LifecycleNode::on_shutdown(state);
     return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
   }
 


### PR DESCRIPTION
This adds a lifecycle subscriber example and test linked to the [PR](https://github.com/ros2/rclcpp/pull/2254 ) that implements the lifecycle subscriber.