### PR TITLE
Change all of the demos to use the new rclpy context manager.

### DIFF
--- a/action_tutorials/action_tutorials_py/action_tutorials_py/fibonacci_action_client.py
+++ b/action_tutorials/action_tutorials_py/action_tutorials_py/fibonacci_action_client.py
@@ -17,6 +17,7 @@ from action_tutorials_interfaces.action import Fibonacci
 
 import rclpy
 from rclpy.action import ActionClient
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 
@@ -62,13 +63,15 @@ class FibonacciActionClient(Node):
 
 
 def main(args=None):
-    rclpy.init(args=args)
+    try:
+        with rclpy.init(args=args):
+            action_client = FibonacciActionClient()
 
-    action_client = FibonacciActionClient()
+            action_client.send_goal(10)
 
-    action_client.send_goal(10)
-
-    rclpy.spin(action_client)
+            rclpy.spin(action_client)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
 
 
 if __name__ == '__main__':

--- a/action_tutorials/action_tutorials_py/action_tutorials_py/fibonacci_action_server.py
+++ b/action_tutorials/action_tutorials_py/action_tutorials_py/fibonacci_action_server.py
@@ -19,6 +19,7 @@ from action_tutorials_interfaces.action import Fibonacci
 
 import rclpy
 from rclpy.action import ActionServer
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 
 
@@ -53,13 +54,11 @@ class FibonacciActionServer(Node):
 
 
 def main(args=None):
-    rclpy.init(args=args)
-
-    fibonacci_action_server = FibonacciActionServer()
-
     try:
-        rclpy.spin(fibonacci_action_server)
-    except KeyboardInterrupt:
+        with rclpy.init(args=args):
+            fibonacci_action_server = FibonacciActionServer()
+            rclpy.spin(fibonacci_action_server)
+    except (KeyboardInterrupt, ExternalShutdownException):
         pass
 
 

--- a/demo_nodes_py/demo_nodes_py/parameters/async_param_client.py
+++ b/demo_nodes_py/demo_nodes_py/parameters/async_param_client.py
@@ -16,6 +16,7 @@ import os
 from ament_index_python import get_package_share_directory
 import rclpy
 import rclpy.context
+from rclpy.executors import ExternalShutdownException
 from rclpy.parameter import Parameter
 from rclpy.parameter import parameter_dict_from_yaml_file
 from rclpy.parameter import parameter_value_to_python
@@ -23,80 +24,84 @@ from rclpy.parameter_client import AsyncParameterClient
 
 
 def main(args=None):
-    rclpy.init()
-    node = rclpy.create_node('async_param_client')
-    client = AsyncParameterClient(node, 'parameter_blackboard')
-    if not client.wait_for_services(3.0):
-        raise RuntimeError(
-            'parameter_blackboard is not available, start parameter blackboard with '
-            '`ros2 run demo_nodes_cpp parameter_blackboard` before running this demo')
-    param_list = ['int_parameter', 'bool_parameter', 'string_parameter']
+    try:
+        with rclpy.init():
+            node = rclpy.create_node('async_param_client')
+            client = AsyncParameterClient(node, 'parameter_blackboard')
+            if not client.wait_for_services(3.0):
+                raise RuntimeError(
+                    'parameter_blackboard is not available, start parameter blackboard with '
+                    '`ros2 run demo_nodes_cpp parameter_blackboard` before running this demo')
+            param_list = ['int_parameter', 'bool_parameter', 'string_parameter']
 
-    node.get_logger().info('Setting parameters:')
-    future = client.set_parameters([
-        Parameter('int_parameter', Parameter.Type.INTEGER, 10),
-        Parameter('bool_parameter', Parameter.Type.BOOL, False),
-        Parameter('string_parameter', Parameter.Type.STRING, 'Fee Fi Fo Fum'), ])
-    rclpy.spin_until_future_complete(node, future)
-    set_parameters_result = future.result()
-    if set_parameters_result is not None:
-        for i, v in enumerate(set_parameters_result.results):
-            node.get_logger().info(f'    {param_list[i]}:')
-            node.get_logger().info(f'        successful: {v.successful}')
-    else:
-        node.get_logger().error(f'Error setting parameters: {future.exception()}')
+            logger = node.get_logger()
 
-    node.get_logger().info('Listing Parameters:')
-    future = client.list_parameters(param_list, 10)
-    rclpy.spin_until_future_complete(node, future)
-    list_parameters_result = future.result()
-    if list_parameters_result is not None:
-        for param_name in list_parameters_result.result.names:
-            node.get_logger().info(f'    - {param_name}')
-    else:
-        node.get_logger().error(f'Error listing parameters: {future.exception()}')
+            logger.info('Setting parameters:')
+            future = client.set_parameters([
+                Parameter('int_parameter', Parameter.Type.INTEGER, 10),
+                Parameter('bool_parameter', Parameter.Type.BOOL, False),
+                Parameter('string_parameter', Parameter.Type.STRING, 'Fee Fi Fo Fum'), ])
+            rclpy.spin_until_future_complete(node, future)
+            set_parameters_result = future.result()
+            if set_parameters_result is not None:
+                for i, v in enumerate(set_parameters_result.results):
+                    logger.info(f'    {param_list[i]}:')
+                    logger.info(f'        successful: {v.successful}')
+            else:
+                logger.error(f'Error setting parameters: {future.exception()}')
 
