### PR TITLE
Fix format-security warning with clang.

### DIFF
--- a/action_tutorials/action_tutorials_cpp/src/fibonacci_action_client.cpp
+++ b/action_tutorials/action_tutorials_cpp/src/fibonacci_action_client.cpp
@@ -86,7 +86,7 @@ public:
         for (auto number : feedback->partial_sequence) {
           ss << number << " ";
         }
-        RCLCPP_INFO(this->get_logger(), ss.str().c_str());
+        RCLCPP_INFO(this->get_logger(), "%s", ss.str().c_str());
       };
 
     send_goal_options.result_callback = [this](
@@ -110,7 +110,7 @@ public:
         for (auto number : result.result->sequence) {
           ss << number << " ";
         }
-        RCLCPP_INFO(this->get_logger(), ss.str().c_str());
+        RCLCPP_INFO(this->get_logger(), "%s", ss.str().c_str());
         rclcpp::shutdown();
       };
 


### PR DESCRIPTION
In particular, make sure to use a "%s" format string.