### PR TITLE
Lint image_tools/CMakeLists.txt

### DIFF
--- a/image_tools/CMakeLists.txt
+++ b/image_tools/CMakeLists.txt
@@ -95,7 +95,7 @@ if(BUILD_TESTING)
       TARGET test_showimage_cam2image${target_suffix}
       ENV
       RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
-       ${rmw_implementation_env_var}
+      ${rmw_implementation_env_var}
       TIMEOUT 30
     )
   endmacro()


### PR DESCRIPTION
Fix style regression caused by #711. The CI job succeeded despite the logs printing the error: https://ci.ros2.org/job/ci_linux/22891/console