### PR TITLE
Set envars to run tests with rmw_zenoh_cpp with multicast discovery

### DIFF
--- a/composition/CMakeLists.txt
+++ b/composition/CMakeLists.txt
@@ -164,6 +164,15 @@ if(BUILD_TESTING)
     set(EXPECTED_OUTPUT_PUBSUB "${CMAKE_CURRENT_SOURCE_DIR}/test/composition_pubsub")
     set(EXPECTED_OUTPUT_SRV "${CMAKE_CURRENT_SOURCE_DIR}/test/composition_srv")
 
+    # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+    if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
+      list(APPEND rmw_implementation_env_var
+        ZENOH_ROUTER_CHECK_ATTEMPTS=-1
+        ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
+        RUST_LOG=z=error
+      )
+    endif()
+
     set(test_names
       "test_dlopen_composition"
       "test_linktime_composition"
@@ -183,6 +192,7 @@ if(BUILD_TESTING)
         "${CMAKE_CURRENT_BINARY_DIR}/${test_name}${target_suffix}_$<CONFIG>.py"
         TARGET ${test_name}${target_suffix}
         ENV RMW_IMPLEMENTATION=${rmw_implementation}
+        ${rmw_implementation_env_var}
         APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/test_ament_index/$<CONFIG>
         APPEND_LIBRARY_DIRS "${append_library_dirs}"
         TIMEOUT 60

--- a/composition/CMakeLists.txt
+++ b/composition/CMakeLists.txt
@@ -164,12 +164,12 @@ if(BUILD_TESTING)
     set(EXPECTED_OUTPUT_PUBSUB "${CMAKE_CURRENT_SOURCE_DIR}/test/composition_pubsub")
     set(EXPECTED_OUTPUT_SRV "${CMAKE_CURRENT_SOURCE_DIR}/test/composition_srv")
 
+    set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
     # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+    # Note: This is a temporary change that will be reverted before we branch into Kilted.
     if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
       list(APPEND rmw_implementation_env_var
-        ZENOH_ROUTER_CHECK_ATTEMPTS=-1
         ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
-        RUST_LOG=z=error
       )
     endif()
 
@@ -191,8 +191,7 @@ if(BUILD_TESTING)
       add_launch_test(
         "${CMAKE_CURRENT_BINARY_DIR}/${test_name}${target_suffix}_$<CONFIG>.py"
         TARGET ${test_name}${target_suffix}
-        ENV RMW_IMPLEMENTATION=${rmw_implementation}
-        ${rmw_implementation_env_var}
+        ENV ${rmw_implementation_env_var}
         APPEND_ENV AMENT_PREFIX_PATH=${CMAKE_CURRENT_BINARY_DIR}/test_ament_index/$<CONFIG>
         APPEND_LIBRARY_DIRS "${append_library_dirs}"
         TIMEOUT 60

--- a/demo_nodes_cpp/CMakeLists.txt
+++ b/demo_nodes_cpp/CMakeLists.txt
@@ -250,11 +250,10 @@ if(BUILD_TESTING)
 
       set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
       # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+      # Note: This is a temporary change that will be reverted before we branch into Kilted.
       if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
         list(APPEND rmw_implementation_env_var
-          ZENOH_ROUTER_CHECK_ATTEMPTS=-1
           ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
-          RUST_LOG=z=error
         )
       endif()
 
@@ -263,8 +262,8 @@ if(BUILD_TESTING)
         TARGET test_tutorial_${exe_list_underscore}${target_suffix}
         TIMEOUT 60
         ENV
-          RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
-          ${rmw_implementation_env_var}
+        RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
+        ${rmw_implementation_env_var}
       )
       foreach(executable ${exe_list})
         set_property(

--- a/demo_nodes_cpp/CMakeLists.txt
+++ b/demo_nodes_cpp/CMakeLists.txt
@@ -248,6 +248,7 @@ if(BUILD_TESTING)
         INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_${exe_list_underscore}${target_suffix}.py.configured"
       )
 
+      set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
       # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
       if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
         list(APPEND rmw_implementation_env_var
@@ -262,9 +263,8 @@ if(BUILD_TESTING)
         TARGET test_tutorial_${exe_list_underscore}${target_suffix}
         TIMEOUT 60
         ENV
-        RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
-        RMW_IMPLEMENTATION=${rmw_implementation}
-        ${rmw_implementation_env_var}
+          RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
+          ${rmw_implementation_env_var}
       )
       foreach(executable ${exe_list})
         set_property(

--- a/demo_nodes_cpp/CMakeLists.txt
+++ b/demo_nodes_cpp/CMakeLists.txt
@@ -248,6 +248,15 @@ if(BUILD_TESTING)
         INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_${exe_list_underscore}${target_suffix}.py.configured"
       )
 
+      # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+      if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
+        list(APPEND rmw_implementation_env_var
+          ZENOH_ROUTER_CHECK_ATTEMPTS=-1
+          ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
+          RUST_LOG=z=error
+        )
+      endif()
+
       add_launch_test(
         "${CMAKE_CURRENT_BINARY_DIR}/test_${exe_list_underscore}${target_suffix}_$<CONFIG>.py"
         TARGET test_tutorial_${exe_list_underscore}${target_suffix}
@@ -255,6 +264,7 @@ if(BUILD_TESTING)
         ENV
         RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
         RMW_IMPLEMENTATION=${rmw_implementation}
+        ${rmw_implementation_env_var}
       )
       foreach(executable ${exe_list})
         set_property(

--- a/image_tools/CMakeLists.txt
+++ b/image_tools/CMakeLists.txt
@@ -81,6 +81,7 @@ if(BUILD_TESTING)
       INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_showimage_cam2image${target_suffix}.py.genexp"
     )
 
+    set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
     # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
     if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
       list(APPEND rmw_implementation_env_var
@@ -94,9 +95,8 @@ if(BUILD_TESTING)
       "${CMAKE_CURRENT_BINARY_DIR}/test_showimage_cam2image${target_suffix}_$<CONFIG>.py"
       TARGET test_showimage_cam2image${target_suffix}
       ENV
-      RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
-      RMW_IMPLEMENTATION=${rmw_implementation}
-      ${rmw_implementation_env_var}
+        RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
+        ${rmw_implementation_env_var}
       TIMEOUT 30
     )
   endmacro()

--- a/image_tools/CMakeLists.txt
+++ b/image_tools/CMakeLists.txt
@@ -81,12 +81,22 @@ if(BUILD_TESTING)
       INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_showimage_cam2image${target_suffix}.py.genexp"
     )
 