-    node.get_logger().info('Getting parameters:')
-    future = client.get_parameters(param_list)
-    rclpy.spin_until_future_complete(node, future)
-    get_parameters_result = future.result()
-    if get_parameters_result is not None:
-        for i, v in enumerate(get_parameters_result.values):
-            node.get_logger().info(f'    - {param_list[i]}: {parameter_value_to_python(v)}')
-    else:
-        node.get_logger().error(f'Error getting parameters: {future.exception()}')
+            logger.info('Listing Parameters:')
+            future = client.list_parameters(param_list, 10)
+            rclpy.spin_until_future_complete(node, future)
+            list_parameters_result = future.result()
+            if list_parameters_result is not None:
+                for param_name in list_parameters_result.result.names:
+                    logger.info(f'    - {param_name}')
+            else:
+                logger.error(f'Error listing parameters: {future.exception()}')
 
-    node.get_logger().info('Loading parameters: ')
-    param_dir = get_package_share_directory('demo_nodes_py')
-    param_file_path = os.path.join(param_dir, 'params.yaml')
-    future = client.load_parameter_file(param_file_path)
-    rclpy.spin_until_future_complete(node, future)
-    load_parameter_results = future.result()
-    if load_parameter_results is not None:
-        param_file_dict = parameter_dict_from_yaml_file(param_file_path)
-        for i, v in enumerate(param_file_dict.keys()):
-            node.get_logger().info(f'    {v}:')
-            node.get_logger().info(f'        successful: '
-                                   f'{load_parameter_results.results[i].successful}')
-            node.get_logger().info(f'        value: '
-                                   f'{parameter_value_to_python(param_file_dict[v].value)}')
-    else:
-        node.get_logger().error(f'Error loading parameters: {future.exception()}')
+            logger.info('Getting parameters:')
+            future = client.get_parameters(param_list)
+            rclpy.spin_until_future_complete(node, future)
+            get_parameters_result = future.result()
+            if get_parameters_result is not None:
+                for i, v in enumerate(get_parameters_result.values):
+                    logger.info(f'    - {param_list[i]}: {parameter_value_to_python(v)}')
+            else:
+                logger.error(f'Error getting parameters: {future.exception()}')
 
-    node.get_logger().info('Deleting parameters: ')
-    params_to_delete = ['other_int_parameter', 'other_string_parameter', 'string_parameter']
-    future = client.delete_parameters(params_to_delete)
-    rclpy.spin_until_future_complete(node, future)
-    delete_parameters_result = future.result()
-    if delete_parameters_result is not None:
-        for i, v in enumerate(delete_parameters_result.results):
-            node.get_logger().info(f'    {params_to_delete[i]}:')
-            node.get_logger().info(f'        successful: {v.successful}')
-            node.get_logger().info(f'        reason: {v.reason}')
-    else:
-        node.get_logger().error(f'Error deleting parameters: {future.exception()}')
+            logger.info('Loading parameters: ')
+            param_dir = get_package_share_directory('demo_nodes_py')
+            param_file_path = os.path.join(param_dir, 'params.yaml')
+            future = client.load_parameter_file(param_file_path)
+            rclpy.spin_until_future_complete(node, future)
+            load_parameter_results = future.result()
+            if load_parameter_results is not None:
+                param_file_dict = parameter_dict_from_yaml_file(param_file_path)
+                for i, v in enumerate(param_file_dict.keys()):
+                    logger.info(f'    {v}:')
+                    logger.info(f'        successful: '
+                                f'{load_parameter_results.results[i].successful}')
+                    logger.info(f'        value: '
+                                f'{parameter_value_to_python(param_file_dict[v].value)}')
+            else:
+                logger.error(f'Error loading parameters: {future.exception()}')
 
-    rclpy.shutdown()
+            logger.info('Deleting parameters: ')
+            params_to_delete = ['other_int_parameter', 'other_string_parameter',
+                                'string_parameter']
+            future = client.delete_parameters(params_to_delete)
+            rclpy.spin_until_future_complete(node, future)
+            delete_parameters_result = future.result()
+            if delete_parameters_result is not None:
+                for i, v in enumerate(delete_parameters_result.results):
+                    logger.info(f'    {params_to_delete[i]}:')
+                    logger.info(f'        successful: {v.successful}')
+                    logger.info(f'        reason: {v.reason}')
+            else:
+                logger.error(f'Error deleting parameters: {future.exception()}')
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
 
 
 if __name__ == '__main__':

