### PR TITLE
correct name of shared libraries and their location

### DIFF
--- a/composition/README.md
+++ b/composition/README.md
@@ -35,10 +35,31 @@ ros2 run composition manual_composition
 
 This runs `dlopen_composition` which is an alternative to run-time composition by creating a generic container process and explicitly passing the libraries to load without using ROS interfaces.
 
-The process will open each library and create one instance of each “rclcpp::Node” class in the library.
-
+if you have build the composition package separately then you can find its location by running
 ```bash
-ros2 run composition dlopen_composition `ros2 pkg prefix composition`/lib/libtalker_component.so `ros2 pkg prefix composition`/lib/liblistener_component.so
+ros2 pkg prefix composition
+```
+and then you can find the path of the required shared libraries to run the process.
+
+The process will open each library and create one instance of each “rclcpp::Node” class in the library.
+```bash
+ros2 run composition dlopen_composition <path_to_talker_component_shared_library> <path_to_listener_component_shared_library>
+```
+or
+```bash
+ros2 run composition dlopen_composition `ros2 pkg prefix composition`\lib\talker_component.dll `ros2 pkg prefix composition`\lib\listener_component.dll
+```
+
+if you have composition package pre-installed with ROS then you will find the libraries in `<path_to_your_ros2_installation>\bin`.
+
+for example the command will work if you have installed ROS in `C:\pixi_ws\ros2_windows\`
+```bash
+ros2 run composition dlopen_composition C:\pixi_ws\ros2_windows\bin\talker_component.dll C:\pixi_ws\ros2_windows\bin\listener_component.dll
+```
+or
+```bash
+cd C:\pixi_ws\ros2_windows\bin
+ros2 run composition dlopen_composition talker_component.dll listener_component.dll
 ```
 
 ### Linktime Composition

--- a/composition/README.md
+++ b/composition/README.md
@@ -35,37 +35,49 @@ ros2 run composition manual_composition
 
 This runs `dlopen_composition` which is an alternative to run-time composition by creating a generic container process and explicitly passing the libraries to load without using ROS interfaces.
 
-first we will get the libraries. run the command
+First run the command to find the libraries prefix path.
+
 ```bash
 ros2 pkg prefix composition
 ```
-and then you can find the prefix path of the required shared libraries to run the process.
+
+Then you can find the prefix path of the required shared libraries to load.
 
 The process will open each library and create one instance of each “rclcpp::Node” class in the library.
+
 ```bash
 ros2 run composition dlopen_composition <path_to_talker_component_shared_library> <path_to_listener_component_shared_library>
 ```
-### Linux
-the libraries will be present in `<prefix_path>/lib/` as `lib*.so` files.
 
-run
+#### Linux
+
+The libraries will be present in `<prefix_path>/lib/` as `lib*.so` files.
+
+Run the following command to load the libraries.
+
 ```bash
 ros2 run composition dlopen_composition `ros2 pkg prefix composition`/lib/libtalker_component.so `ros2 pkg prefix composition`/lib/liblistener_component.so
 ```
-Linux command line subsitution will take care of the `ros2 pkg prefix composition` part. if you have the composition package, this line will work
-### Windows
-on windows we will need the `*.dll` files. since command subsitution will not work on windows you have to give the absolute path of the libraries.
 
-our libraries will be in `<path_to_your_ros2_installation>\bin\`, so we have to run.
+#### Windows
+
+On Windows, we will need the `*.dll` files.
+Since command substitution will not work on Windows, you have to give the absolute path of the libraries.
+
+The libraries will be in `<path_to_your_ros2_installation>\bin\`, so we have to run.
 
 ```bash
 ros2 run composition dlopen_composition <prefix_path>\bin\talker_component.dll <prefix_path>\bin\listener_component.dll
 ```
-to get the `prefix_path` run
+
+To get the `prefix_path` run
+
 ```bash
 ros2 pkg prefix composition
 ```
-for example if our `prefix_path` comes out to be `C:\pixi_ws\ros2-windows\` we will run
+
+For example if our `prefix_path` comes out to be `C:\pixi_ws\ros2-windows\` we will run
+
 ```bash
 ros2 run composition dlopen_composition C:\pixi_ws\ros2-windows\bin\talker_component.dll C:\pixi_ws\ros2-windows\bin\listener_component.dll
 ```

--- a/composition/README.md
+++ b/composition/README.md
@@ -35,31 +35,39 @@ ros2 run composition manual_composition
 
 This runs `dlopen_composition` which is an alternative to run-time composition by creating a generic container process and explicitly passing the libraries to load without using ROS interfaces.
 
-if you have build the composition package separately then you can find its location by running
+first we will get the libraries. run the command
 ```bash
 ros2 pkg prefix composition
 ```
-and then you can find the path of the required shared libraries to run the process.
+and then you can find the prefix path of the required shared libraries to run the process.
 
 The process will open each library and create one instance of each “rclcpp::Node” class in the library.
 ```bash
 ros2 run composition dlopen_composition <path_to_talker_component_shared_library> <path_to_listener_component_shared_library>
 ```
-or
-```bash
-ros2 run composition dlopen_composition `ros2 pkg prefix composition`\lib\talker_component.dll `ros2 pkg prefix composition`\lib\listener_component.dll
-```
+### Linux
+the libraries will be present in `<prefix_path>/lib/` as `lib*.so` files.
 
-if you have composition package pre-installed with ROS then you will find the libraries in `<path_to_your_ros2_installation>\bin`.
-
-for example the command will work if you have installed ROS in `C:\pixi_ws\ros2_windows\`
+run
 ```bash
