### PR TITLE
Fix gcc warnings when building with optimizations.

### DIFF
--- a/demo_nodes_cpp/src/topics/allocator_tutorial_pmr.cpp
+++ b/demo_nodes_cpp/src/topics/allocator_tutorial_pmr.cpp
@@ -16,6 +16,7 @@
 #include <list>
 #include <memory>
 #include <memory_resource>
+#include <stdexcept>
 #include <string>
 #include <utility>
 
@@ -66,10 +67,20 @@ static uint32_t global_runtime_deallocs = 0;
 
 void * operator new(std::size_t size)
 {
+  if (size == 0) {
+    ++size;
+  }
+
   if (is_running) {
     global_runtime_allocs++;
   }
-  return std::malloc(size);
+
+  void * ptr = std::malloc(size);
+  if (ptr != nullptr) {
+    return ptr;
+  }
+
+  throw std::bad_alloc{};
 }
 
 void operator delete(void * ptr, size_t size) noexcept

--- a/demo_nodes_cpp/src/topics/allocator_tutorial_pmr.cpp
+++ b/demo_nodes_cpp/src/topics/allocator_tutorial_pmr.cpp
@@ -69,12 +69,12 @@ static uint32_t global_runtime_deallocs = 0;
 // always inline the overridden new and delete operators.
 
 #if defined(__GNUC__) || defined(__clang__)
-#define ALWAYS_INLINE __attribute__((always_inline))
+#define NOINLINE __attribute__((noinline))
 #else
-#define ALWAYS_INLINE
+#define NOINLINE
 #endif
 
-inline ALWAYS_INLINE void * operator new(std::size_t size)
+NOINLINE void * operator new(std::size_t size)
 {
   if (size == 0) {
     ++size;
@@ -92,7 +92,7 @@ inline ALWAYS_INLINE void * operator new(std::size_t size)
   throw std::bad_alloc{};
 }
 
-inline ALWAYS_INLINE void operator delete(void * ptr, size_t size) noexcept
+NOINLINE void operator delete(void * ptr, size_t size) noexcept
 {
   (void)size;
   if (ptr != nullptr) {
@@ -103,7 +103,7 @@ inline ALWAYS_INLINE void operator delete(void * ptr, size_t size) noexcept
   }
 }
 
-inline ALWAYS_INLINE void operator delete(void * ptr) noexcept
+NOINLINE void operator delete(void * ptr) noexcept
 {
   if (ptr != nullptr) {
     if (is_running) {

--- a/demo_nodes_cpp/src/topics/allocator_tutorial_pmr.cpp
+++ b/demo_nodes_cpp/src/topics/allocator_tutorial_pmr.cpp
@@ -65,7 +65,16 @@ static bool is_running = false;
 static uint32_t global_runtime_allocs = 0;
 static uint32_t global_runtime_deallocs = 0;
 
-void * operator new(std::size_t size)
+// Due to GCC bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103993, we
+// always inline the overridden new and delete operators.
+
+#if defined(__GNUC__) || defined(__clang__)
+#define ALWAYS_INLINE __attribute__((always_inline))
+#else
+#define ALWAYS_INLINE
+#endif
+
+inline ALWAYS_INLINE void * operator new(std::size_t size)
 {
   if (size == 0) {
     ++size;
@@ -83,7 +92,7 @@ void * operator new(std::size_t size)
   throw std::bad_alloc{};
 }
 
-void operator delete(void * ptr, size_t size) noexcept
+inline ALWAYS_INLINE void operator delete(void * ptr, size_t size) noexcept
 {
   (void)size;
   if (ptr != nullptr) {
@@ -94,7 +103,7 @@ void operator delete(void * ptr, size_t size) noexcept
   }
 }
 
-void operator delete(void * ptr) noexcept
+inline ALWAYS_INLINE void operator delete(void * ptr) noexcept
 {
   if (ptr != nullptr) {
     if (is_running) {


### PR DESCRIPTION
When building the allocator_tutorial_pmr demo with -O2, gcc is throwing an error saying that new and delete are mismatched.  This is something of a misnomer, however; the real problem is that the global new override we have in that demo is actually implemented incorrectly.

In particular, the documentation at
https://en.cppreference.com/w/cpp/memory/new/operator_new very clearly specifies that operator new either has to return a valid pointer, or throw an exception on error. Our version wasn't throwing the exception, so change it to throw std::bad_alloc if std::malloc fails.

While we are in here, also fix another small possible is where std::malloc could return nullptr on a zero-sized object, thus throwing an exception it shouldn't.