--- a/demo_nodes_py/demo_nodes_py/parameters/set_parameters_callback.py
+++ b/demo_nodes_py/demo_nodes_py/parameters/set_parameters_callback.py
@@ -73,17 +73,12 @@ class SetParametersCallback(Node):
 
 
 def main(args=None):
-    rclpy.init(args=args)
-
-    node = SetParametersCallback()
-
     try:
-        rclpy.spin(node)
+        with rclpy.init(args=args):
+            node = SetParametersCallback()
+            rclpy.spin(node)
     except (KeyboardInterrupt, ExternalShutdownException):
         pass
-    finally:
-        node.destroy_node()
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/demo_nodes_py/demo_nodes_py/services/add_two_ints_client.py
+++ b/demo_nodes_py/demo_nodes_py/services/add_two_ints_client.py
@@ -15,28 +15,28 @@
 from example_interfaces.srv import AddTwoInts
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 
 
 def main(args=None):
-    rclpy.init(args=args)
+    try:
+        with rclpy.init(args=args):
+            node = rclpy.create_node('add_two_ints_client')
 
-    node = rclpy.create_node('add_two_ints_client')
-
-    cli = node.create_client(AddTwoInts, 'add_two_ints')
-    while not cli.wait_for_service(timeout_sec=1.0):
-        print('service not available, waiting again...')
-    req = AddTwoInts.Request()
-    req.a = 2
-    req.b = 3
-    future = cli.call_async(req)
-    rclpy.spin_until_future_complete(node, future)
-    if future.result() is not None:
-        node.get_logger().info('Result of add_two_ints: %d' % future.result().sum)
-    else:
-        node.get_logger().error('Exception while calling service: %r' % future.exception())
-
-    node.destroy_node()
-    rclpy.try_shutdown()
+            cli = node.create_client(AddTwoInts, 'add_two_ints')
+            while not cli.wait_for_service(timeout_sec=1.0):
+                print('service not available, waiting again...')
+            req = AddTwoInts.Request()
+            req.a = 2
+            req.b = 3
+            future = cli.call_async(req)
+            rclpy.spin_until_future_complete(node, future)
+            if future.result() is not None:
+                node.get_logger().info('Result of add_two_ints: %d' % future.result().sum)
+            else:
+                node.get_logger().error('Exception while calling service: %r' % future.exception())
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
 
 
 if __name__ == '__main__':

--- a/demo_nodes_py/demo_nodes_py/services/add_two_ints_client_async.py
+++ b/demo_nodes_py/demo_nodes_py/services/add_two_ints_client_async.py
@@ -15,33 +15,35 @@
 from example_interfaces.srv import AddTwoInts
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
 
 
 def main(args=None):
+    try:
+        with rclpy.init(args=args):
+            node = rclpy.create_node('add_two_ints_client')
 
-    rclpy.init(args=args)
+            cli = node.create_client(AddTwoInts, 'add_two_ints')
 
-    node = rclpy.create_node('add_two_ints_client')
+            req = AddTwoInts.Request()
+            req.a = 2
+            req.b = 3
+            while not cli.wait_for_service(timeout_sec=1.0):
+                print('service not available, waiting again...')
+            future = cli.call_async(req)
 
-    cli = node.create_client(AddTwoInts, 'add_two_ints')
+            logger = node.get_logger()
 
-    req = AddTwoInts.Request()
-    req.a = 2
-    req.b = 3
-    while not cli.wait_for_service(timeout_sec=1.0):
-        print('service not available, waiting again...')
-    future = cli.call_async(req)
-    while rclpy.ok():
-        rclpy.spin_once(node)
-        if future.done():
-            if future.result() is not None:
-                node.get_logger().info('Result of add_two_ints: %d' % future.result().sum)
-            else:
-                node.get_logger().error('Exception while calling service: %r' % future.exception())
-            break
-
-    node.destroy_node()
-    rclpy.try_shutdown()
+            while rclpy.ok():
+                rclpy.spin_once(node)
+                if future.done():
+                    if future.result() is not None:
+                        logger.info('Result of add_two_ints: %d' % future.result().sum)
+                    else:
+                        logger.error('Exception while calling service: %r' % future.exception())
+                    break
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
 
 
 if __name__ == '__main__':

--- a/demo_nodes_py/demo_nodes_py/services/add_two_ints_server.py
+++ b/demo_nodes_py/demo_nodes_py/services/add_two_ints_server.py
@@ -33,19 +33,13 @@ class AddTwoIntsServer(Node):
 
 
 def main(args=None):
-    rclpy.init(args=args)
-
-    node = AddTwoIntsServer()
-
     try:
