### PR TITLE
Explicit time conversion

### DIFF
--- a/quality_of_service_demo/rclcpp/src/message_lost_listener.cpp
+++ b/quality_of_service_demo/rclcpp/src/message_lost_listener.cpp
@@ -33,7 +33,8 @@ public:
       [this](const sensor_msgs::msg::Image::ConstSharedPtr msg) -> void
       {
         rclcpp::Time now = this->get_clock()->now();
-        auto diff = now - msg->header.stamp;
+        rclcpp::Time stamp_time(msg->header.stamp, RCL_ROS_TIME);
+        auto diff = now - stamp_time;
         RCLCPP_INFO(
           this->get_logger(),
           "I heard an image. Message single trip latency: [%f]",

--- a/quality_of_service_demo/rclcpp/src/qos_overrides_listener.cpp
+++ b/quality_of_service_demo/rclcpp/src/qos_overrides_listener.cpp
@@ -34,7 +34,8 @@ public:
       [this](sensor_msgs::msg::Image::ConstSharedPtr msg) -> void
       {
         rclcpp::Time now = this->get_clock()->now();
-        auto diff = now - msg->header.stamp;
+        rclcpp::Time stamp_time(msg->header.stamp, RCL_ROS_TIME);
+        auto diff = now - stamp_time;
         RCLCPP_INFO(
           this->get_logger(),
           "I heard an image. Message single trip latency: [%f]",


### PR DESCRIPTION
To conform with potential breaking changes introduced in https://github.com/ros2/rclcpp/pull/2293

Here I opted to be fully explicit, including the default RCL_ROS_TIME into the constructor call. There are no changes to the overall behavior.