### PR TITLE
[intra_process_demo] executable name in README.md fix-up

### DIFF
--- a/intra_process_demo/README.md
+++ b/intra_process_demo/README.md
@@ -72,7 +72,7 @@ This starts the `camera_node` ROS 2 node and publishes images captured from your
 ros2 run intra_process_demo camera_node
 ```
 
-This starts the `watermarked_node` ROS 2 node which subscribes to raw images from ROS 2 topic `/image`, overlays both **process ID number** and **message address** on top of the image visually and publishes to ROS 2 topic `/watermarked_image`.
+This starts the `watermark_node` ROS 2 node which subscribes to raw images from ROS 2 topic `/image`, overlays both **process ID number** and **message address** on top of the image visually and publishes to ROS 2 topic `/watermarked_image`.
 ```bash
 # Open new terminal
 ros2 run intra_process_demo watermark_node

--- a/intra_process_demo/README.md
+++ b/intra_process_demo/README.md
@@ -75,7 +75,7 @@ ros2 run intra_process_demo camera_node
 This starts the `watermarked_node` ROS 2 node which subscribes to raw images from ROS 2 topic `/image`, overlays both **process ID number** and **message address** on top of the image visually and publishes to ROS 2 topic `/watermarked_image`.
 ```bash
 # Open new terminal
-ros2 run intra_process_demo watermarked_node
+ros2 run intra_process_demo watermark_node
 ```
 
 This starts the `image_view_node` ROS 2 node which subscribes to `/watermarked_image` and displays the received images in an OpenCV GUI window.


### PR DESCRIPTION
Would like to add that the node name needs to be updated to watermark_node (instead of watermarked_node), Line 75 in the [README.md](https://github.com/ros2/demos/blob/54a4a681f429d327ace2665cc70ce8c2e9ca48d4/intra_process_demo/README.md?plain=1#L75). Node name [here](https://github.com/ros2/demos/blob/54a4a681f429d327ace2665cc70ce8c2e9ca48d4/intra_process_demo/include/image_pipeline/watermark_node.hpp#L40).