### PR TITLE
fix(action_tutorials_cpp): Do not drop future returned by async_send_…

### DIFF
--- a/action_tutorials/action_tutorials_cpp/src/fibonacci_action_client.cpp
+++ b/action_tutorials/action_tutorials_cpp/src/fibonacci_action_client.cpp
@@ -73,12 +73,13 @@ public:
       std::bind(&FibonacciActionClient::feedback_callback, this, _1, _2);
     send_goal_options.result_callback =
       std::bind(&FibonacciActionClient::result_callback, this, _1);
-    this->client_ptr_->async_send_goal(goal_msg, send_goal_options);
+    goal_future_ = this->client_ptr_->async_send_goal(goal_msg, send_goal_options);
   }
 
 private:
   rclcpp_action::Client<Fibonacci>::SharedPtr client_ptr_;
   rclcpp::TimerBase::SharedPtr timer_;
+  std::shared_future<GoalHandleFibonacci::SharedPtr> goal_future_;
 
   ACTION_TUTORIALS_CPP_LOCAL
   void goal_response_callback(GoalHandleFibonacci::SharedPtr goal_handle)


### PR DESCRIPTION
…goal

This is part of https://github.com/ros2/rclcpp/pull/2296