### PR TITLE
Change occupancy value in `dummy_map_server` to  1.

### DIFF
--- a/dummy_robot/dummy_map_server/src/dummy_map_server.cpp
+++ b/dummy_robot/dummy_map_server/src/dummy_map_server.cpp
@@ -65,7 +65,7 @@ int main(int argc, char * argv[])
     msg.data[(center) % (msg.info.width * msg.info.height)] = -1;
     msg.data[(rhs) % (msg.info.width * msg.info.height)] = -1;
     msg.data[(++lhs) % (msg.info.width * msg.info.height)] = 0;
-    msg.data[(++center) % (msg.info.width * msg.info.height)] = 100;
+    msg.data[(++center) % (msg.info.width * msg.info.height)] = 1;
     msg.data[(++rhs) % (msg.info.width * msg.info.height)] = 0;
 
     msg.header.stamp = clock->now();


### PR DESCRIPTION
As pointed out in https://github.com/osrf/ros2_test_cases/issues/1200, dummy map server occupancy value should be `1` as specified in https://github.com/ros2/common_interfaces/blob/rolling/nav_msgs/msg/OccupancyGrid.msg.

We should backport this once merged.