### PR TITLE
Remove unnecessary captures in the various demos.

### DIFF
--- a/demo_nodes_cpp/src/parameters/set_parameters_callback.cpp
+++ b/demo_nodes_cpp/src/parameters/set_parameters_callback.cpp
@@ -47,7 +47,7 @@ public:
     // setting another parameter from the callback is possible
     // we expect the callback to be called for param2
     auto pre_set_parameter_callback =
-      [this](std::vector<rclcpp::Parameter> & parameters) {
+      [](std::vector<rclcpp::Parameter> & parameters) {
         for (auto & param : parameters) {
           // if "param1" is being set try setting "param2" as well.
           if (param.get_name() == "param1") {
@@ -58,7 +58,7 @@ public:
 
     // validation callback
     auto on_set_parameter_callback =
-      [this](std::vector<rclcpp::Parameter> parameters) {
+      [](std::vector<rclcpp::Parameter> parameters) {
         rcl_interfaces::msg::SetParametersResult result;
         result.successful = true;
 

--- a/demo_nodes_cpp/src/services/introspection_client.cpp
+++ b/demo_nodes_cpp/src/services/introspection_client.cpp
@@ -70,7 +70,7 @@ public:
     client_ = create_client<example_interfaces::srv::AddTwoInts>("add_two_ints");
 
     auto on_set_parameter_callback =
-      [this](std::vector<rclcpp::Parameter> parameters) {
+      [](std::vector<rclcpp::Parameter> parameters) {
         rcl_interfaces::msg::SetParametersResult result;
         result.successful = true;
         for (const rclcpp::Parameter & param : parameters) {

--- a/demo_nodes_cpp/src/services/introspection_service.cpp
+++ b/demo_nodes_cpp/src/services/introspection_service.cpp
@@ -80,7 +80,7 @@ public:
     srv_ = create_service<example_interfaces::srv::AddTwoInts>("add_two_ints", handle_add_two_ints);
 
     auto on_set_parameter_callback =
-      [this](std::vector<rclcpp::Parameter> parameters) {
+      [](std::vector<rclcpp::Parameter> parameters) {
         rcl_interfaces::msg::SetParametersResult result;
         result.successful = true;
         for (const rclcpp::Parameter & param : parameters) {


### PR DESCRIPTION
This was pointed out by building with clang.