+    # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+    if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
+      list(APPEND rmw_implementation_env_var
+        ZENOH_ROUTER_CHECK_ATTEMPTS=-1
+        ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
+        RUST_LOG=z=error
+      )
+    endif()
+
     add_launch_test(
       "${CMAKE_CURRENT_BINARY_DIR}/test_showimage_cam2image${target_suffix}_$<CONFIG>.py"
       TARGET test_showimage_cam2image${target_suffix}
       ENV
       RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
       RMW_IMPLEMENTATION=${rmw_implementation}
+      ${rmw_implementation_env_var}
       TIMEOUT 30
     )
   endmacro()

--- a/image_tools/CMakeLists.txt
+++ b/image_tools/CMakeLists.txt
@@ -83,11 +83,10 @@ if(BUILD_TESTING)
 
     set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
     # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+    # Note: This is a temporary change that will be reverted before we branch into Kilted.
     if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
       list(APPEND rmw_implementation_env_var
-        ZENOH_ROUTER_CHECK_ATTEMPTS=-1
         ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
-        RUST_LOG=z=error
       )
     endif()
 
@@ -95,8 +94,8 @@ if(BUILD_TESTING)
       "${CMAKE_CURRENT_BINARY_DIR}/test_showimage_cam2image${target_suffix}_$<CONFIG>.py"
       TARGET test_showimage_cam2image${target_suffix}
       ENV
-        RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
-        ${rmw_implementation_env_var}
+      RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
+       ${rmw_implementation_env_var}
       TIMEOUT 30
     )
   endmacro()

--- a/intra_process_demo/CMakeLists.txt
+++ b/intra_process_demo/CMakeLists.txt
@@ -144,6 +144,15 @@ if(BUILD_TESTING)
         INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_${exe_list_underscore}${target_suffix}.py.configured"
       )
 
