### PR TITLE
Update README.md with image pipeline all seperately executable name error

### DIFF
--- a/intra_process_demo/README.md
+++ b/intra_process_demo/README.md
@@ -75,7 +75,7 @@ ros2 run intra_process_demo camera_node
 This starts the `watermarked_node` ROS 2 node which subscribes to raw images from ROS 2 topic `/image`, overlays both **process ID number** and **message address** on top of the image visually and publishes to ROS 2 topic `/watermarked_image`.
 ```bash
 # Open new terminal
-ros2 run intra_process_demo watermarked_node
+ros2 run intra_process_demo watermark_node
 ```
 
 This starts the `image_view_node` ROS 2 node which subscribes to `/watermarked_image` and displays the received images in an OpenCV GUI window.


### PR DESCRIPTION
During the testing of issue [Intra-process executables #1328](https://github.com/osrf/ros2_test_cases/issues/1328), I noticed a discrepancy in the node name specified for the **Image Pipeline All Separately**. The documentation states the executable name as ```watermarked_node```, which should be corrected to ```watermark_node``` for consistency and accuracy.

Brief:
Executable name: ```watermarked_node``` -> ```watermark_node```