-ros2 run composition dlopen_composition C:\pixi_ws\ros2_windows\bin\talker_component.dll C:\pixi_ws\ros2_windows\bin\listener_component.dll
+ros2 run composition dlopen_composition `ros2 pkg prefix composition`/lib/libtalker_component.so `ros2 pkg prefix composition`/lib/liblistener_component.so
 ```
-or
+Linux command line subsitution will take care of the `ros2 pkg prefix composition` part. if you have the composition package, this line will work
+### Windows
+on windows we will need the `*.dll` files. since command subsitution will not work on windows you have to give the absolute path of the libraries.
+
+our libraries will be in `<path_to_your_ros2_installation>\bin\`, so we have to run.
+
 ```bash
-cd C:\pixi_ws\ros2_windows\bin
-ros2 run composition dlopen_composition talker_component.dll listener_component.dll
+ros2 run composition dlopen_composition <prefix_path>\bin\talker_component.dll <prefix_path>\bin\listener_component.dll
+```
+to get the `prefix_path` run
+```bash
+ros2 pkg prefix composition
+```
+for example if our `prefix_path` comes out to be `C:\pixi_ws\ros2-windows\` we will run
+```bash
+ros2 run composition dlopen_composition C:\pixi_ws\ros2-windows\bin\talker_component.dll C:\pixi_ws\ros2-windows\bin\listener_component.dll
 ```
 
 ### Linktime Composition


### PR DESCRIPTION
### **Summary**
This PR updates the `composition/README.md` to fix shared library naming inconsistencies in the ROS 2 Kilted tutorial for Windows. The current documentation incorrectly references Linux-style shared library names (`lib*.so`) despite the target platform being Windows, where `.dll` files are used.

This PR updates the documentation to reflect changes in ROS Kilted, where:

- Updates libtalker_component.so → talker_component.dll
- Updates liblistener_component.so→ listener_component.dll
- Adjusts library path usage where needed to reflect Windows conventions

This ensures that users following the documentation with the latest ROS version do not encounter errors.

### **Context**
This issue is discussed in [ros2/kilted_tutorial_party#103](https://github.com/ros2/kilted_tutorial_party/issues/103). Without this change, users on Windows following the tutorial encounter errors when using dlopen_composition.

### **Details**
These files are updated:

- `composition/README.md`
---
Thank you for maintaining this project!