+      # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+      if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
+        list(APPEND rmw_implementation_env_var
+          ZENOH_ROUTER_CHECK_ATTEMPTS=-1
+          ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
+          RUST_LOG=z=error
+        )
+      endif()
+
       add_launch_test(
         "${CMAKE_CURRENT_BINARY_DIR}/test_${exe_list_underscore}${target_suffix}_$<CONFIG>.py"
         TARGET test_demo_${exe_list_underscore}${target_suffix}
@@ -151,6 +160,7 @@ if(BUILD_TESTING)
         ENV
         RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
         RMW_IMPLEMENTATION=${rmw_implementation}
+        ${rmw_implementation_env_var}
       )
       if(TEST test_demo_${exe_list_underscore}${target_suffix})
         set_tests_properties(test_demo_${exe_list_underscore}${target_suffix}

--- a/intra_process_demo/CMakeLists.txt
+++ b/intra_process_demo/CMakeLists.txt
@@ -146,11 +146,10 @@ if(BUILD_TESTING)
 
       set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
       # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+      # Note: This is a temporary change that will be reverted before we branch into Kilted.
       if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
         list(APPEND rmw_implementation_env_var
-          ZENOH_ROUTER_CHECK_ATTEMPTS=-1
           ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
-          RUST_LOG=z=error
         )
       endif()
 
@@ -159,8 +158,8 @@ if(BUILD_TESTING)
         TARGET test_demo_${exe_list_underscore}${target_suffix}
         TIMEOUT 30
         ENV
-          RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
-          ${rmw_implementation_env_var}
+        RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
+        ${rmw_implementation_env_var}
       )
       if(TEST test_demo_${exe_list_underscore}${target_suffix})
         set_tests_properties(test_demo_${exe_list_underscore}${target_suffix}

--- a/intra_process_demo/CMakeLists.txt
+++ b/intra_process_demo/CMakeLists.txt
@@ -144,6 +144,7 @@ if(BUILD_TESTING)
         INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_${exe_list_underscore}${target_suffix}.py.configured"
       )
 
+      set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
       # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
       if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
         list(APPEND rmw_implementation_env_var
@@ -158,9 +159,8 @@ if(BUILD_TESTING)
         TARGET test_demo_${exe_list_underscore}${target_suffix}
         TIMEOUT 30
         ENV
-        RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
-        RMW_IMPLEMENTATION=${rmw_implementation}
-        ${rmw_implementation_env_var}
+          RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
+          ${rmw_implementation_env_var}
       )
       if(TEST test_demo_${exe_list_underscore}${target_suffix})
         set_tests_properties(test_demo_${exe_list_underscore}${target_suffix}

--- a/logging_demo/CMakeLists.txt
+++ b/logging_demo/CMakeLists.txt
@@ -92,6 +92,7 @@ if(BUILD_TESTING)
       INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_logging_demo${target_suffix}.py.genexp"
     )
 
+    set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
     # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
     if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
       list(APPEND rmw_implementation_env_var
@@ -104,8 +105,7 @@ if(BUILD_TESTING)
     add_launch_test(
       "${CMAKE_CURRENT_BINARY_DIR}/test_logging_demo${target_suffix}_$<CONFIG>.py"
       TARGET test_logging_demo${target_suffix}
-      ENV RMW_IMPLEMENTATION=${rmw_implementation}
-      ${rmw_implementation_env_var}
+      ENV ${rmw_implementation_env_var}
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
       TIMEOUT 30
     )

--- a/logging_demo/CMakeLists.txt
+++ b/logging_demo/CMakeLists.txt
@@ -91,10 +91,21 @@ if(BUILD_TESTING)
       OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test_logging_demo${target_suffix}_$<CONFIG>.py"
       INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_logging_demo${target_suffix}.py.genexp"
     )