-        rclpy.spin(node)
+        with rclpy.init(args=args):
+            node = AddTwoIntsServer()
+
+            rclpy.spin(node)
     except (KeyboardInterrupt, ExternalShutdownException):
         pass
-    finally:
-        # Destroy the node explicitly
-        # (optional - Done automatically when node is garbage collected)
-        node.destroy_node()
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/demo_nodes_py/demo_nodes_py/services/introspection.py
+++ b/demo_nodes_py/demo_nodes_py/services/introspection.py
@@ -186,25 +186,19 @@ class IntrospectionServiceNode(Node):
 
 
 def main(args=None):
-    rclpy.init(args=args)
-
-    service_node = IntrospectionServiceNode()
-
-    client_node = IntrospectionClientNode()
-
-    executor = SingleThreadedExecutor()
-    executor.add_node(service_node)
-    executor.add_node(client_node)
-
     try:
-        executor.spin()
+        with rclpy.init(args=args):
+            service_node = IntrospectionServiceNode()
+
+            client_node = IntrospectionClientNode()
+
+            executor = SingleThreadedExecutor()
+            executor.add_node(service_node)
+            executor.add_node(client_node)
+
+            executor.spin()
     except (KeyboardInterrupt, ExternalShutdownException):
-        executor.remove_node(client_node)
-        executor.remove_node(service_node)
-        executor.shutdown()
-        service_node.destroy_node()
-        client_node.destroy_node()
-        rclpy.try_shutdown()
+        pass
 
 
 if __name__ == '__main__':

--- a/demo_nodes_py/demo_nodes_py/topics/listener.py
+++ b/demo_nodes_py/demo_nodes_py/topics/listener.py
@@ -30,16 +30,12 @@ class Listener(Node):
 
 
 def main(args=None):
-    rclpy.init(args=args)
-
-    node = Listener()
     try:
-        rclpy.spin(node)
+        with rclpy.init(args=args):
+            node = Listener()
+            rclpy.spin(node)
     except (KeyboardInterrupt, ExternalShutdownException):
         pass
-    finally:
-        node.destroy_node()
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/demo_nodes_py/demo_nodes_py/topics/listener_qos.py
+++ b/demo_nodes_py/demo_nodes_py/topics/listener_qos.py
@@ -52,27 +52,23 @@ def main(argv=sys.argv[1:]):
         help='max number of spin_once iterations')
     args = parser.parse_args(remove_ros_args(args=argv))
 
-    rclpy.init(args=argv)
-
-    if args.reliable:
-        custom_qos_profile = QoSProfile(
-            depth=10,
-            reliability=QoSReliabilityPolicy.RELIABLE)
-    else:
-        custom_qos_profile = qos_profile_sensor_data
-
-    node = ListenerQos(custom_qos_profile)
-
-    cycle_count = 0
     try:
-        while rclpy.ok() and cycle_count < args.number_of_cycles:
-            rclpy.spin_once(node)
-            cycle_count += 1
+        with rclpy.init(args=argv):
+            if args.reliable:
+                custom_qos_profile = QoSProfile(
+                    depth=10,
+                    reliability=QoSReliabilityPolicy.RELIABLE)
+            else:
+                custom_qos_profile = qos_profile_sensor_data
+
+            node = ListenerQos(custom_qos_profile)
+
+            cycle_count = 0
+            while rclpy.ok() and cycle_count < args.number_of_cycles:
+                rclpy.spin_once(node)
+                cycle_count += 1
     except (KeyboardInterrupt, ExternalShutdownException):
         pass
-    finally:
-        node.destroy_node()
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/demo_nodes_py/demo_nodes_py/topics/listener_serialized.py
+++ b/demo_nodes_py/demo_nodes_py/topics/listener_serialized.py
@@ -35,20 +35,13 @@ class SerializedSubscriber(Node):
 
 
 def main(args=None):
-    rclpy.init(args=args)
-
-    serialized_subscriber = SerializedSubscriber()
-
     try:
-        rclpy.spin(serialized_subscriber)
+        with rclpy.init(args=args):
+            serialized_subscriber = SerializedSubscriber()
+
+            rclpy.spin(serialized_subscriber)
     except (KeyboardInterrupt, ExternalShutdownException):
         pass
-    finally:
-        # Destroy the node explicitly
-        # (optional - otherwise it will be done automatically
-        # when the garbage collector destroys the node object)
-        serialized_subscriber.destroy_node()
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/demo_nodes_py/demo_nodes_py/topics/talker.py
+++ b/demo_nodes_py/demo_nodes_py/topics/talker.py
@@ -37,17 +37,13 @@ class Talker(Node):
 
 
 def main(args=None):
-    rclpy.init(args=args)
-
-    node = Talker()
-
     try:
-        rclpy.spin(node)
+        with rclpy.init(args=args):
+            node = Talker()
+
+            rclpy.spin(node)
     except (KeyboardInterrupt, ExternalShutdownException):
         pass
