### PR TITLE
[dummy_sensors] update topic name to match code behavior

### DIFF
--- a/dummy_robot/dummy_sensors/README.md
+++ b/dummy_robot/dummy_sensors/README.md
@@ -45,7 +45,7 @@ A similar terminal output should be seen after running commands described in the
 
 ```bash
 # Open new terminal.
-ros2 topic echo /laser
+ros2 topic echo /scan
 ```
 
 ```bash


### PR DESCRIPTION
Found when testing https://github.com/osrf/ros2_test_cases/issues/1203
The dummy_laser publisher on `/scan` and not on `/laser`

```
root@d8ff93e471d7:/# ros2 run dummy_sensors dummy_laser
[INFO] [1714865257.258147676] [dummy_laser]: angle inc:	0.004363
[INFO] [1714865257.258194665] [dummy_laser]: scan size:	1081
[INFO] [1714865257.258202679] [dummy_laser]: scan time increment: 	0.000000
````

```
root@d8ff93e471d7:~/ros2_ws# ros2 topic list
/parameter_events
/rosout
/scan
```