+
+    # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+    if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
+      list(APPEND rmw_implementation_env_var
+        ZENOH_ROUTER_CHECK_ATTEMPTS=-1
+        ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
+        RUST_LOG=z=error
+      )
+    endif()
+
     add_launch_test(
       "${CMAKE_CURRENT_BINARY_DIR}/test_logging_demo${target_suffix}_$<CONFIG>.py"
       TARGET test_logging_demo${target_suffix}
       ENV RMW_IMPLEMENTATION=${rmw_implementation}
+      ${rmw_implementation_env_var}
       APPEND_LIBRARY_DIRS "${append_library_dirs}"
       TIMEOUT 30
     )

--- a/logging_demo/CMakeLists.txt
+++ b/logging_demo/CMakeLists.txt
@@ -94,11 +94,10 @@ if(BUILD_TESTING)
 
     set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
     # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+    # Note: This is a temporary change that will be reverted before we branch into Kilted.
     if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
       list(APPEND rmw_implementation_env_var
-        ZENOH_ROUTER_CHECK_ATTEMPTS=-1
         ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
-        RUST_LOG=z=error
       )
     endif()
 

--- a/pendulum_control/CMakeLists.txt
+++ b/pendulum_control/CMakeLists.txt
@@ -108,11 +108,10 @@ if(BUILD_TESTING)
 
     set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
     # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+    # Note: This is a temporary change that will be reverted before we branch into Kilted.
     if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
       list(APPEND rmw_implementation_env_var
-        ZENOH_ROUTER_CHECK_ATTEMPTS=-1
         ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
-        RUST_LOG=z=error
       )
     endif()
 
@@ -122,8 +121,8 @@ if(BUILD_TESTING)
       TARGET test_pendulum__${rmw_implementation}
       TIMEOUT 20
       ENV
-        RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
-        ${rmw_implementation_env_var}
+      RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
+      ${rmw_implementation_env_var}
       # since the test generates a .csv file in the cwd
       WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_pendulum__${rmw_implementation}"
       ${SKIP_TEST}
@@ -138,9 +137,9 @@ if(BUILD_TESTING)
       TARGET test_pendulum_teleop__${rmw_implementation}
       TIMEOUT 20
       ENV
-        RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
-        ${rmw_implementation_env_var}
-        ${SKIP_TEST}
+      RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
+      ${rmw_implementation_env_var}
+      ${SKIP_TEST}
     )
     if(TEST test_pendulum_teleop__${rmw_implementation})
       set_tests_properties(test_pendulum_teleop__${rmw_implementation}

--- a/pendulum_control/CMakeLists.txt
+++ b/pendulum_control/CMakeLists.txt
@@ -106,14 +106,24 @@ if(BUILD_TESTING)
       execute_with_delay.py
     )
 
+    set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
+    # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+    if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
+      list(APPEND rmw_implementation_env_var
+        ZENOH_ROUTER_CHECK_ATTEMPTS=-1
+        ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
+        RUST_LOG=z=error
+      )
+    endif()
+
     file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_pendulum__${rmw_implementation}")
     add_launch_test(
       "${CMAKE_CURRENT_BINARY_DIR}/test_pendulum__${rmw_implementation}.py"
       TARGET test_pendulum__${rmw_implementation}
       TIMEOUT 20
       ENV
-      RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
-      RMW_IMPLEMENTATION=${rmw_implementation}
+        RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
+        ${rmw_implementation_env_var}
       # since the test generates a .csv file in the cwd
       WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_pendulum__${rmw_implementation}"
       ${SKIP_TEST}
@@ -128,9 +138,9 @@ if(BUILD_TESTING)
       TARGET test_pendulum_teleop__${rmw_implementation}
       TIMEOUT 20
       ENV
-      RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
-      RMW_IMPLEMENTATION=${rmw_implementation}
-      ${SKIP_TEST}
+        RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
+        ${rmw_implementation_env_var}
+        ${SKIP_TEST}
     )
     if(TEST test_pendulum_teleop__${rmw_implementation})
       set_tests_properties(test_pendulum_teleop__${rmw_implementation}


### PR DESCRIPTION
See https://github.com/ros2/rmw_zenoh/issues/567

To test this PR, we can run the usual CI jobs to show there are no regressions and additionally run a CI job with a copy of the ros2.repos file from https://github.com/ros2/ros2/pull/1649 with CI Scripts branch set to yadu/cargo