### PR TITLE
Update dummy_sensors readme to echo the correct topic

### DIFF
--- a/dummy_robot/dummy_sensors/README.md
+++ b/dummy_robot/dummy_sensors/README.md
@@ -45,7 +45,7 @@ A similar terminal output should be seen after running commands described in the
 
 ```bash
 # Open new terminal.
-ros2 topic echo /laser
+ros2 topic echo /scan
 ```
 
 ```bash


### PR DESCRIPTION
The output topic of `dummy_laser` is `/scan`. This just updates the README to inform the user to echo the `/scan` topic instead of the `/laser` topic. This was found while testing https://github.com/osrf/ros2_test_cases/issues/1202.