### PR TITLE
Switching to example_interfaces

### DIFF
--- a/composition/CMakeLists.txt
+++ b/composition/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(example_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(rcutils REQUIRED)
-find_package(std_msgs REQUIRED)
+find_package(example_interfaces REQUIRED)
 
 include_directories(include)
 
@@ -31,7 +31,7 @@ target_compile_definitions(talker_component
 ament_target_dependencies(talker_component
   "rclcpp"
   "rclcpp_components"
-  "std_msgs")
+  "example_interfaces")
 rclcpp_components_register_nodes(talker_component "composition::Talker")
 set(node_plugins "${node_plugins}composition::Talker;$<TARGET_FILE:talker_component>\n")
 
@@ -42,7 +42,7 @@ target_compile_definitions(listener_component
 ament_target_dependencies(listener_component
   "rclcpp"
   "rclcpp_components"
-  "std_msgs")
+  "example_interfaces")
 rclcpp_components_register_nodes(listener_component "composition::Listener")
 set(node_plugins "${node_plugins}composition::Listener;$<TARGET_FILE:listener_component>\n")
 
@@ -53,7 +53,7 @@ target_compile_definitions(node_like_listener_component
 ament_target_dependencies(node_like_listener_component
   "rclcpp"
   "rclcpp_components"
-  "std_msgs")
+  "example_interfaces")
 rclcpp_components_register_nodes(node_like_listener_component "composition::NodeLikeListener")
 set(node_plugins "${node_plugins}composition::NodeLikeListener;$<TARGET_FILE:node_like_listener_component>\n")
 

--- a/composition/include/composition/listener_component.hpp
+++ b/composition/include/composition/listener_component.hpp
@@ -17,7 +17,7 @@
 
 #include "composition/visibility_control.h"
 #include "rclcpp/rclcpp.hpp"
-#include "std_msgs/msg/string.hpp"
+#include "example_interfaces/msg/string.hpp"
 
 namespace composition
 {
@@ -29,7 +29,7 @@ public:
   explicit Listener(const rclcpp::NodeOptions & options);
 
 private:
-  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr sub_;
+  rclcpp::Subscription<example_interfaces::msg::String>::SharedPtr sub_;
 };
 
 }  // namespace composition

--- a/composition/include/composition/node_like_listener_component.hpp
+++ b/composition/include/composition/node_like_listener_component.hpp
@@ -17,7 +17,7 @@
 
 #include "composition/visibility_control.h"
 #include "rclcpp/rclcpp.hpp"
-#include "std_msgs/msg/string.hpp"
+#include "example_interfaces/msg/string.hpp"
 
 namespace composition
 {
@@ -34,7 +34,7 @@ public:
 
 private:
   rclcpp::Node::SharedPtr node_;
-  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr sub_;
+  rclcpp::Subscription<example_interfaces::msg::String>::SharedPtr sub_;
 };
 
 }  // namespace composition

--- a/composition/include/composition/talker_component.hpp
+++ b/composition/include/composition/talker_component.hpp
@@ -17,7 +17,7 @@
 
 #include "composition/visibility_control.h"
 #include "rclcpp/rclcpp.hpp"
-#include "std_msgs/msg/string.hpp"
+#include "example_interfaces/msg/string.hpp"
 
 namespace composition
 {
@@ -33,7 +33,7 @@ protected:
 
 private:
   size_t count_;
-  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr pub_;
+  rclcpp::Publisher<example_interfaces::msg::String>::SharedPtr pub_;
   rclcpp::TimerBase::SharedPtr timer_;
 };
 

--- a/composition/package.xml
+++ b/composition/package.xml
@@ -19,14 +19,14 @@
   <build_depend>rclcpp</build_depend>
   <build_depend>rclcpp_components</build_depend>
   <build_depend>rcutils</build_depend>
-  <build_depend>std_msgs</build_depend>
+  <build_depend>example_interfaces</build_depend>
 
   <exec_depend>example_interfaces</exec_depend>
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclcpp_components</exec_depend>
   <exec_depend>rcutils</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>example_interfaces</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/composition/src/listener_component.cpp
+++ b/composition/src/listener_component.cpp
@@ -18,7 +18,7 @@
 #include <memory>
 
 #include "rclcpp/rclcpp.hpp"
-#include "std_msgs/msg/string.hpp"
+#include "example_interfaces/msg/string.hpp"
 
 namespace composition
 {
@@ -32,7 +32,7 @@ Listener::Listener(const rclcpp::NodeOptions & options)
   // Create a callback function for when messages are received.
   // Variations of this function also exist using, for example, UniquePtr for zero-copy transport.
   auto callback =
-    [this](std_msgs::msg::String::ConstSharedPtr msg) -> void
+    [this](example_interfaces::msg::String::ConstSharedPtr msg) -> void
     {
       RCLCPP_INFO(this->get_logger(), "I heard: [%s]", msg->data.c_str());
       std::flush(std::cout);
@@ -42,7 +42,7 @@ Listener::Listener(const rclcpp::NodeOptions & options)
   // compatible ROS publishers.
   // Note that not all publishers on the same topic with the same type will be compatible:
   // they must have compatible Quality of Service policies.
-  sub_ = create_subscription<std_msgs::msg::String>("chatter", 10, callback);
+  sub_ = create_subscription<example_interfaces::msg::String>("chatter", 10, callback);
 }
 
 }  // namespace composition

--- a/composition/src/node_like_listener_component.cpp
+++ b/composition/src/node_like_listener_component.cpp
@@ -18,7 +18,7 @@
 #include <memory>
 
 #include "rclcpp/rclcpp.hpp"
-#include "std_msgs/msg/string.hpp"
+#include "example_interfaces/msg/string.hpp"
 
 namespace composition
 {
@@ -38,7 +38,7 @@ NodeLikeListener::NodeLikeListener(const rclcpp::NodeOptions & options)
   // Create a callback function for when messages are received.
   // Variations of this function also exist using, for example, UniquePtr for zero-copy transport.
   auto callback =
-    [this](std_msgs::msg::String::ConstSharedPtr msg) -> void
+    [this](example_interfaces::msg::String::ConstSharedPtr msg) -> void
     {
       RCLCPP_INFO(this->node_->get_logger(), "I heard: [%s]", msg->data.c_str());
       std::flush(std::cout);
@@ -48,7 +48,7 @@ NodeLikeListener::NodeLikeListener(const rclcpp::NodeOptions & options)
   // compatible ROS publishers.
   // Note that not all publishers on the same topic with the same type will be compatible:
   // they must have compatible Quality of Service policies.
-  sub_ = this->node_->create_subscription<std_msgs::msg::String>("chatter", 10, callback);
+  sub_ = this->node_->create_subscription<example_interfaces::msg::String>("chatter", 10, callback);
 }
 
 rclcpp::node_interfaces::NodeBaseInterface::SharedPtr

--- a/composition/src/talker_component.cpp
+++ b/composition/src/talker_component.cpp
@@ -20,7 +20,7 @@
 #include <utility>
 
 #include "rclcpp/rclcpp.hpp"
-#include "std_msgs/msg/string.hpp"
+#include "example_interfaces/msg/string.hpp"
 
 using namespace std::chrono_literals;
 
@@ -33,8 +33,8 @@ namespace composition
 Talker::Talker(const rclcpp::NodeOptions & options)
 : Node("talker", options), count_(0)
 {
-  // Create a publisher of "std_mgs/String" messages on the "chatter" topic.
-  pub_ = create_publisher<std_msgs::msg::String>("chatter", 10);
+  // Create a publisher of "example_interfaces/msg/String" messages on the "chatter" topic.
+  pub_ = create_publisher<example_interfaces::msg::String>("chatter", 10);
 
   // Use a timer to schedule periodic message publishing.
   timer_ = create_wall_timer(1s, [this]() {return this->on_timer();});
@@ -42,7 +42,7 @@ Talker::Talker(const rclcpp::NodeOptions & options)
 
 void Talker::on_timer()
 {
-  auto msg = std::make_unique<std_msgs::msg::String>();
+  auto msg = std::make_unique<example_interfaces::msg::String>();
   msg->data = "Hello World: " + std::to_string(++count_);
   RCLCPP_INFO(this->get_logger(), "Publishing: '%s'", msg->data.c_str());
   std::flush(std::cout);

--- a/demo_nodes_cpp/CMakeLists.txt
+++ b/demo_nodes_cpp/CMakeLists.txt
@@ -21,7 +21,7 @@ find_package(rclcpp_components REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rmw REQUIRED)
-find_package(std_msgs REQUIRED)
+find_package(example_interfaces REQUIRED)
 
 function(custom_executable subfolder target)
   cmake_parse_arguments(ARG "" "" "DEPENDENCIES" ${ARGN})
@@ -50,7 +50,7 @@ target_include_directories(allocator_tutorial PRIVATE
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 target_link_libraries(allocator_tutorial PRIVATE
   rclcpp::rclcpp
-  ${std_msgs_TARGETS}
+  ${example_interfaces_TARGETS}
 )
 install(TARGETS allocator_tutorial
   DESTINATION lib/${PROJECT_NAME})
@@ -71,10 +71,10 @@ custom_executable(parameters set_and_get_parameters_async
   DEPENDENCIES rclcpp::rclcpp)
 
 custom_executable(events matched_event_detect
-  DEPENDENCIES rclcpp::rclcpp ${std_msgs_TARGETS})
+  DEPENDENCIES rclcpp::rclcpp ${example_interfaces_TARGETS})
 
 custom_executable(logging use_logger_service
-  DEPENDENCIES ${rcl_interfaces_TARGETS} rclcpp::rclcpp ${std_msgs_TARGETS})
+  DEPENDENCIES ${rcl_interfaces_TARGETS} rclcpp::rclcpp ${example_interfaces_TARGETS})
 
 function(create_demo_library plugin executable)
   cmake_parse_arguments(ARG "" "" "FILES;DEPENDENCIES" ${ARGN})
@@ -145,28 +145,28 @@ create_demo_library("demo_nodes_cpp::IntrospectionClientNode" introspection_clie
 # Topics
 create_demo_library("demo_nodes_cpp::ContentFilteringPublisher" content_filtering_publisher
   FILES src/topics/content_filtering_publisher.cpp
-  DEPENDENCIES rclcpp::rclcpp rclcpp_components::component ${std_msgs_TARGETS})
+  DEPENDENCIES rclcpp::rclcpp rclcpp_components::component ${example_interfaces_TARGETS})
 create_demo_library("demo_nodes_cpp::ContentFilteringSubscriber" content_filtering_subscriber
   FILES src/topics/content_filtering_subscriber.cpp
-  DEPENDENCIES rclcpp::rclcpp rclcpp_components::component rcpputils::rcpputils ${std_msgs_TARGETS})
+  DEPENDENCIES rclcpp::rclcpp rclcpp_components::component rcpputils::rcpputils ${example_interfaces_TARGETS})
 create_demo_library("demo_nodes_cpp::Talker" talker
   FILES src/topics/talker.cpp
-  DEPENDENCIES rclcpp::rclcpp rclcpp_components::component ${std_msgs_TARGETS})
+  DEPENDENCIES rclcpp::rclcpp rclcpp_components::component ${example_interfaces_TARGETS})
 create_demo_library("demo_nodes_cpp::LoanedMessageTalker" talker_loaned_message
   FILES src/topics/talker_loaned_message.cpp
-  DEPENDENCIES rclcpp::rclcpp rclcpp_components::component ${std_msgs_TARGETS})
+  DEPENDENCIES rclcpp::rclcpp rclcpp_components::component ${example_interfaces_TARGETS})
 create_demo_library("demo_nodes_cpp::SerializedMessageTalker" talker_serialized_message
   FILES src/topics/talker_serialized_message.cpp
-  DEPENDENCIES rclcpp::rclcpp rclcpp_components::component ${std_msgs_TARGETS})
+  DEPENDENCIES rclcpp::rclcpp rclcpp_components::component ${example_interfaces_TARGETS})
 create_demo_library("demo_nodes_cpp::Listener" listener
   FILES src/topics/listener.cpp
-  DEPENDENCIES rclcpp::rclcpp rclcpp_components::component ${std_msgs_TARGETS})
+  DEPENDENCIES rclcpp::rclcpp rclcpp_components::component ${example_interfaces_TARGETS})
 create_demo_library("demo_nodes_cpp::SerializedMessageListener" listener_serialized_message
   FILES src/topics/listener_serialized_message.cpp
-  DEPENDENCIES rclcpp::rclcpp rclcpp_components::component ${std_msgs_TARGETS})
+  DEPENDENCIES rclcpp::rclcpp rclcpp_components::component ${example_interfaces_TARGETS})
 create_demo_library("demo_nodes_cpp::ListenerBestEffort" listener_best_effort
   FILES src/topics/listener_best_effort.cpp
-  DEPENDENCIES rclcpp::rclcpp rclcpp_components::component ${std_msgs_TARGETS})
+  DEPENDENCIES rclcpp::rclcpp rclcpp_components::component ${example_interfaces_TARGETS})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/demo_nodes_cpp/README.md
+++ b/demo_nodes_cpp/README.md
@@ -198,7 +198,7 @@ ros2 run demo_nodes_cpp set_and_get_parameters_async
 
 ### Allocator Tutorial
 