-    finally:
-        node.destroy_node()
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/demo_nodes_py/demo_nodes_py/topics/talker_qos.py
+++ b/demo_nodes_py/demo_nodes_py/topics/talker_qos.py
@@ -59,27 +59,23 @@ def main(argv=sys.argv[1:]):
         help='number of sending attempts')
     args = parser.parse_args(remove_ros_args(args=argv))
 
-    rclpy.init(args=argv)
-
-    if args.reliable:
-        custom_qos_profile = QoSProfile(
-            depth=10,
-            reliability=QoSReliabilityPolicy.RELIABLE)
-    else:
-        custom_qos_profile = qos_profile_sensor_data
-
-    node = TalkerQos(custom_qos_profile)
-
-    cycle_count = 0
     try:
-        while rclpy.ok() and cycle_count < args.number_of_cycles:
-            rclpy.spin_once(node)
-            cycle_count += 1
+        with rclpy.init(args=argv):
+            if args.reliable:
+                custom_qos_profile = QoSProfile(
+                    depth=10,
+                    reliability=QoSReliabilityPolicy.RELIABLE)
+            else:
+                custom_qos_profile = qos_profile_sensor_data
+
+            node = TalkerQos(custom_qos_profile)
+
+            cycle_count = 0
+            while rclpy.ok() and cycle_count < args.number_of_cycles:
+                rclpy.spin_once(node)
+                cycle_count += 1
     except (KeyboardInterrupt, ExternalShutdownException):
         pass
-    finally:
-        node.destroy_node()
-        rclpy.try_shutdown()
 
 
 if __name__ == '__main__':

