### PR TITLE
fix typo in Parameter Events Async command in demo_nodes_cpp docs

### DIFF
--- a/demo_nodes_cpp/README.md
+++ b/demo_nodes_cpp/README.md
@@ -223,7 +223,7 @@ ros2 run demo_nodes_cpp parameter_events
 
 ```bash
 # Open new terminal
-ros2 run demo_nodes_cpp parameters_events_async
+ros2 run demo_nodes_cpp parameter_events_async
 ```
 
 ### Even Parameters Node


### PR DESCRIPTION
While testing `kilted_tutorial_party` [the Demo Nodes (C++) executables](https://github.com/ros2/kilted_tutorial_party/issues/121#issuecomment-2848203260), I found a typo in the command under the Parameter Events Asynchronous section of the `demo_nodes_cpp` documentation.

The command currently:
```bash
ros2 run demo_nodes_cpp parameters_events_async
```

But the correct executable name is:
```bash
ros2 run demo_nodes_cpp parameter_events_async
```