-This runs `allocator_tutorial` ROS 2 node that publishes a `std_msgs/msg/UInt32` message that contains an integer representing the number of allocations and deallocations that happened during the program.
+This runs `allocator_tutorial` ROS 2 node that publishes a `example_interfaces/msg/UInt32` message that contains an integer representing the number of allocations and deallocations that happened during the program.
 
 ```bash
 # Open new terminal

--- a/demo_nodes_cpp/package.xml
+++ b/demo_nodes_cpp/package.xml
@@ -25,7 +25,7 @@
   <build_depend>rcpputils</build_depend>
   <build_depend>rcutils</build_depend>
   <build_depend>rmw</build_depend>
-  <build_depend>std_msgs</build_depend>
+  <build_depend>example_interfaces</build_depend>
 
   <exec_depend>example_interfaces</exec_depend>
   <exec_depend>launch_ros</exec_depend>
@@ -37,7 +37,7 @@
   <exec_depend>rcpputils</exec_depend>
   <exec_depend>rcutils</exec_depend>
   <exec_depend>rmw</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>example_interfaces</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/demo_nodes_cpp/src/events/matched_event_detect.cpp
+++ b/demo_nodes_cpp/src/events/matched_event_detect.cpp
@@ -18,7 +18,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 
-#include "std_msgs/msg/string.hpp"
+#include "example_interfaces/msg/string.hpp"
 
 using namespace std::chrono_literals;
 
@@ -60,7 +60,7 @@ public:
         promise_->set_value(true);
       };
 
-    pub_ = create_publisher<std_msgs::msg::String>(
+    pub_ = create_publisher<example_interfaces::msg::String>(
       pub_topic_name, 10, pub_options);
 
     rclcpp::SubscriptionOptions sub_options;
@@ -84,10 +84,10 @@ public:
         }
         promise_->set_value(true);
       };
-    sub_ = create_subscription<std_msgs::msg::String>(
+    sub_ = create_subscription<example_interfaces::msg::String>(
       sub_topic_name,
       10,
-      [](std_msgs::msg::String::ConstSharedPtr) {},
+      [](example_interfaces::msg::String::ConstSharedPtr) {},
       sub_options);
   }
 
@@ -98,8 +98,8 @@ public:
   }
 
 private:
-  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr pub_;
-  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr sub_;
+  rclcpp::Publisher<example_interfaces::msg::String>::SharedPtr pub_;
+  rclcpp::Subscription<example_interfaces::msg::String>::SharedPtr sub_;
   bool any_subscription_connected_{false};
   bool any_publisher_connected_{false};
   std::shared_ptr<std::promise<bool>> promise_;
@@ -113,19 +113,19 @@ public:
     topic_name_(topic_name)
   {}
 
-  rclcpp::Subscription<std_msgs::msg::String>::WeakPtr create_one_sub(void)
+  rclcpp::Subscription<example_interfaces::msg::String>::WeakPtr create_one_sub(void)
   {
     RCLCPP_INFO(this->get_logger(), "Create a new subscription.");
-    auto sub = create_subscription<std_msgs::msg::String>(
+    auto sub = create_subscription<example_interfaces::msg::String>(
       topic_name_,
       10,
-      [](std_msgs::msg::String::ConstSharedPtr) {});
+      [](example_interfaces::msg::String::ConstSharedPtr) {});
 
     subs_.emplace_back(sub);
     return sub;
   }
 
-  void destroy_one_sub(rclcpp::Subscription<std_msgs::msg::String>::WeakPtr sub)
+  void destroy_one_sub(rclcpp::Subscription<example_interfaces::msg::String>::WeakPtr sub)
   {
     auto sub_shared_ptr = sub.lock();
     if (sub_shared_ptr == nullptr) {
@@ -143,7 +143,7 @@ public:
 
 private:
   std::string topic_name_;
-  std::vector<rclcpp::Subscription<std_msgs::msg::String>::SharedPtr> subs_;
+  std::vector<rclcpp::Subscription<example_interfaces::msg::String>::SharedPtr> subs_;
 };
 
 class MultiPubNode : public rclcpp::Node
@@ -154,16 +154,16 @@ public:
     topic_name_(topic_name)
   {}
 
-  rclcpp::Publisher<std_msgs::msg::String>::WeakPtr create_one_pub(void)
+  rclcpp::Publisher<example_interfaces::msg::String>::WeakPtr create_one_pub(void)
   {
     RCLCPP_INFO(this->get_logger(), "Create a new publisher.");
-    auto pub = create_publisher<std_msgs::msg::String>(topic_name_, 10);
+    auto pub = create_publisher<example_interfaces::msg::String>(topic_name_, 10);
     pubs_.emplace_back(pub);
 
     return pub;
   }
 
-  void destroy_one_pub(rclcpp::Publisher<std_msgs::msg::String>::WeakPtr pub)
+  void destroy_one_pub(rclcpp::Publisher<example_interfaces::msg::String>::WeakPtr pub)
   {
     auto pub_shared_ptr = pub.lock();
     if (pub_shared_ptr == nullptr) {
@@ -181,7 +181,7 @@ public:
 
 private:
   std::string topic_name_;
-  std::vector<rclcpp::Publisher<std_msgs::msg::String>::SharedPtr> pubs_;
+  std::vector<rclcpp::Publisher<example_interfaces::msg::String>::SharedPtr> pubs_;
 };
 
 int main(int argc, char ** argv)

--- a/demo_nodes_cpp/src/logging/use_logger_service.cpp
+++ b/demo_nodes_cpp/src/logging/use_logger_service.cpp
@@ -18,7 +18,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 
-#include "std_msgs/msg/string.hpp"
+#include "example_interfaces/msg/string.hpp"
 
 #include "rcl_interfaces/srv/get_logger_levels.hpp"
 #include "rcl_interfaces/srv/set_logger_levels.hpp"
@@ -36,18 +36,18 @@ public:
   explicit LoggerServiceNode(const std::string & node_name)
   : Node(node_name, rclcpp::NodeOptions().enable_logger_service(true))
   {
-    auto callback = [this](std_msgs::msg::String::ConstSharedPtr msg)-> void {
+    auto callback = [this](example_interfaces::msg::String::ConstSharedPtr msg)-> void {
         RCLCPP_DEBUG(this->get_logger(), "%s with DEBUG logger level.", msg->data.c_str());
         RCLCPP_INFO(this->get_logger(), "%s with INFO logger level.", msg->data.c_str());
         RCLCPP_WARN(this->get_logger(), "%s with WARN logger level.", msg->data.c_str());
         RCLCPP_ERROR(this->get_logger(), "%s with ERROR logger level.", msg->data.c_str());
       };
 
-    sub_ = this->create_subscription<std_msgs::msg::String>("output", 10, callback);
+    sub_ = this->create_subscription<example_interfaces::msg::String>("output", 10, callback);
   }
 
 private:
-  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr sub_;
+  rclcpp::Subscription<example_interfaces::msg::String>::SharedPtr sub_;
 };
 
 class TestNode : public rclcpp::Node
@@ -57,14 +57,14 @@ public:
   : Node("TestNode"),
     remote_node_name_(remote_node_name)
   {
-    pub_ = this->create_publisher<std_msgs::msg::String>("output", 10);
+    pub_ = this->create_publisher<example_interfaces::msg::String>("output", 10);
     logger_set_client_ = this->create_client<rcl_interfaces::srv::SetLoggerLevels>(
       remote_node_name + "/set_logger_levels");
     logger_get_client_ = this->create_client<rcl_interfaces::srv::GetLoggerLevels>(
       remote_node_name + "/get_logger_levels");
   }
 
-  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr get_pub()
+  rclcpp::Publisher<example_interfaces::msg::String>::SharedPtr get_pub()
   {
     return pub_;
   }
@@ -122,7 +122,7 @@ public:
 
 private:
   const std::string remote_node_name_;
-  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr pub_;
+  rclcpp::Publisher<example_interfaces::msg::String>::SharedPtr pub_;
   rclcpp::Client<rcl_interfaces::srv::SetLoggerLevels>::SharedPtr logger_set_client_;
   rclcpp::Client<rcl_interfaces::srv::GetLoggerLevels>::SharedPtr logger_get_client_;
 };
@@ -159,7 +159,7 @@ int main(int argc, char ** argv)
   // Output with default logger level
   RCLCPP_INFO(test_node->get_logger(), "Output with default logger level:");
   {
-    auto msg = std::make_unique<std_msgs::msg::String>();
+    auto msg = std::make_unique<example_interfaces::msg::String>();
     msg->data = "Output 1";
     test_node->get_pub()->publish(std::move(msg));
   }
@@ -171,7 +171,7 @@ int main(int argc, char ** argv)
   // Output with debug logger level
   RCLCPP_INFO(test_node->get_logger(), "Output with debug logger level:");
   if (test_node->set_logger_level_on_remote_node(rclcpp::Logger::Level::Debug)) {
-    auto msg = std::make_unique<std_msgs::msg::String>();
+    auto msg = std::make_unique<example_interfaces::msg::String>();
     msg->data = "Output 2";
     test_node->get_pub()->publish(std::move(msg));
     std::this_thread::sleep_for(200ms);
@@ -185,7 +185,7 @@ int main(int argc, char ** argv)
   // Output with warn logger level
   RCLCPP_INFO(test_node->get_logger(), "Output with warn logger level:");
   if (test_node->set_logger_level_on_remote_node(rclcpp::Logger::Level::Warn)) {
-    auto msg = std::make_unique<std_msgs::msg::String>();
+    auto msg = std::make_unique<example_interfaces::msg::String>();
     msg->data = "Output 3";
     test_node->get_pub()->publish(std::move(msg));
     std::this_thread::sleep_for(200ms);
@@ -199,7 +199,7 @@ int main(int argc, char ** argv)
   // Output with error logger level
   RCLCPP_INFO(test_node->get_logger(), "Output with error logger level:");
   if (test_node->set_logger_level_on_remote_node(rclcpp::Logger::Level::Error)) {
-    auto msg = std::make_unique<std_msgs::msg::String>();
+    auto msg = std::make_unique<example_interfaces::msg::String>();
     msg->data = "Output 4";
     test_node->get_pub()->publish(std::move(msg));
     std::this_thread::sleep_for(200ms);

--- a/demo_nodes_cpp/src/topics/allocator_tutorial_custom.cpp
+++ b/demo_nodes_cpp/src/topics/allocator_tutorial_custom.cpp
@@ -21,7 +21,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/allocator/allocator_common.hpp"
 #include "rclcpp/strategies/allocator_memory_strategy.hpp"
-#include "std_msgs/msg/u_int32.hpp"
+#include "example_interfaces/msg/u_int32.hpp"
 
 using namespace std::chrono_literals;
 
@@ -132,10 +132,10 @@ int main(int argc, char ** argv)
   using rclcpp::memory_strategies::allocator_memory_strategy::AllocatorMemoryStrategy;
   using Alloc = MyAllocator<void>;
   using MessageAllocTraits =
-    rclcpp::allocator::AllocRebind<std_msgs::msg::UInt32, Alloc>;
+    rclcpp::allocator::AllocRebind<example_interfaces::msg::UInt32, Alloc>;
   using MessageAlloc = MessageAllocTraits::allocator_type;
-  using MessageDeleter = rclcpp::allocator::Deleter<MessageAlloc, std_msgs::msg::UInt32>;
-  using MessageUniquePtr = std::unique_ptr<std_msgs::msg::UInt32, MessageDeleter>;
+  using MessageDeleter = rclcpp::allocator::Deleter<MessageAlloc, example_interfaces::msg::UInt32>;
+  using MessageUniquePtr = std::unique_ptr<example_interfaces::msg::UInt32, MessageDeleter>;
   rclcpp::init(argc, argv);
 
   rclcpp::Node::SharedPtr node;
@@ -177,7 +177,7 @@ int main(int argc, char ** argv)
   }
 
   uint32_t counter = 0;
-  auto callback = [&counter](std_msgs::msg::UInt32::ConstSharedPtr msg) -> void
+  auto callback = [&counter](example_interfaces::msg::UInt32::ConstSharedPtr msg) -> void
     {
       (void)msg;
       ++counter;
@@ -187,15 +187,15 @@ int main(int argc, char ** argv)
   auto alloc = std::make_shared<Alloc>();
   rclcpp::PublisherOptionsWithAllocator<Alloc> publisher_options;
   publisher_options.allocator = alloc;
-  auto publisher = node->create_publisher<std_msgs::msg::UInt32>(
+  auto publisher = node->create_publisher<example_interfaces::msg::UInt32>(
     "allocator_tutorial", 10, publisher_options);
 
   rclcpp::SubscriptionOptionsWithAllocator<Alloc> subscription_options;
   subscription_options.allocator = alloc;
   auto msg_mem_strat = std::make_shared<
     rclcpp::message_memory_strategy::MessageMemoryStrategy<
-      std_msgs::msg::UInt32, Alloc>>(alloc);
-  auto subscriber = node->create_subscription<std_msgs::msg::UInt32>(
+      example_interfaces::msg::UInt32, Alloc>>(alloc);
+  auto subscriber = node->create_subscription<example_interfaces::msg::UInt32>(
     "allocator_tutorial", 10, callback, subscription_options, msg_mem_strat);
 
   // Create a MemoryStrategy, which handles the allocations made by the Executor during the

--- a/demo_nodes_cpp/src/topics/allocator_tutorial_pmr.cpp
+++ b/demo_nodes_cpp/src/topics/allocator_tutorial_pmr.cpp
@@ -23,7 +23,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/allocator/allocator_common.hpp"
 #include "rclcpp/strategies/allocator_memory_strategy.hpp"
-#include "std_msgs/msg/u_int32.hpp"
+#include "example_interfaces/msg/u_int32.hpp"
 
 using namespace std::chrono_literals;
 
@@ -118,10 +118,10 @@ int main(int argc, char ** argv)
   using rclcpp::memory_strategies::allocator_memory_strategy::AllocatorMemoryStrategy;
   using Alloc = std::pmr::polymorphic_allocator<void>;
   using MessageAllocTraits =
-    rclcpp::allocator::AllocRebind<std_msgs::msg::UInt32, Alloc>;
+    rclcpp::allocator::AllocRebind<example_interfaces::msg::UInt32, Alloc>;
   using MessageAlloc = MessageAllocTraits::allocator_type;
-  using MessageDeleter = rclcpp::allocator::Deleter<MessageAlloc, std_msgs::msg::UInt32>;
-  using MessageUniquePtr = std::unique_ptr<std_msgs::msg::UInt32, MessageDeleter>;
+  using MessageDeleter = rclcpp::allocator::Deleter<MessageAlloc, example_interfaces::msg::UInt32>;
+  using MessageUniquePtr = std::unique_ptr<example_interfaces::msg::UInt32, MessageDeleter>;
   rclcpp::init(argc, argv);
 
   rclcpp::Node::SharedPtr node;
@@ -163,7 +163,7 @@ int main(int argc, char ** argv)
   }
 
   uint32_t counter = 0;
-  auto callback = [&counter](std_msgs::msg::UInt32::ConstSharedPtr msg) -> void
+  auto callback = [&counter](example_interfaces::msg::UInt32::ConstSharedPtr msg) -> void
     {
       (void)msg;
       ++counter;
@@ -174,15 +174,15 @@ int main(int argc, char ** argv)
   auto alloc = std::make_shared<Alloc>(&mem_resource);
   rclcpp::PublisherOptionsWithAllocator<Alloc> publisher_options;
   publisher_options.allocator = alloc;
-  auto publisher = node->create_publisher<std_msgs::msg::UInt32>(
+  auto publisher = node->create_publisher<example_interfaces::msg::UInt32>(
     "allocator_tutorial", 10, publisher_options);
 
   rclcpp::SubscriptionOptionsWithAllocator<Alloc> subscription_options;
   subscription_options.allocator = alloc;
   auto msg_mem_strat = std::make_shared<
     rclcpp::message_memory_strategy::MessageMemoryStrategy<
-      std_msgs::msg::UInt32, Alloc>>(alloc);
-  auto subscriber = node->create_subscription<std_msgs::msg::UInt32>(
+      example_interfaces::msg::UInt32, Alloc>>(alloc);
+  auto subscriber = node->create_subscription<example_interfaces::msg::UInt32>(
     "allocator_tutorial", 10, callback, subscription_options, msg_mem_strat);
 
   // Create a MemoryStrategy, which handles the allocations made by the Executor during the

--- a/demo_nodes_cpp/src/topics/content_filtering_publisher.cpp
+++ b/demo_nodes_cpp/src/topics/content_filtering_publisher.cpp
@@ -20,7 +20,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
 
-#include "std_msgs/msg/float32.hpp"
+#include "example_interfaces/msg/float32.hpp"
 
 #include "demo_nodes_cpp/visibility_control.h"
 
@@ -42,7 +42,7 @@ public:
     auto publish_message =
       [this]() -> void
       {
-        msg_ = std::make_unique<std_msgs::msg::Float32>();
+        msg_ = std::make_unique<example_interfaces::msg::Float32>();
         msg_->data = temperature_;
         temperature_ += TEMPERATURE_SETTING[2];
         if (temperature_ > TEMPERATURE_SETTING[1]) {
@@ -58,7 +58,7 @@ public:
     // rclcpp::KeepAll{} if the user wishes.
     // (rclcpp::KeepLast(7) -> rclcpp::KeepAll() fails to compile)
     rclcpp::QoS qos(rclcpp::KeepLast{7});
-    pub_ = this->create_publisher<std_msgs::msg::Float32>("temperature", qos);
+    pub_ = this->create_publisher<example_interfaces::msg::Float32>("temperature", qos);
 
     int64_t publish_ms = this->declare_parameter("publish_ms", 1000);
 
@@ -68,8 +68,8 @@ public:
 
 private:
   float temperature_ = TEMPERATURE_SETTING[0];
-  std::unique_ptr<std_msgs::msg::Float32> msg_;
-  rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr pub_;
+  std::unique_ptr<example_interfaces::msg::Float32> msg_;
+  rclcpp::Publisher<example_interfaces::msg::Float32>::SharedPtr pub_;
   rclcpp::TimerBase::SharedPtr timer_;
 };
 

--- a/demo_nodes_cpp/src/topics/content_filtering_subscriber.cpp
+++ b/demo_nodes_cpp/src/topics/content_filtering_subscriber.cpp
@@ -19,7 +19,7 @@
 #include "rclcpp_components/register_node_macro.hpp"
 #include "rcpputils/join.hpp"
 
-#include "std_msgs/msg/float32.hpp"
+#include "example_interfaces/msg/float32.hpp"
 
 #include "demo_nodes_cpp/visibility_control.h"
 
@@ -39,7 +39,7 @@ public:
   {
     // Create a callback function for when messages are received.
     auto callback =
-      [this](const std_msgs::msg::Float32 & msg) -> void
+      [this](const example_interfaces::msg::Float32 & msg) -> void
       {
         if (msg.data < EMERGENCY_TEMPERATURE[0] || msg.data > EMERGENCY_TEMPERATURE[1]) {
           RCLCPP_INFO(
@@ -59,7 +59,8 @@ public:
       std::to_string(EMERGENCY_TEMPERATURE[1])
     };
 
-    sub_ = create_subscription<std_msgs::msg::Float32>("temperature", 10, callback, sub_options);
+    sub_ = create_subscription<example_interfaces::msg::Float32>(
+      "temperature", 10, callback, sub_options);
 
     if (!sub_->is_cft_enabled()) {
       RCLCPP_WARN(
@@ -75,7 +76,7 @@ public:
   }
 
 private:
-  rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr sub_;
+  rclcpp::Subscription<example_interfaces::msg::Float32>::SharedPtr sub_;
 };
 
 }  // namespace demo_nodes_cpp

--- a/demo_nodes_cpp/src/topics/listener.cpp
+++ b/demo_nodes_cpp/src/topics/listener.cpp
@@ -15,7 +15,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
 
-#include "std_msgs/msg/string.hpp"
+#include "example_interfaces/msg/string.hpp"
 
 #include "demo_nodes_cpp/visibility_control.h"
 
@@ -34,7 +34,7 @@ public:
     // Variations of this function also exist using, for example UniquePtr for zero-copy transport.
     setvbuf(stdout, NULL, _IONBF, BUFSIZ);
     auto callback =
-      [this](std_msgs::msg::String::ConstSharedPtr msg) -> void
+      [this](example_interfaces::msg::String::ConstSharedPtr msg) -> void
       {
         RCLCPP_INFO(this->get_logger(), "I heard: [%s]", msg->data.c_str());
       };
@@ -42,11 +42,11 @@ public:
     // publishers.
     // Note that not all publishers on the same topic with the same type will be compatible:
     // they must have compatible Quality of Service policies.
-    sub_ = create_subscription<std_msgs::msg::String>("chatter", 10, callback);
+    sub_ = create_subscription<example_interfaces::msg::String>("chatter", 10, callback);
   }
 
 private:
-  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr sub_;
+  rclcpp::Subscription<example_interfaces::msg::String>::SharedPtr sub_;
 };
 
 }  // namespace demo_nodes_cpp

--- a/demo_nodes_cpp/src/topics/listener_best_effort.cpp
+++ b/demo_nodes_cpp/src/topics/listener_best_effort.cpp
@@ -17,7 +17,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
-#include "std_msgs/msg/string.hpp"
+#include "example_interfaces/msg/string.hpp"
 
 #include "demo_nodes_cpp/visibility_control.h"
 
@@ -32,16 +32,17 @@ public:
   {
     setvbuf(stdout, NULL, _IONBF, BUFSIZ);
     auto callback =
-      [this](std_msgs::msg::String::ConstSharedPtr msg) -> void
+      [this](example_interfaces::msg::String::ConstSharedPtr msg) -> void
       {
         RCLCPP_INFO(this->get_logger(), "I heard: [%s]", msg->data.c_str());
       };
 
-    sub_ = create_subscription<std_msgs::msg::String>("chatter", rclcpp::SensorDataQoS(), callback);
+    sub_ = create_subscription<example_interfaces::msg::String>(
+      "chatter", rclcpp::SensorDataQoS(), callback);
   }
 
 private:
-  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr sub_;
+  rclcpp::Subscription<example_interfaces::msg::String>::SharedPtr sub_;
 };
 
 }  // namespace demo_nodes_cpp

--- a/demo_nodes_cpp/src/topics/listener_serialized_message.cpp
+++ b/demo_nodes_cpp/src/topics/listener_serialized_message.cpp
@@ -20,7 +20,7 @@
 #include "rclcpp/serialization.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
 
-#include "std_msgs/msg/string.hpp"
+#include "example_interfaces/msg/string.hpp"
 
 #include "demo_nodes_cpp/visibility_control.h"
 
@@ -53,7 +53,7 @@ public:
 
         // In order to deserialize the message we have to manually create a ROS 2
         // message in which we want to convert the serialized data.
-        using MessageT = std_msgs::msg::String;
+        using MessageT = example_interfaces::msg::String;
         MessageT string_msg;
         auto serializer = rclcpp::Serialization<MessageT>();
         serializer.deserialize_message(msg.get(), &string_msg);
@@ -64,11 +64,11 @@ public:
     // publishers.
     // Note that not all publishers on the same topic with the same type will be compatible:
     // they must have compatible Quality of Service policies.
-    sub_ = create_subscription<std_msgs::msg::String>("chatter", 10, callback);
+    sub_ = create_subscription<example_interfaces::msg::String>("chatter", 10, callback);
   }
 
 private:
-  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr sub_;
+  rclcpp::Subscription<example_interfaces::msg::String>::SharedPtr sub_;
 };
 
 }  // namespace demo_nodes_cpp

--- a/demo_nodes_cpp/src/topics/talker.cpp
+++ b/demo_nodes_cpp/src/topics/talker.cpp
@@ -20,7 +20,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
 
-#include "std_msgs/msg/string.hpp"
+#include "example_interfaces/msg/string.hpp"
 
 #include "demo_nodes_cpp/visibility_control.h"
 
@@ -42,7 +42,7 @@ public:
     auto publish_message =
       [this]() -> void
       {
-        msg_ = std::make_unique<std_msgs::msg::String>();
+        msg_ = std::make_unique<example_interfaces::msg::String>();
         msg_->data = "Hello World: " + std::to_string(count_++);
         RCLCPP_INFO(this->get_logger(), "Publishing: '%s'", msg_->data.c_str());
         // Put the message into a queue to be processed by the middleware.
@@ -54,7 +54,7 @@ public:
     // rclcpp::KeepAll{} if the user wishes.
     // (rclcpp::KeepLast(7) -> rclcpp::KeepAll() fails to compile)
     rclcpp::QoS qos(rclcpp::KeepLast{7});
-    pub_ = this->create_publisher<std_msgs::msg::String>("chatter", qos);
+    pub_ = this->create_publisher<example_interfaces::msg::String>("chatter", qos);
 
     // Use a timer to schedule periodic message publishing.
     timer_ = this->create_wall_timer(1s, publish_message);
@@ -62,8 +62,8 @@ public:
 
 private:
   size_t count_ = 1;
-  std::unique_ptr<std_msgs::msg::String> msg_;
-  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr pub_;
+  std::unique_ptr<example_interfaces::msg::String> msg_;
+  rclcpp::Publisher<example_interfaces::msg::String>::SharedPtr pub_;
   rclcpp::TimerBase::SharedPtr timer_;
 };
 

--- a/demo_nodes_cpp/src/topics/talker_loaned_message.cpp
+++ b/demo_nodes_cpp/src/topics/talker_loaned_message.cpp
@@ -20,8 +20,8 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
 
-#include "std_msgs/msg/float64.hpp"
-#include "std_msgs/msg/string.hpp"
+#include "example_interfaces/msg/float64.hpp"
+#include "example_interfaces/msg/string.hpp"
 
 #include "demo_nodes_cpp/visibility_control.h"
 
@@ -85,8 +85,8 @@ public:
 
     // Create a publisher with a custom Quality of Service profile.
     rclcpp::QoS qos(rclcpp::KeepLast(7));
-    pod_pub_ = this->create_publisher<std_msgs::msg::Float64>("chatter_pod", qos);
-    non_pod_pub_ = this->create_publisher<std_msgs::msg::String>("chatter", qos);
+    pod_pub_ = this->create_publisher<example_interfaces::msg::Float64>("chatter_pod", qos);
+    non_pod_pub_ = this->create_publisher<example_interfaces::msg::String>("chatter", qos);
 
     // Use a timer to schedule periodic message publishing.
     timer_ = this->create_wall_timer(1s, publish_message);
@@ -94,8 +94,8 @@ public:
 
 private:
   size_t count_ = 1;
-  rclcpp::Publisher<std_msgs::msg::Float64>::SharedPtr pod_pub_;
-  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr non_pod_pub_;
+  rclcpp::Publisher<example_interfaces::msg::Float64>::SharedPtr pod_pub_;
+  rclcpp::Publisher<example_interfaces::msg::String>::SharedPtr non_pod_pub_;
   rclcpp::TimerBase::SharedPtr timer_;
 };
 

--- a/demo_nodes_cpp/src/topics/talker_serialized_message.cpp
+++ b/demo_nodes_cpp/src/topics/talker_serialized_message.cpp
@@ -19,7 +19,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
 
-#include "std_msgs/msg/string.hpp"
+#include "example_interfaces/msg/string.hpp"
 
 #include "rclcpp/serialization.hpp"
 
@@ -42,7 +42,7 @@ public:
     auto publish_message =
       [this]() -> void
       {
-        // In this example we send a std_msgs/String as serialized data.
+        // In this example we send a example_interfaces/String as serialized data.
         // This is the manual CDR serialization of a string message with the content of
         // Hello World: <count_> equivalent to talker example.
         // The serialized data is composed of a 8 Byte header
@@ -54,8 +54,9 @@ public:
 
         // In order to ease things up, we call the rmw_serialize function,
         // which can do the above conversion for us.
-        // For this, we initially fill up a std_msgs/String message and fill up its content
-        auto string_msg = std::make_shared<std_msgs::msg::String>();
+        // For this, we initially fill up a example_interfaces/String message and
+        // fill up its content
+        auto string_msg = std::make_shared<example_interfaces::msg::String>();
         string_msg->data = "Hello World:" + std::to_string(count_++);
 
         // We know the size of the data to be sent, and thus can pre-allocate the
@@ -68,7 +69,7 @@ public:
         auto message_payload_length = static_cast<size_t>(string_msg->data.size());
         serialized_msg_.reserve(message_header_length + message_payload_length);
 
-        static rclcpp::Serialization<std_msgs::msg::String> serializer;
+        static rclcpp::Serialization<example_interfaces::msg::String> serializer;
         serializer.serialize_message(string_msg.get(), &serialized_msg_);
 
         // For demonstration we print the ROS 2 message format
@@ -85,7 +86,7 @@ public:
       };
 
     rclcpp::QoS qos(rclcpp::KeepLast(7));
-    pub_ = this->create_publisher<std_msgs::msg::String>("chatter", qos);
+    pub_ = this->create_publisher<example_interfaces::msg::String>("chatter", qos);
 
     // Use a timer to schedule periodic message publishing.
     timer_ = this->create_wall_timer(1s, publish_message);
@@ -94,7 +95,7 @@ public:
 private:
   size_t count_ = 1;
   rclcpp::SerializedMessage serialized_msg_;
-  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr pub_;
+  rclcpp::Publisher<example_interfaces::msg::String>::SharedPtr pub_;
   rclcpp::TimerBase::SharedPtr timer_;
 };
 

--- a/demo_nodes_cpp_native/CMakeLists.txt
+++ b/demo_nodes_cpp_native/CMakeLists.txt
@@ -22,7 +22,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(rmw REQUIRED)
-find_package(std_msgs REQUIRED)
+find_package(example_interfaces REQUIRED)
 
 include_directories(include)
 
@@ -32,7 +32,7 @@ target_compile_definitions(talker_native
   PRIVATE "DEMO_NODES_CPP_NATIVE_BUILDING_DLL")
 ament_target_dependencies(talker_native
   "rclcpp"
-  "std_msgs"
+  "example_interfaces"
   "rclcpp_components"
   "rmw_fastrtps_cpp")
 rclcpp_components_register_node(talker_native PLUGIN "demo_nodes_cpp_native::Talker" EXECUTABLE talker)

--- a/demo_nodes_cpp_native/package.xml
+++ b/demo_nodes_cpp_native/package.xml
@@ -20,7 +20,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>rmw_fastrtps_cpp</depend>
-  <depend>std_msgs</depend>
+  <depend>example_interfaces</depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/demo_nodes_cpp_native/src/talker.cpp
+++ b/demo_nodes_cpp_native/src/talker.cpp
@@ -19,7 +19,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
-#include "std_msgs/msg/string.hpp"
+#include "example_interfaces/msg/string.hpp"
 
 #include "rmw_fastrtps_cpp/get_participant.hpp"
 #include "rmw_fastrtps_cpp/get_publisher.hpp"
@@ -49,13 +49,13 @@ public:
     auto publish =
       [this]() -> void
       {
-        msg_ = std::make_unique<std_msgs::msg::String>();
+        msg_ = std::make_unique<example_interfaces::msg::String>();
         msg_->data = "Hello World: " + std::to_string(count_++);
         RCLCPP_INFO(this->get_logger(), "Publishing: '%s'", msg_->data.c_str());
         pub_->publish(std::move(msg_));
       };
     timer_ = create_wall_timer(500ms, publish);
-    pub_ = create_publisher<std_msgs::msg::String>("chatter", 10);
+    pub_ = create_publisher<example_interfaces::msg::String>("chatter", 10);
 
     rcl_publisher_t * rcl_pub = pub_->get_publisher_handle().get();
     rmw_publisher_t * rmw_pub = rcl_publisher_get_rmw_handle(rcl_pub);
@@ -68,8 +68,8 @@ public:
 
 private:
   size_t count_ = 1;
-  std::unique_ptr<std_msgs::msg::String> msg_;
-  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr pub_;
+  std::unique_ptr<example_interfaces::msg::String> msg_;
+  rclcpp::Publisher<example_interfaces::msg::String>::SharedPtr pub_;
   rclcpp::TimerBase::SharedPtr timer_;
 };
 

--- a/demo_nodes_py/demo_nodes_py/events/matched_event_detect.py
+++ b/demo_nodes_py/demo_nodes_py/events/matched_event_detect.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from example_interfaces.msg import String
 import rclpy
 from rclpy.event_handler import PublisherEventCallbacks
 from rclpy.event_handler import QoSPublisherMatchedInfo
@@ -22,7 +23,6 @@ from rclpy.node import Node
 from rclpy.publisher import Publisher
 from rclpy.subscription import Subscription
 from rclpy.task import Future
-from std_msgs.msg import String
 
 """
 This demo program shows detected matched event.

--- a/demo_nodes_py/demo_nodes_py/logging/use_logger_service.py
+++ b/demo_nodes_py/demo_nodes_py/logging/use_logger_service.py
@@ -15,6 +15,7 @@
 import threading
 import time
 
+from example_interfaces.msg import String
 from rcl_interfaces.msg import LoggerLevel
 from rcl_interfaces.srv import GetLoggerLevels
 from rcl_interfaces.srv import SetLoggerLevels
@@ -22,7 +23,6 @@ import rclpy
 from rclpy.executors import SingleThreadedExecutor
 from rclpy.impl.logging_severity import LoggingSeverity
 from rclpy.node import Node
-from std_msgs.msg import String
 
 """
 This demo program shows how to enable logger service and control logger level via logger service.

--- a/demo_nodes_py/demo_nodes_py/topics/listener.py
+++ b/demo_nodes_py/demo_nodes_py/topics/listener.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from example_interfaces.msg import String
+
 import rclpy
 from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
-
-from std_msgs.msg import String
 
 
 class Listener(Node):

--- a/demo_nodes_py/demo_nodes_py/topics/listener_qos.py
+++ b/demo_nodes_py/demo_nodes_py/topics/listener_qos.py
@@ -15,6 +15,8 @@
 import argparse
 import sys
 
+from example_interfaces.msg import String
+
 import rclpy
 from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
@@ -22,8 +24,6 @@ from rclpy.qos import qos_profile_sensor_data
 from rclpy.qos import QoSProfile
 from rclpy.qos import QoSReliabilityPolicy
 from rclpy.utilities import remove_ros_args
-
-from std_msgs.msg import String
 
 
 class ListenerQos(Node):

--- a/demo_nodes_py/demo_nodes_py/topics/listener_serialized.py
+++ b/demo_nodes_py/demo_nodes_py/topics/listener_serialized.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from example_interfaces.msg import String
+
 import rclpy
 from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
-
-from std_msgs.msg import String
 
 
 class SerializedSubscriber(Node):
@@ -28,7 +28,7 @@ class SerializedSubscriber(Node):
             'chatter',
             self.listener_callback,
             10,
-            raw=True)  # We're subscribing to the serialized bytes, not std_msgs.msg.String
+            raw=True)  # We're subscribing to the serialized bytes, not example_interfaces.msg.String
 
     def listener_callback(self, msg):
         self.get_logger().info('I heard: "%s"' % msg)

--- a/demo_nodes_py/demo_nodes_py/topics/talker.py
+++ b/demo_nodes_py/demo_nodes_py/topics/talker.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from example_interfaces.msg import String
+
 import rclpy
 from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
-
-from std_msgs.msg import String
 
 
 class Talker(Node):

--- a/demo_nodes_py/demo_nodes_py/topics/talker_qos.py
+++ b/demo_nodes_py/demo_nodes_py/topics/talker_qos.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from example_interfaces.msg import String
+
 import argparse
 import sys
 
@@ -22,8 +24,6 @@ from rclpy.qos import qos_profile_sensor_data
 from rclpy.qos import QoSProfile
 from rclpy.qos import QoSReliabilityPolicy
 from rclpy.utilities import remove_ros_args
-
-from std_msgs.msg import String
 
 
 class TalkerQos(Node):

--- a/demo_nodes_py/package.xml
+++ b/demo_nodes_py/package.xml
@@ -21,7 +21,7 @@
   <exec_depend>example_interfaces</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rcl_interfaces</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>example_interfaces</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/image_tools/CMakeLists.txt
+++ b/image_tools/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(example_interfaces REQUIRED)
 find_package(OpenCV REQUIRED COMPONENTS core highgui imgcodecs imgproc videoio)
 
 add_library(${PROJECT_NAME} SHARED
@@ -34,6 +35,7 @@ target_link_libraries(${PROJECT_NAME}
   rclcpp::rclcpp
   ${sensor_msgs_TARGETS}
   ${std_msgs_TARGETS}
+  ${example_interfaces_TARGETS}
   rclcpp_components::component
   ${OpenCV_LIBS})
 rclcpp_components_register_node(${PROJECT_NAME} PLUGIN "image_tools::Cam2Image" EXECUTABLE cam2image)

--- a/image_tools/package.xml
+++ b/image_tools/package.xml
@@ -19,12 +19,14 @@
   <build_depend>rclcpp_components</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>example_interfaces</build_depend>
 
   <exec_depend>libopencv-dev</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclcpp_components</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>example_interfaces</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/image_tools/src/cam2image.cpp
+++ b/image_tools/src/cam2image.cpp
@@ -27,7 +27,7 @@
 #include "rcl_interfaces/msg/parameter_descriptor.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_components/register_node_macro.hpp"
-#include "std_msgs/msg/bool.hpp"
+#include "example_interfaces/msg/bool.hpp"
 
 #include "image_tools/cv_mat_sensor_msgs_image_type_adapter.hpp"
 #include "image_tools/visibility_control.h"
@@ -85,13 +85,13 @@ private:
 
     // Subscribe to a message that will toggle flipping or not flipping, and manage the state in a
     // callback
-    auto callback = [this](std_msgs::msg::Bool::ConstSharedPtr msg) -> void
+    auto callback = [this](example_interfaces::msg::Bool::ConstSharedPtr msg) -> void
       {
         this->is_flipped_ = msg->data;
         RCLCPP_INFO(this->get_logger(), "Set flip mode to: %s", this->is_flipped_ ? "on" : "off");
       };
     // Set the QoS profile for the subscription to the flip message.
-    sub_ = create_subscription<std_msgs::msg::Bool>(
+    sub_ = create_subscription<example_interfaces::msg::Bool>(
       "flip_image", rclcpp::SensorDataQoS(), callback);
 
     if (!burger_mode_) {
@@ -254,7 +254,7 @@ private:
   cv::VideoCapture cap;
   burger::Burger burger_cap;
 
-  rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr sub_;
+  rclcpp::Subscription<example_interfaces::msg::Bool>::SharedPtr sub_;
   rclcpp::Publisher<image_tools::ROSCvMatContainer>::SharedPtr pub_;
   rclcpp::TimerBase::SharedPtr timer_;
 

--- a/intra_process_demo/CMakeLists.txt
+++ b/intra_process_demo/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(builtin_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rmw REQUIRED)
 find_package(sensor_msgs REQUIRED)
-find_package(std_msgs REQUIRED)
+find_package(example_interfaces REQUIRED)
 
 find_package(OpenCV REQUIRED COMPONENTS core highgui imgproc videoio)
 
@@ -34,14 +34,14 @@ add_executable(two_node_pipeline
   src/two_node_pipeline/two_node_pipeline.cpp)
 target_link_libraries(two_node_pipeline
   rclcpp::rclcpp
-  ${std_msgs_TARGETS})
+  ${example_interfaces_TARGETS})
 
   # Simple example of a cyclic pipeline which uses no allocation while iterating.
 add_executable(cyclic_pipeline
   src/cyclic_pipeline/cyclic_pipeline.cpp)
 target_link_libraries(cyclic_pipeline
   rclcpp::rclcpp
-  ${std_msgs_TARGETS})
+  ${example_interfaces_TARGETS})
 
 # A single program with one of each of the image pipeline demo nodes.
 add_executable(image_pipeline_all_in_one

--- a/intra_process_demo/package.xml
+++ b/intra_process_demo/package.xml
@@ -18,7 +18,7 @@
   <build_depend>libopencv-dev</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
-  <build_depend>std_msgs</build_depend>
+  <build_depend>example_interfaces</build_depend>
 
   <exec_depend>libopencv-dev</exec_depend>
   <exec_depend>rclcpp</exec_depend>

--- a/intra_process_demo/src/cyclic_pipeline/cyclic_pipeline.cpp
+++ b/intra_process_demo/src/cyclic_pipeline/cyclic_pipeline.cpp
@@ -20,7 +20,7 @@
 #include <utility>
 
 #include "rclcpp/rclcpp.hpp"
-#include "std_msgs/msg/int32.hpp"
+#include "example_interfaces/msg/int32.hpp"
 
 using namespace std::chrono_literals;
 
@@ -31,13 +31,13 @@ struct IncrementerPipe : public rclcpp::Node
   : Node(name, rclcpp::NodeOptions().use_intra_process_comms(true))
   {
     // Create a publisher on the output topic.
-    pub = this->create_publisher<std_msgs::msg::Int32>(out, 10);
+    pub = this->create_publisher<example_interfaces::msg::Int32>(out, 10);
     std::weak_ptr<std::remove_pointer<decltype(pub.get())>::type> captured_pub = pub;
     // Create a subscription on the input topic.
-    sub = this->create_subscription<std_msgs::msg::Int32>(
+    sub = this->create_subscription<example_interfaces::msg::Int32>(
       in,
       10,
-      [captured_pub](std_msgs::msg::Int32::UniquePtr msg) {
+      [captured_pub](example_interfaces::msg::Int32::UniquePtr msg) {
         auto pub_ptr = captured_pub.lock();
         if (!pub_ptr) {
           return;
@@ -58,8 +58,8 @@ struct IncrementerPipe : public rclcpp::Node
       });
   }
 
-  rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr pub;
-  rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr sub;
+  rclcpp::Publisher<example_interfaces::msg::Int32>::SharedPtr pub;
+  rclcpp::Subscription<example_interfaces::msg::Int32>::SharedPtr sub;
 };
 
 int main(int argc, char * argv[])
@@ -74,7 +74,7 @@ int main(int argc, char * argv[])
   auto pipe2 = std::make_shared<IncrementerPipe>("pipe2", "topic2", "topic1");
   rclcpp::sleep_for(1s);  // Wait for subscriptions to be established to avoid race conditions.
   // Publish the first message (kicking off the cycle).
-  std::unique_ptr<std_msgs::msg::Int32> msg(new std_msgs::msg::Int32());
+  std::unique_ptr<example_interfaces::msg::Int32> msg(new example_interfaces::msg::Int32());
   msg->data = 42;
   printf(
     "Published first message with value:  %d, and address: 0x%" PRIXPTR "\n", msg->data,

--- a/intra_process_demo/src/two_node_pipeline/two_node_pipeline.cpp
+++ b/intra_process_demo/src/two_node_pipeline/two_node_pipeline.cpp
@@ -20,7 +20,7 @@
 #include <utility>
 
 #include "rclcpp/rclcpp.hpp"
-#include "std_msgs/msg/int32.hpp"
+#include "example_interfaces/msg/int32.hpp"
 
 using namespace std::chrono_literals;
 
@@ -31,7 +31,7 @@ struct Producer : public rclcpp::Node
   : Node(name, rclcpp::NodeOptions().use_intra_process_comms(true))
   {
     // Create a publisher on the output topic.
-    pub_ = this->create_publisher<std_msgs::msg::Int32>(output, 10);
+    pub_ = this->create_publisher<example_interfaces::msg::Int32>(output, 10);
     std::weak_ptr<std::remove_pointer<decltype(pub_.get())>::type> captured_pub = pub_;
     // Create a timer which publishes on the output topic at ~1Hz.
     auto callback = [captured_pub]() -> void {
@@ -40,7 +40,7 @@ struct Producer : public rclcpp::Node
           return;
         }
         static int32_t count = 0;
-        std_msgs::msg::Int32::UniquePtr msg(new std_msgs::msg::Int32());
+        example_interfaces::msg::Int32::UniquePtr msg(new example_interfaces::msg::Int32());
         msg->data = count++;
         printf(
           "Published message with value: %d, and address: 0x%" PRIXPTR "\n", msg->data,
@@ -50,7 +50,7 @@ struct Producer : public rclcpp::Node
     timer_ = this->create_wall_timer(1s, callback);
   }
 
-  rclcpp::Publisher<std_msgs::msg::Int32>::SharedPtr pub_;
+  rclcpp::Publisher<example_interfaces::msg::Int32>::SharedPtr pub_;
   rclcpp::TimerBase::SharedPtr timer_;
 };
 
@@ -61,17 +61,17 @@ struct Consumer : public rclcpp::Node
   : Node(name, rclcpp::NodeOptions().use_intra_process_comms(true))
   {
     // Create a subscription on the input topic which prints on receipt of new messages.
-    sub_ = this->create_subscription<std_msgs::msg::Int32>(
+    sub_ = this->create_subscription<example_interfaces::msg::Int32>(
       input,
       10,
-      [](std_msgs::msg::Int32::UniquePtr msg) {
+      [](example_interfaces::msg::Int32::UniquePtr msg) {
         printf(
           " Received message with value: %d, and address: 0x%" PRIXPTR "\n", msg->data,
           reinterpret_cast<std::uintptr_t>(msg.get()));
       });
   }
 
-  rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr sub_;
+  rclcpp::Subscription<example_interfaces::msg::Int32>::SharedPtr sub_;
 };
 
 int main(int argc, char * argv[])

--- a/lifecycle/CMakeLists.txt
+++ b/lifecycle/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(std_msgs REQUIRED)
+find_package(example_interfaces REQUIRED)
 
 ### demos
 add_executable(lifecycle_talker
@@ -25,14 +25,14 @@ ament_target_dependencies(lifecycle_talker
   "lifecycle_msgs"
   "rclcpp"
   "rclcpp_lifecycle"
-  "std_msgs"
+  "example_interfaces"
 )
 add_executable(lifecycle_listener
   src/lifecycle_listener.cpp)
 ament_target_dependencies(lifecycle_listener
   "lifecycle_msgs"
   "rclcpp"
-  "std_msgs"
+  "example_interfaces"
 )
 add_executable(lifecycle_service_client
   src/lifecycle_service_client.cpp)

--- a/lifecycle/package.xml
+++ b/lifecycle/package.xml
@@ -18,7 +18,7 @@
   <depend>lifecycle_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
-  <depend>std_msgs</depend>
+  <depend>example_interfaces</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/lifecycle/src/lifecycle_listener.cpp
+++ b/lifecycle/src/lifecycle_listener.cpp
@@ -20,7 +20,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 
-#include "std_msgs/msg/string.hpp"
+#include "example_interfaces/msg/string.hpp"
 
 /// LifecycleListener class as a simple listener node
 /**
@@ -37,9 +37,9 @@ public:
   : Node(node_name)
   {
     // Data topic from the lc_talker node
-    sub_data_ = this->create_subscription<std_msgs::msg::String>(
+    sub_data_ = this->create_subscription<example_interfaces::msg::String>(
       "lifecycle_chatter", 10,
-      [this](std_msgs::msg::String::ConstSharedPtr msg) {return this->data_callback(msg);});
+      [this](example_interfaces::msg::String::ConstSharedPtr msg) {return this->data_callback(msg);});
 
     // Notification event topic. All state changes
     // are published here as TransitionEvents with
@@ -53,7 +53,7 @@ public:
     );
   }
 
-  void data_callback(std_msgs::msg::String::ConstSharedPtr msg)
+  void data_callback(example_interfaces::msg::String::ConstSharedPtr msg)
   {
     RCLCPP_INFO(get_logger(), "data_callback: %s", msg->data.c_str());
   }
@@ -66,7 +66,7 @@ public:
   }
 
 private:
-  std::shared_ptr<rclcpp::Subscription<std_msgs::msg::String>> sub_data_;
+  std::shared_ptr<rclcpp::Subscription<example_interfaces::msg::String>> sub_data_;
   std::shared_ptr<rclcpp::Subscription<lifecycle_msgs::msg::TransitionEvent>>
   sub_notification_;
 };

--- a/lifecycle/src/lifecycle_talker.cpp
+++ b/lifecycle/src/lifecycle_talker.cpp
@@ -26,7 +26,7 @@
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "rclcpp_lifecycle/lifecycle_publisher.hpp"
 
-#include "std_msgs/msg/string.hpp"
+#include "example_interfaces/msg/string.hpp"
 
 using namespace std::chrono_literals;
 
@@ -73,7 +73,7 @@ public:
   publish()
   {
     static size_t count = 0;
-    auto msg = std::make_unique<std_msgs::msg::String>();
+    auto msg = std::make_unique<example_interfaces::msg::String>();
     msg->data = "Lifecycle HelloWorld #" + std::to_string(++count);
 
     // Print the current state for demo purposes
@@ -114,7 +114,7 @@ public:
     // can comply to the current state of the node.
     // As of the beta version, there is only a lifecycle publisher
     // available.
-    pub_ = this->create_publisher<std_msgs::msg::String>("lifecycle_chatter", 10);
+    pub_ = this->create_publisher<example_interfaces::msg::String>("lifecycle_chatter", 10);
     timer_ = this->create_wall_timer(
       1s, [this]() {return this->publish();});
 
@@ -264,7 +264,7 @@ private:
   // is in.
   // By default, a lifecycle publisher is inactive by creation and has to be
   // activated to publish messages into the ROS world.
-  std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::String>> pub_;
+  std::shared_ptr<rclcpp_lifecycle::LifecyclePublisher<example_interfaces::msg::String>> pub_;
 
   // We hold an instance of a timer which periodically triggers the publish function.
   // As for the beta version, this is a regular timer. In a future version, a

--- a/lifecycle_py/lifecycle_py/talker.py
+++ b/lifecycle_py/lifecycle_py/talker.py
@@ -20,13 +20,13 @@ import rclpy
 # respectively.
 # In case of ambiguity, the more explicit names can be imported.
 
+import example_interfaces.msg
+
 from rclpy.lifecycle import Node
 from rclpy.lifecycle import Publisher
 from rclpy.lifecycle import State
 from rclpy.lifecycle import TransitionCallbackReturn
 from rclpy.timer import Timer
-
-import std_msgs.msg
 
 
 class LifecycleTalker(Node):
@@ -41,7 +41,7 @@ class LifecycleTalker(Node):
 
     def publish(self):
         """Publish a new message when enabled."""
-        msg = std_msgs.msg.String()
+        msg = example_interfaces.msg.String()
         msg.data = 'Lifecycle HelloWorld #' + str(self._count)
         self._count += 1
 
@@ -71,7 +71,7 @@ class LifecycleTalker(Node):
             TransitionCallbackReturn.FAILURE transitions to "unconfigured".
             TransitionCallbackReturn.ERROR or any uncaught exceptions to "errorprocessing"
         """
-        self._pub = self.create_lifecycle_publisher(std_msgs.msg.String, 'lifecycle_chatter', 10)
+        self._pub = self.create_lifecycle_publisher(example_interfaces.msg.String, 'lifecycle_chatter', 10)
         self._timer = self.create_timer(1.0, self.publish)
 
         self.get_logger().info('on_configure() is called.')

--- a/lifecycle_py/package.xml
+++ b/lifecycle_py/package.xml
@@ -14,7 +14,7 @@
 
   <exec_depend>rclpy</exec_depend>
   <exec_depend>lifecycle_msgs</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>example_interfaces</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/logging_demo/CMakeLists.txt
+++ b/logging_demo/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(rcutils REQUIRED)
-find_package(std_msgs REQUIRED)
+find_package(example_interfaces REQUIRED)
 
 find_package(rosidl_default_generators REQUIRED)
 rosidl_generate_interfaces(${PROJECT_NAME}
@@ -43,7 +43,7 @@ target_compile_definitions(logger_usage_component
 ament_target_dependencies(logger_usage_component
   "rclcpp"
   "rclcpp_components"
-  "std_msgs")
+  "example_interfaces")
 rclcpp_components_register_nodes(logger_usage_component "logging_demo::LoggerUsage")
 
 add_executable(logging_demo_main

--- a/logging_demo/include/logging_demo/logger_usage_component.hpp
+++ b/logging_demo/include/logging_demo/logger_usage_component.hpp
@@ -19,7 +19,7 @@
 
 #include "logging_demo/visibility_control.h"
 #include "rclcpp/rclcpp.hpp"
-#include "std_msgs/msg/string.hpp"
+#include "example_interfaces/msg/string.hpp"
 
 namespace logging_demo
 {
@@ -35,7 +35,7 @@ protected:
 
 private:
   size_t count_;
-  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr pub_;
+  rclcpp::Publisher<example_interfaces::msg::String>::SharedPtr pub_;
   rclcpp::TimerBase::SharedPtr one_shot_timer_, timer_;
   std::function<bool()> debug_function_to_evaluate_;
 };

--- a/logging_demo/package.xml
+++ b/logging_demo/package.xml
@@ -21,13 +21,13 @@
   <build_depend>rclcpp_components</build_depend>
   <build_depend>rcutils</build_depend>
   <build_depend>rosidl_default_generators</build_depend>
-  <build_depend>std_msgs</build_depend>
+  <build_depend>example_interfaces</build_depend>
 
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclcpp_components</exec_depend>
   <exec_depend>rcutils</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>example_interfaces</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/logging_demo/src/logger_usage_component.cpp
+++ b/logging_demo/src/logger_usage_component.cpp
@@ -22,7 +22,7 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "rcutils/error_handling.h"
-#include "std_msgs/msg/string.hpp"
+#include "example_interfaces/msg/string.hpp"
 
 using namespace std::chrono_literals;
 
@@ -32,7 +32,7 @@ namespace logging_demo
 LoggerUsage::LoggerUsage(rclcpp::NodeOptions options)
 : Node("logger_usage_demo", options), count_(0)
 {
-  pub_ = create_publisher<std_msgs::msg::String>("logging_demo_count", 10);
+  pub_ = create_publisher<example_interfaces::msg::String>("logging_demo_count", 10);
   timer_ = create_wall_timer(500ms, [this]() {return this->on_timer();});
   debug_function_to_evaluate_ = [this]() {
       return is_divisor_of_twelve(std::cref(this->count_), this->get_logger());
@@ -59,7 +59,7 @@ void LoggerUsage::on_timer()
   // This message will be logged only the first time this line is reached.
   RCLCPP_INFO_ONCE(get_logger(), "Timer callback called (this will only log once)");
 
-  auto msg = std::make_unique<std_msgs::msg::String>();
+  auto msg = std::make_unique<example_interfaces::msg::String>();
   msg->data = "Current count: " + std::to_string(count_);
 
   // This message will be logged each time it is reached.

--- a/quality_of_service_demo/rclcpp/CMakeLists.txt
+++ b/quality_of_service_demo/rclcpp/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(rclcpp_components REQUIRED)
 find_package(rcutils)
 find_package(rmw REQUIRED)
 find_package(sensor_msgs REQUIRED)
-find_package(std_msgs REQUIRED)
+find_package(example_interfaces REQUIRED)
 
 include_directories(include)
 # TODO(sloretz) stop exporting old-style CMake variables in the future
@@ -32,7 +32,7 @@ function(qos_demo_executable target)
   target_link_libraries(${target}
     rclcpp::rclcpp
     rcutils::rcutils
-    ${std_msgs_TARGETS})
+    ${example_interfaces_TARGETS})
   install(TARGETS ${target} DESTINATION lib/${PROJECT_NAME})
 endfunction()
 

--- a/quality_of_service_demo/rclcpp/include/quality_of_service_demo/common_nodes.hpp
+++ b/quality_of_service_demo/rclcpp/include/quality_of_service_demo/common_nodes.hpp
@@ -20,7 +20,7 @@
 #include <string>
 
 #include "rclcpp/rclcpp.hpp"
-#include "std_msgs/msg/string.hpp"
+#include "example_interfaces/msg/string.hpp"
 
 constexpr char DEFAULT_TOPIC_NAME[] = "qos_chatter";
 
@@ -86,7 +86,7 @@ public:
 private:
   rclcpp::QoS qos_profile_;
   rclcpp::PublisherOptions publisher_options_;
-  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr publisher_ = nullptr;
+  rclcpp::Publisher<example_interfaces::msg::String>::SharedPtr publisher_ = nullptr;
 
   const std::string topic_name_;
   size_t publish_count_ = 0;
@@ -133,7 +133,7 @@ public:
 private:
   rclcpp::QoS qos_profile_;
   rclcpp::SubscriptionOptions subscription_options_;
-  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr subscription_ = nullptr;
+  rclcpp::Subscription<example_interfaces::msg::String>::SharedPtr subscription_ = nullptr;
 
   const std::string topic_name_;
   const bool defer_subscribe_ = false;

--- a/quality_of_service_demo/rclcpp/package.xml
+++ b/quality_of_service_demo/rclcpp/package.xml
@@ -23,7 +23,7 @@
   <build_depend>rmw</build_depend>
   <build_depend>rmw_implementation_cmake</build_depend>
   <build_depend>sensor_msgs</build_depend>
-  <build_depend>std_msgs</build_depend>
+  <build_depend>example_interfaces</build_depend>
 
   <exec_depend>example_interfaces</exec_depend>
   <exec_depend>launch_ros</exec_depend>
@@ -32,7 +32,7 @@
   <exec_depend>rcutils</exec_depend>
   <exec_depend>rmw</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>example_interfaces</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/quality_of_service_demo/rclcpp/src/common_nodes.cpp
+++ b/quality_of_service_demo/rclcpp/src/common_nodes.cpp
@@ -39,7 +39,7 @@ Talker::initialize()
 {
   RCLCPP_INFO(get_logger(), "Talker starting up");
 
-  publisher_ = create_publisher<std_msgs::msg::String>(
+  publisher_ = create_publisher<example_interfaces::msg::String>(
     topic_name_,
     qos_profile_,
     publisher_options_);
@@ -62,7 +62,7 @@ Talker::initialize()
 void
 Talker::publish()
 {
-  std_msgs::msg::String msg;
+  example_interfaces::msg::String msg;
   msg.data = "Talker says " + std::to_string(publish_count_);
   RCLCPP_INFO(get_logger(), "Publishing: '%s'", msg.data.c_str());
   publisher_->publish(msg);
@@ -156,10 +156,10 @@ void
 Listener::start_listening()
 {
   if (!subscription_) {
-    subscription_ = create_subscription<std_msgs::msg::String>(
+    subscription_ = create_subscription<example_interfaces::msg::String>(
       topic_name_,
       qos_profile_,
-      [this](std_msgs::msg::String::ConstSharedPtr msg) -> void
+      [this](example_interfaces::msg::String::ConstSharedPtr msg) -> void
       {
         RCLCPP_INFO(get_logger(), "Listener heard: [%s]", msg->data.c_str());
       },

--- a/quality_of_service_demo/rclcpp/src/deadline.cpp
+++ b/quality_of_service_demo/rclcpp/src/deadline.cpp
@@ -21,8 +21,8 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/executors/single_threaded_executor.hpp"
 
-#include "std_msgs/msg/string.hpp"
-#include "std_msgs/msg/bool.hpp"
+#include "example_interfaces/msg/string.hpp"
+#include "example_interfaces/msg/bool.hpp"
 
 #include "quality_of_service_demo/common_nodes.hpp"
 

--- a/quality_of_service_demo/rclcpp/src/incompatible_qos.cpp
+++ b/quality_of_service_demo/rclcpp/src/incompatible_qos.cpp
@@ -21,8 +21,8 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/executors/single_threaded_executor.hpp"
 
-#include "std_msgs/msg/string.hpp"
-#include "std_msgs/msg/bool.hpp"
+#include "example_interfaces/msg/string.hpp"
+#include "example_interfaces/msg/bool.hpp"
 
 #include "quality_of_service_demo/common_nodes.hpp"
 

--- a/quality_of_service_demo/rclcpp/src/interactive_publisher.cpp
+++ b/quality_of_service_demo/rclcpp/src/interactive_publisher.cpp
@@ -19,7 +19,7 @@
 #include <string>
 #include <thread>
 
-#include "std_msgs/msg/string.hpp"
+#include "example_interfaces/msg/string.hpp"
 #include "rcutils/cmdline_parser.h"
 #include "rclcpp/rclcpp.hpp"
 

--- a/quality_of_service_demo/rclcpp/src/interactive_subscriber.cpp
+++ b/quality_of_service_demo/rclcpp/src/interactive_subscriber.cpp
@@ -19,7 +19,7 @@
 #include <string>
 #include <thread>
 
-#include "std_msgs/msg/string.hpp"
+#include "example_interfaces/msg/string.hpp"
 #include "rcutils/cmdline_parser.h"
 #include "rclcpp/rclcpp.hpp"
 

--- a/quality_of_service_demo/rclpy/package.xml
+++ b/quality_of_service_demo/rclpy/package.xml
@@ -16,7 +16,7 @@
 
   <exec_depend>rclpy</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>example_interfaces</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/quality_of_service_demo/rclpy/quality_of_service_demo_py/common_nodes.py
+++ b/quality_of_service_demo/rclpy/quality_of_service_demo_py/common_nodes.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from example_interfaces.msg import String
 from rclpy.node import Node
-from std_msgs.msg import String
 
 
 class Talker(Node):

--- a/quality_of_service_demo/rclpy/quality_of_service_demo_py/qos_overrides_listener.py
+++ b/quality_of_service_demo/rclpy/quality_of_service_demo_py/qos_overrides_listener.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from example_interfaces.msg import String
+
 import sys
 
 import rclpy
@@ -19,8 +21,6 @@ from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from rclpy.qos_overriding_options import QosCallbackResult
 from rclpy.qos_overriding_options import QoSOverridingOptions
-
-from std_msgs.msg import String
 
 
 class Listener(Node):

--- a/quality_of_service_demo/rclpy/quality_of_service_demo_py/qos_overrides_talker.py
+++ b/quality_of_service_demo/rclpy/quality_of_service_demo_py/qos_overrides_talker.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from example_interfaces.msg import String
+
 import sys
 
 import rclpy
@@ -19,8 +21,6 @@ from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from rclpy.qos_overriding_options import QosCallbackResult
 from rclpy.qos_overriding_options import QoSOverridingOptions
-
-from std_msgs.msg import String
 
 
 class Talker(Node):

--- a/topic_monitor/package.xml
+++ b/topic_monitor/package.xml
@@ -20,6 +20,7 @@
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>rclpy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>example_interfaces</exec_depend>
 
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>

--- a/topic_monitor/topic_monitor/scripts/topic_monitor.py
+++ b/topic_monitor/topic_monitor/scripts/topic_monitor.py
@@ -23,7 +23,8 @@ import rclpy.logging
 from rclpy.qos import QoSProfile
 from rclpy.qos import QoSReliabilityPolicy
 
-from std_msgs.msg import Float32, Header
+from std_msgs.msg import Header
+from example_interfaces.msg import Float32
 
 QOS_DEPTH = 10
 logger = rclpy.logging.get_logger('topic_monitor')

--- a/topic_statistics_demo/CMakeLists.txt
+++ b/topic_statistics_demo/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcutils)
 find_package(sensor_msgs REQUIRED)
-find_package(statistics_msgs REQUIRED)
+find_package(example_interfaces REQUIRED)
 
 include_directories(include)
 # TODO(sloretz) stop exporting old-style CMake variables in the future
@@ -31,7 +31,8 @@ target_link_libraries(display_topic_statistics
   rclcpp::rclcpp
   rcutils::rcutils
   ${sensor_msgs_TARGETS}
-  ${statistics_msgs_TARGETS})
+  ${statistics_msgs_TARGETS}
+  ${example_interfaces_TARGETS})
 install(TARGETS display_topic_statistics DESTINATION lib/${PROJECT_NAME})
 
 if(BUILD_TESTING)

--- a/topic_statistics_demo/include/topic_statistics_demo/string_talker_listener_nodes.hpp
+++ b/topic_statistics_demo/include/topic_statistics_demo/string_talker_listener_nodes.hpp
@@ -20,7 +20,7 @@
 #include <string>
 
 #include "rclcpp/rclcpp.hpp"
-#include "std_msgs/msg/string.hpp"
+#include "example_interfaces/msg/string.hpp"
 
 namespace string_msgs
 {
@@ -46,7 +46,7 @@ public:
   void publish();
 
 private:
-  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr publisher_ = nullptr;
+  rclcpp::Publisher<example_interfaces::msg::String>::SharedPtr publisher_ = nullptr;
 
   const std::string topic_name_;
 
@@ -75,7 +75,7 @@ public:
 
 private:
   rclcpp::SubscriptionOptions subscription_options_;
-  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr subscription_ = nullptr;
+  rclcpp::Subscription<example_interfaces::msg::String>::SharedPtr subscription_ = nullptr;
 
   const std::string topic_name_;
 };

--- a/topic_statistics_demo/package.xml
+++ b/topic_statistics_demo/package.xml
@@ -19,11 +19,13 @@
   <build_depend>rcutils</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>statistics_msgs</build_depend>
+  <build_depend>example_interfaces</build_depend>
 
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rcutils</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>statistics_msgs</exec_depend>
+  <exec_depend>example_interfaces</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/topic_statistics_demo/src/string_talker_listener_nodes.cpp
+++ b/topic_statistics_demo/src/string_talker_listener_nodes.cpp
@@ -30,7 +30,7 @@ void StringTalker::initialize()
 {
   RCLCPP_INFO(get_logger(), "Talker starting up");
 
-  publisher_ = this->create_publisher<std_msgs::msg::String>(
+  publisher_ = this->create_publisher<example_interfaces::msg::String>(
     topic_name_,
     10 /* QoS history_depth */);
   publish_timer_ = create_wall_timer(
@@ -42,7 +42,7 @@ void StringTalker::initialize()
 
 void StringTalker::publish()
 {
-  std_msgs::msg::String msg;
+  example_interfaces::msg::String msg;
   msg.data = "Talker says " + std::to_string(publish_count_);
   RCLCPP_DEBUG(get_logger(), "Publishing: '%s'", msg.data.c_str());
   publisher_->publish(msg);
@@ -67,10 +67,10 @@ void StringListener::initialize()
 void StringListener::start_listening()
 {
   if (!subscription_) {
-    subscription_ = create_subscription<std_msgs::msg::String>(
+    subscription_ = create_subscription<example_interfaces::msg::String>(
       topic_name_,
       10,  /**QoS history_depth */
-      [this](std_msgs::msg::String::ConstSharedPtr msg) -> void
+      [this](example_interfaces::msg::String::ConstSharedPtr msg) -> void
       {
         RCLCPP_DEBUG(get_logger(), "Listener heard: [%s]", msg->data.c_str());
       },


### PR DESCRIPTION
This pull request the `demos` side of [this ros2_documentation issue](https://github.com/ros2/ros2_documentation/issues/3358) in which we switch from `std_msgs` to `example_interfaces` because std_msgs was deprecated about 4 years ago.