--- a/lifecycle_py/launch/lifecycle_demo_launch.py
+++ b/lifecycle_py/launch/lifecycle_demo_launch.py
@@ -19,7 +19,7 @@ from launch_ros.actions import Node
 
 def generate_launch_description():
     return LaunchDescription([
-        LifecycleNode(package='lifecycle', executable='lifecycle_talker',
+        LifecycleNode(package='lifecycle_py', executable='lifecycle_talker',
                       name='lc_talker', namespace='', output='screen'),
         Node(package='lifecycle', executable='lifecycle_listener', output='screen'),
         Node(package='lifecycle', executable='lifecycle_service_client', output='screen')

--- a/lifecycle_py/lifecycle_py/talker.py
+++ b/lifecycle_py/lifecycle_py/talker.py
@@ -15,6 +15,8 @@
 from typing import Optional
 
 import rclpy
+from rclpy.executors import ExternalShutdownException
+from rclpy.executors import SingleThreadedExecutor
 
 # Node, State and Publisher are aliases for LifecycleNode, LifecycleState and LifecyclePublisher
 # respectively.
@@ -142,15 +144,14 @@ class LifecycleTalker(Node):
 # node, give it a name and add it to the executor.
 
 def main():
-    rclpy.init()
-
-    executor = rclpy.executors.SingleThreadedExecutor()
-    lc_node = LifecycleTalker('lc_talker')
-    executor.add_node(lc_node)
     try:
-        executor.spin()
-    except (KeyboardInterrupt, rclpy.executors.ExternalShutdownException):
-        lc_node.destroy_node()
+        with rclpy.init():
+            executor = SingleThreadedExecutor()
+            lc_node = LifecycleTalker('lc_talker')
+            executor.add_node(lc_node)
+            executor.spin()
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass
 
 
 if __name__ == '__main__':

--- a/quality_of_service_demo/rclpy/quality_of_service_demo_py/deadline.py
+++ b/quality_of_service_demo/rclpy/quality_of_service_demo_py/deadline.py
@@ -44,47 +44,46 @@ def parse_args():
 
 
 def main(args=None):
-    parsed_args = parse_args()
-    rclpy.init(args=args)
-
-    topic = 'qos_deadline_chatter'
-    deadline = Duration(seconds=parsed_args.deadline / 1000.0)
-
-    qos_profile = QoSProfile(
-        depth=10,
-        deadline=deadline)
-
-    def sub_deadline_event(event):
-        count = event.total_count
-        delta = event.total_count_change
-        get_logger('listener').info(f'Requested deadline missed - total {count} delta {delta}')
-
-    subscription_callbacks = SubscriptionEventCallbacks(deadline=sub_deadline_event)
-    listener = Listener(topic, qos_profile, event_callbacks=subscription_callbacks)
-
-    def pub_deadline_event(event):
-        count = event.total_count
-        delta = event.total_count_change
-        get_logger('talker').info(f'Offered deadline missed - total {count} delta {delta}')
-
-    publisher_callbacks = PublisherEventCallbacks(deadline=pub_deadline_event)
-    talker = Talker(topic, qos_profile, event_callbacks=publisher_callbacks)
-
-    publish_for_seconds = parsed_args.publish_for / 1000.0
-    pause_for_seconds = parsed_args.pause_for / 1000.0
-    pause_timer = talker.create_timer(  # noqa: F841
-        publish_for_seconds,
-        lambda: talker.pause_for(pause_for_seconds))
-
-    executor = SingleThreadedExecutor()
-    executor.add_node(listener)
-    executor.add_node(talker)
     try:
-        executor.spin()
+        parsed_args = parse_args()
+
+        with rclpy.init(args=args):
+            topic = 'qos_deadline_chatter'
+            deadline = Duration(seconds=parsed_args.deadline / 1000.0)
+
+            qos_profile = QoSProfile(
+                depth=10,
+                deadline=deadline)
+
+            def sub_deadline_event(event):
+                count = event.total_count
+                delta = event.total_count_change
+                get_logger('listener').info(
+                    f'Requested deadline missed - total {count} delta {delta}')
+
+            subscription_callbacks = SubscriptionEventCallbacks(deadline=sub_deadline_event)
+            listener = Listener(topic, qos_profile, event_callbacks=subscription_callbacks)
+
+            def pub_deadline_event(event):
+                count = event.total_count
+                delta = event.total_count_change
+                get_logger('talker').info(f'Offered deadline missed - total {count} delta {delta}')
+
+            publisher_callbacks = PublisherEventCallbacks(deadline=pub_deadline_event)
+            talker = Talker(topic, qos_profile, event_callbacks=publisher_callbacks)
+
+            publish_for_seconds = parsed_args.publish_for / 1000.0
+            pause_for_seconds = parsed_args.pause_for / 1000.0
+            pause_timer = talker.create_timer(  # noqa: F841
+                publish_for_seconds,
+                lambda: talker.pause_for(pause_for_seconds))
+
+            executor = SingleThreadedExecutor()
+            executor.add_node(listener)
+            executor.add_node(talker)
+            executor.spin()
     except (KeyboardInterrupt, ExternalShutdownException):
         pass
-    finally:
-        rclpy.try_shutdown()
 
     return 0
 

--- a/quality_of_service_demo/rclpy/quality_of_service_demo_py/incompatible_qos.py
+++ b/quality_of_service_demo/rclpy/quality_of_service_demo_py/incompatible_qos.py
@@ -44,120 +44,120 @@ def get_parser():
 
 
 def main(args=None):
-    # Argument parsing and usage
-    parser = get_parser()
-    parsed_args = parser.parse_args()
-
-    # Configuration variables
-    qos_policy_name = parsed_args.incompatible_qos_policy_name
-    qos_profile_publisher = QoSProfile(depth=10)
-    qos_profile_subscription = QoSProfile(depth=10)
-
-    if qos_policy_name == 'durability':
-        print(
-            'Durability incompatibility selected.\n'
-            'Incompatibility condition: publisher durability kind < '
-            'subscription durability kind.\n'
-            'Setting publisher durability to: VOLATILE\n'
-            'Setting subscription durability to: TRANSIENT_LOCAL\n'
-        )
-        qos_profile_publisher.durability = \
-            QoSDurabilityPolicy.VOLATILE
-        qos_profile_subscription.durability = \
-            QoSDurabilityPolicy.TRANSIENT_LOCAL
-    elif qos_policy_name == 'deadline':
-        print(
-            'Deadline incompatibility selected.\n'
-            'Incompatibility condition: publisher deadline > subscription deadline.\n'
-            'Setting publisher durability to: 2 seconds\n'
-            'Setting subscription durability to: 1 second\n'
-        )
-        qos_profile_publisher.deadline = Duration(seconds=2)
-        qos_profile_subscription.deadline = Duration(seconds=1)
-    elif qos_policy_name == 'liveliness_policy':
-        print(
-            'Liveliness Policy incompatibility selected.\n'
-            'Incompatibility condition: publisher liveliness policy <'
-            'subscripition liveliness policy.\n'
-            'Setting publisher liveliness policy to: AUTOMATIC\n'
-            'Setting subscription liveliness policy to: MANUAL_BY_TOPIC\n'
-        )
-        qos_profile_publisher.liveliness = \
-            QoSLivelinessPolicy.AUTOMATIC
-        qos_profile_subscription.liveliness = \
-            QoSLivelinessPolicy.MANUAL_BY_TOPIC
-    elif qos_policy_name == 'liveliness_lease_duration':
-        print(
-            'Liveliness lease duration incompatibility selected.\n'
-            'Incompatibility condition: publisher liveliness lease duration >'
-            'subscription liveliness lease duration.\n'
-            'Setting publisher liveliness lease duration to: 2 seconds\n'
-            'Setting subscription liveliness lease duration to: 1 second\n'
-        )
-        qos_profile_publisher.liveliness_lease_duration = Duration(seconds=2)
-        qos_profile_subscription.liveliness_lease_duration = Duration(seconds=1)
-    elif qos_policy_name == 'reliability':
-        print(
-            'Reliability incompatibility selected.\n'
-            'Incompatibility condition: publisher reliability < subscripition reliability.\n'
-            'Setting publisher reliability to: BEST_EFFORT\n'
-            'Setting subscription reliability to: RELIABLE\n'
-        )
-        qos_profile_publisher.reliability = \
-            QoSReliabilityPolicy.BEST_EFFORT
-        qos_profile_subscription.reliability = \
-            QoSReliabilityPolicy.RELIABLE
-    else:
-        print('{name} not recognised.'.format(name=qos_policy_name))
-        parser.print_help()
-        return 1
-
-    # Initialization and configuration
-    rclpy.init(args=args)
-    topic = 'incompatible_qos_chatter'
-    num_msgs = 5
-
-    def sub_incompatible_qos_event(event):
-        count = event.total_count
-        delta = event.total_count_change
-        policy = event.last_policy_kind
-        get_logger('listener').info(
-            f'Requested incompatible qos - total {count} delta {delta} last_policy_kind: {policy}')
-
-    def pub_incompatible_qos_event(event):
-        count = event.total_count
-        delta = event.total_count_change
-        policy = event.last_policy_kind
-        get_logger('talker').info(
-            f'Offered incompatible qos - total {count} delta {delta} last_policy_kind: {policy}')
-
-    publisher_callbacks = PublisherEventCallbacks(incompatible_qos=pub_incompatible_qos_event)
-    subscription_callbacks = SubscriptionEventCallbacks(
-        incompatible_qos=sub_incompatible_qos_event)
-
     try:
-        talker = Talker(
-            topic, qos_profile_publisher, event_callbacks=publisher_callbacks,
-            publish_count=num_msgs)
-        listener = Listener(
-            topic, qos_profile_subscription, event_callbacks=subscription_callbacks)
-    except UnsupportedEventTypeError as exc:
-        print()
-        print(exc, end='\n\n')
-        print('Please try this demo using a different RMW implementation')
-        return 1
+        # Argument parsing and usage
+        parser = get_parser()
+        parsed_args = parser.parse_args()
 
-    executor = SingleThreadedExecutor()
-    executor.add_node(listener)
-    executor.add_node(talker)
+        # Configuration variables
+        qos_policy_name = parsed_args.incompatible_qos_policy_name
+        qos_profile_publisher = QoSProfile(depth=10)
+        qos_profile_subscription = QoSProfile(depth=10)
 
-    try:
-        while talker.publish_count < num_msgs:
-            executor.spin_once()
+        if qos_policy_name == 'durability':
+            print(
+                'Durability incompatibility selected.\n'
+                'Incompatibility condition: publisher durability kind < '
+                'subscription durability kind.\n'
+                'Setting publisher durability to: VOLATILE\n'
+                'Setting subscription durability to: TRANSIENT_LOCAL\n'
+            )
+            qos_profile_publisher.durability = \
+                QoSDurabilityPolicy.VOLATILE
+            qos_profile_subscription.durability = \
+                QoSDurabilityPolicy.TRANSIENT_LOCAL
+        elif qos_policy_name == 'deadline':
+            print(
+                'Deadline incompatibility selected.\n'
+                'Incompatibility condition: publisher deadline > subscription deadline.\n'
+                'Setting publisher durability to: 2 seconds\n'
+                'Setting subscription durability to: 1 second\n'
+            )
+            qos_profile_publisher.deadline = Duration(seconds=2)
+            qos_profile_subscription.deadline = Duration(seconds=1)
+        elif qos_policy_name == 'liveliness_policy':
+            print(
+                'Liveliness Policy incompatibility selected.\n'
+                'Incompatibility condition: publisher liveliness policy <'
+                'subscripition liveliness policy.\n'
+                'Setting publisher liveliness policy to: AUTOMATIC\n'
+                'Setting subscription liveliness policy to: MANUAL_BY_TOPIC\n'
+            )
+            qos_profile_publisher.liveliness = \
+                QoSLivelinessPolicy.AUTOMATIC
+            qos_profile_subscription.liveliness = \
+                QoSLivelinessPolicy.MANUAL_BY_TOPIC
+        elif qos_policy_name == 'liveliness_lease_duration':
+            print(
+                'Liveliness lease duration incompatibility selected.\n'
+                'Incompatibility condition: publisher liveliness lease duration >'
+                'subscription liveliness lease duration.\n'
+                'Setting publisher liveliness lease duration to: 2 seconds\n'
+                'Setting subscription liveliness lease duration to: 1 second\n'
+            )
+            qos_profile_publisher.liveliness_lease_duration = Duration(seconds=2)
+            qos_profile_subscription.liveliness_lease_duration = Duration(seconds=1)
+        elif qos_policy_name == 'reliability':
+            print(
+                'Reliability incompatibility selected.\n'
+                'Incompatibility condition: publisher reliability < subscripition reliability.\n'
+                'Setting publisher reliability to: BEST_EFFORT\n'
+                'Setting subscription reliability to: RELIABLE\n'
+            )
+            qos_profile_publisher.reliability = \
+                QoSReliabilityPolicy.BEST_EFFORT
+            qos_profile_subscription.reliability = \
+                QoSReliabilityPolicy.RELIABLE
+        else:
+            print('{name} not recognised.'.format(name=qos_policy_name))
+            parser.print_help()
+            return 1
+
+        # Initialization and configuration
+        with rclpy.init(args=args):
+            topic = 'incompatible_qos_chatter'
+            num_msgs = 5
+
+            def sub_incompatible_qos_event(event):
+                count = event.total_count
+                delta = event.total_count_change
+                policy = event.last_policy_kind
+                get_logger('listener').info(
+                    f'Requested incompatible qos - total {count} delta {delta} '
+                    f'last_policy_kind: {policy}')
+
+            def pub_incompatible_qos_event(event):
+                count = event.total_count
+                delta = event.total_count_change
+                policy = event.last_policy_kind
+                get_logger('talker').info(
+                    f'Offered incompatible qos - total {count} delta {delta} '
+                    f'last_policy_kind: {policy}')
+
+            pub_callbacks = PublisherEventCallbacks(incompatible_qos=pub_incompatible_qos_event)
+            subscription_callbacks = SubscriptionEventCallbacks(
+                incompatible_qos=sub_incompatible_qos_event)
+
+            try:
+                talker = Talker(
+                    topic, qos_profile_publisher, event_callbacks=pub_callbacks,
+                    publish_count=num_msgs)
+                listener = Listener(
+                    topic, qos_profile_subscription, event_callbacks=subscription_callbacks)
+            except UnsupportedEventTypeError as exc:
+                print()
+                print(exc, end='\n\n')
+                print('Please try this demo using a different RMW implementation')
+                return 1
+
+            executor = SingleThreadedExecutor()
+            executor.add_node(listener)
+            executor.add_node(talker)
+
+            while talker.publish_count < num_msgs:
+                executor.spin_once()
     except (KeyboardInterrupt, ExternalShutdownException):
         pass
-    finally:
-        rclpy.try_shutdown()
 
     return 0
 

--- a/quality_of_service_demo/rclpy/quality_of_service_demo_py/message_lost_listener.py
+++ b/quality_of_service_demo/rclpy/quality_of_service_demo_py/message_lost_listener.py
@@ -61,18 +61,15 @@ class MessageLostListener(Node):
 
 
 def main(args=None):
-    rclpy.init(args=args)
-
-    listener = MessageLostListener()
-    executor = SingleThreadedExecutor()
-    executor.add_node(listener)
-
     try:
-        executor.spin()
+        with rclpy.init(args=args):
+            listener = MessageLostListener()
+            executor = SingleThreadedExecutor()
+            executor.add_node(listener)
+
+            executor.spin()
     except (KeyboardInterrupt, ExternalShutdownException):
         pass
-    finally:
-        rclpy.try_shutdown()
 
     return 0
 

--- a/quality_of_service_demo/rclpy/quality_of_service_demo_py/qos_overrides_listener.py
+++ b/quality_of_service_demo/rclpy/quality_of_service_demo_py/qos_overrides_listener.py
@@ -48,16 +48,12 @@ class Listener(Node):
 
 
 def main(args=None):
-    rclpy.init(args=args)
-
-    node = Listener()
     try:
-        rclpy.spin(node)
+        with rclpy.init(args=args):
+            node = Listener()
+            rclpy.spin(node)
     except (KeyboardInterrupt, ExternalShutdownException):
         pass
-    finally:
-        node.destroy_node()
-        rclpy.try_shutdown()
 
     return 0
 

--- a/quality_of_service_demo/rclpy/quality_of_service_demo_py/qos_overrides_talker.py
+++ b/quality_of_service_demo/rclpy/quality_of_service_demo_py/qos_overrides_talker.py
@@ -55,17 +55,13 @@ class Talker(Node):
 
 
 def main(args=None):
-    rclpy.init(args=args)
-
-    node = Talker()
-
     try:
-        rclpy.spin(node)
+        with rclpy.init(args=args):
+            node = Talker()
+
+            rclpy.spin(node)
     except (KeyboardInterrupt, ExternalShutdownException):
         pass
-    finally:
-        node.destroy_node()
-        rclpy.try_shutdown()
 
     return 0
 


### PR DESCRIPTION
This will cleans things up at a much more predictable time. While we are in here, we make the handling of KeyboardInterrupt and ExternalShutdownException more consistent across all of the demos.

This is part of https://github.com/ros2/rclpy/issues/1280