### PR TITLE
Clearer Display of OpenCV window in image_tools/showimage ROS2 node 

### DIFF
--- a/image_tools/src/showimage.cpp
+++ b/image_tools/src/showimage.cpp
@@ -186,7 +186,12 @@ private:
         cv::cvtColor(frame, frame, cv::COLOR_YUV2BGR_YUYV);
       }
 
-      // Show the image in a window
+      // Define starting position of OpenCV window.
+      int x_position = 0;
+      int y_position = 0;
+      cv::moveWindow(window_name_, x_position, y_position);
+
+      // Show the image in OpenCV window
       cv::imshow(window_name_, frame);
       // Draw the screen and wait for 1 millisecond.
       cv::waitKey(1);


### PR DESCRIPTION
## **What Is This For?**

The **purpose** of this pull request is to **introduce a small but helpful change** to the `showimage` ROS 2 node under the `image_tools` package.

This change includes **a few new lines** under the file `image_tools/src/showimage.cpp` that defines the starting position for an OpenCV window display at `x=0, y=0` desktop pixel position; the top-left corner of a user's desktop.

## **Why?**

I have been using `image_tools` for a quite a while now. Here are the following reasons why I believe this small change could help improve the user experience for any developers who used the ROS 2 node in their own project:

1.  When displaying camera images, **the image would be cut-off** when it is too big to fit within desktop boundaries (Eg. 4K web cam images). Displaying on the upper-left corner helps reduce that inconvenience.
2. This standardizes the position of the OpenCV window and account for more deterministic behaviour during testing.

## **Other Remarks**

In order to better fit the OpenCV window into a user's desktop automatically, I am considering implementing a **resize** feature within `showimage` of `image_tools` ROS 2 package (which should not take long actually).

However, I fear it may introduce additional dependencies which may complicate testing down the line. **To the maintainers, do let me know your thoughts on this.** In the meantime, will do my own testing offline and update if it is just a false fear.

**Welcoming any constructive feedbacks on this matter** and what I can do to contribute to this amazing community. **To the maintainers, thank you for the work you have done so far** in this repository and will continue to support in whatever way I can, given personal bandwidth. :relaxed: 