### PR TITLE
Replacing old-style C++ allocator with a polymorphic memory resource (PMR)

### DIFF
--- a/demo_nodes_cpp/src/topics/allocator_tutorial.cpp
+++ b/demo_nodes_cpp/src/topics/allocator_tutorial.cpp
@@ -15,9 +15,9 @@
 #include <chrono>
 #include <list>
 #include <memory>
+#include <memory_resource>
 #include <string>
 #include <utility>
-#include <memory_resource>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/allocator/allocator_common.hpp"
@@ -30,16 +30,20 @@ using namespace std::chrono_literals;
 static uint32_t num_allocs = 0;
 static uint32_t num_deallocs = 0;
 // A very simple custom memory resource. Counts calls to do_allocate and do_deallocate.
-class CustomMemoryResource : public std::pmr::memory_resource {
+class CustomMemoryResource : public std::pmr::memory_resource
+{
 private:
-  void* do_allocate(std::size_t bytes, std::size_t alignment) override {
+  void * do_allocate(std::size_t bytes, std::size_t alignment) override
+  {
     num_allocs++;
     (void)alignment;
     return std::malloc(bytes);
   }
 
-  void do_deallocate(void* p, std::size_t bytes,
-                     std::size_t alignment) override {
+  void do_deallocate(
+    void * p, std::size_t bytes,
+    std::size_t alignment) override
+  {
     num_deallocs++;
     (void)bytes;
     (void)alignment;
@@ -47,7 +51,8 @@ private:
   }
 
   bool do_is_equal(
-      const std::pmr::memory_resource& other) const noexcept override {
+    const std::pmr::memory_resource & other) const noexcept override
+  {
     return this == &other;
   }
 };

--- a/demo_nodes_cpp/src/topics/allocator_tutorial.cpp
+++ b/demo_nodes_cpp/src/topics/allocator_tutorial.cpp
@@ -17,6 +17,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <memory_resource>
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/allocator/allocator_common.hpp"
@@ -28,69 +29,29 @@ using namespace std::chrono_literals;
 // For demonstration purposes only, not necessary for allocator_traits
 static uint32_t num_allocs = 0;
 static uint32_t num_deallocs = 0;
-// A very simple custom allocator. Counts calls to allocate and deallocate.
-template<typename T = void>
-struct MyAllocator
-{
-public:
-  using value_type = T;
-  using size_type = std::size_t;
-  using pointer = T *;
-  using const_pointer = const T *;
-  using difference_type = typename std::pointer_traits<pointer>::difference_type;
-
-  MyAllocator() noexcept
-  {
-  }
-
-  ~MyAllocator() noexcept {}
-
-  template<typename U>
-  MyAllocator(const MyAllocator<U> &) noexcept
-  {
-  }
-
-  T * allocate(size_t size, const void * = 0)
-  {
-    if (size == 0) {
-      return nullptr;
-    }
+// A very simple custom memory resource. Counts calls to do_allocate and do_deallocate.
+class CustomMemoryResource : public std::pmr::memory_resource {
+private:
+  void* do_allocate(std::size_t bytes, std::size_t alignment) override {
     num_allocs++;
-    return static_cast<T *>(std::malloc(size * sizeof(T)));
+    (void)alignment;
+    return std::malloc(bytes);
   }
 
-  void deallocate(T * ptr, size_t size)
-  {
-    (void)size;
-    if (!ptr) {
-      return;
-    }
+  void do_deallocate(void* p, std::size_t bytes,
+                     std::size_t alignment) override {
     num_deallocs++;
-    std::free(ptr);
+    (void)bytes;
+    (void)alignment;
+    std::free(p);
   }
 
-  template<typename U>
-  struct rebind
-  {
-    typedef MyAllocator<U> other;
-  };
+  bool do_is_equal(
+      const std::pmr::memory_resource& other) const noexcept override {
+    return this == &other;
+  }
 };
 
-template<typename T, typename U>
-constexpr bool operator==(
-  const MyAllocator<T> &,
-  const MyAllocator<U> &) noexcept
-{
-  return true;
-}
-
-template<typename T, typename U>
-constexpr bool operator!=(
-  const MyAllocator<T> &,
-  const MyAllocator<U> &) noexcept
-{
-  return false;
-}
 
 // Override global new and delete to count calls during execution.
 
@@ -130,7 +91,7 @@ void operator delete(void * ptr) noexcept
 int main(int argc, char ** argv)
 {
   using rclcpp::memory_strategies::allocator_memory_strategy::AllocatorMemoryStrategy;
-  using Alloc = MyAllocator<void>;
+  using Alloc = std::pmr::polymorphic_allocator<void>;
   using MessageAllocTraits =
     rclcpp::allocator::AllocRebind<std_msgs::msg::UInt32, Alloc>;
   using MessageAlloc = MessageAllocTraits::allocator_type;
@@ -184,7 +145,8 @@ int main(int argc, char ** argv)
     };
 
   // Create a custom allocator and pass the allocator to the publisher and subscriber.
-  auto alloc = std::make_shared<Alloc>();
+  CustomMemoryResource mem_resource{};
+  auto alloc = std::make_shared<Alloc>(&mem_resource);
   rclcpp::PublisherOptionsWithAllocator<Alloc> publisher_options;
   publisher_options.allocator = alloc;
   auto publisher = node->create_publisher<std_msgs::msg::UInt32>(


### PR DESCRIPTION
This is a basic example mimicking the original demo. We could use a more advanced resource, like `unsynchronized_pool_resource`, for a realistic scenario.