### PR TITLE
Use EnableRmwIsolation in launch tests

### DIFF
--- a/composition/CMakeLists.txt
+++ b/composition/CMakeLists.txt
@@ -165,13 +165,6 @@ if(BUILD_TESTING)
     set(EXPECTED_OUTPUT_SRV "${CMAKE_CURRENT_SOURCE_DIR}/test/composition_srv")
 
     set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
-    # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
-    # Note: This is a temporary change that will be reverted before we branch into Kilted.
-    if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
-      list(APPEND rmw_implementation_env_var
-        ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
-      )
-    endif()
 
     set(test_names
       "test_dlopen_composition"

--- a/composition/test/test_manual_composition.py.in
+++ b/composition/test/test_manual_composition.py.in
@@ -21,10 +21,13 @@ import launch_testing
 import launch_testing.actions
 import launch_testing.asserts
 import launch_testing_ros
+from launch_testing_ros.actions import EnableRmwIsolation
 
 
 def generate_test_description():
-    launch_description = LaunchDescription()
+    launch_description = LaunchDescription([
+        EnableRmwIsolation(),
+    ])
     process_under_test = ExecuteProcess(
         cmd=['@MANUAL_COMPOSITION_EXECUTABLE@'],
         name='test_manual_composition',

--- a/demo_nodes_cpp/CMakeLists.txt
+++ b/demo_nodes_cpp/CMakeLists.txt
@@ -249,13 +249,6 @@ if(BUILD_TESTING)
       )
 
       set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
-      # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
-      # Note: This is a temporary change that will be reverted before we branch into Kilted.
-      if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
-        list(APPEND rmw_implementation_env_var
-          ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
-        )
-      endif()
 
       add_launch_test(
         "${CMAKE_CURRENT_BINARY_DIR}/test_${exe_list_underscore}${target_suffix}_$<CONFIG>.py"

--- a/demo_nodes_cpp/test/test_executables_tutorial.py.in
+++ b/demo_nodes_cpp/test/test_executables_tutorial.py.in
@@ -14,14 +14,18 @@ import launch_testing.actions
 import launch_testing.asserts
 import launch_testing.util
 import launch_testing_ros
+from launch_testing_ros.actions import EnableRmwIsolation
 
 
 def generate_test_description():
-    env = os.environ.copy()
     # bare minimum formatting for console output matching
-    env['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '{message}'
+    additional_env = {
+        'RCUTILS_CONSOLE_OUTPUT_FORMAT': '{message}',
+    }
 
-    launch_description = LaunchDescription()
+    launch_description = LaunchDescription([
+        EnableRmwIsolation(),
+    ])
 
     processes_under_test = []
     exes_and_params = '@DEMO_NODES_CPP_EXECUTABLE@'.split(';')
@@ -39,7 +43,7 @@ def generate_test_description():
                 cmd=cmd,
                 name='test_executable_' + str(i),
                 output='screen',
-                env=env,
+                additional_env=additional_env,
             )
         )
 

--- a/image_tools/CMakeLists.txt
+++ b/image_tools/CMakeLists.txt
@@ -82,13 +82,6 @@ if(BUILD_TESTING)
     )
 
     set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
-    # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
-    # Note: This is a temporary change that will be reverted before we branch into Kilted.
-    if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
-      list(APPEND rmw_implementation_env_var
-        ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
-      )
-    endif()
 
     add_launch_test(
       "${CMAKE_CURRENT_BINARY_DIR}/test_showimage_cam2image${target_suffix}_$<CONFIG>.py"

--- a/image_tools/test/test_executables_demo.py.in
+++ b/image_tools/test/test_executables_demo.py.in
@@ -24,10 +24,13 @@ import launch_testing
 import launch_testing.actions
 import launch_testing.asserts
 import launch_testing_ros
+from launch_testing_ros.actions import EnableRmwIsolation
 
 
 def generate_test_description():
-    launch_description = LaunchDescription()
+    launch_description = LaunchDescription([
+        EnableRmwIsolation(),
+    ])
     publisher_node_parameters = {
         'reliability': 'reliable',
         'show_camera': False,

--- a/intra_process_demo/CMakeLists.txt
+++ b/intra_process_demo/CMakeLists.txt
@@ -145,13 +145,6 @@ if(BUILD_TESTING)
       )
 
       set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
-      # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
-      # Note: This is a temporary change that will be reverted before we branch into Kilted.
-      if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
-        list(APPEND rmw_implementation_env_var
-          ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
-        )
-      endif()
 
       add_launch_test(
         "${CMAKE_CURRENT_BINARY_DIR}/test_${exe_list_underscore}${target_suffix}_$<CONFIG>.py"

--- a/intra_process_demo/package.xml
+++ b/intra_process_demo/package.xml
@@ -29,6 +29,7 @@
   <test_depend>ament_lint_common</test_depend>
   <test_depend>launch</test_depend>
   <test_depend>launch_testing</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>rmw_implementation_cmake</test_depend>
 

--- a/intra_process_demo/test/test_executables_demo.py.in
+++ b/intra_process_demo/test/test_executables_demo.py.in
@@ -9,10 +9,13 @@ from launch.actions import ExecuteProcess
 import launch_testing
 import launch_testing.actions
 import launch_testing.asserts
+from launch_testing_ros.actions import EnableRmwIsolation
 
 
 def generate_test_description():
-    launch_description = LaunchDescription()
+    launch_description = LaunchDescription([
+        EnableRmwIsolation(),
+    ])
     processes_under_test = [
         ExecuteProcess(
             cmd=[executable, 'test_executable'],

--- a/logging_demo/CMakeLists.txt
+++ b/logging_demo/CMakeLists.txt
@@ -93,13 +93,6 @@ if(BUILD_TESTING)
     )
 
     set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
-    # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
-    # Note: This is a temporary change that will be reverted before we branch into Kilted.
-    if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
-      list(APPEND rmw_implementation_env_var
-        ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
-      )
-    endif()
 
     add_launch_test(
       "${CMAKE_CURRENT_BINARY_DIR}/test_logging_demo${target_suffix}_$<CONFIG>.py"

--- a/logging_demo/test/test_logging_demo.py.in
+++ b/logging_demo/test/test_logging_demo.py.in
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import unittest
 
 from launch import LaunchDescription
@@ -22,17 +21,21 @@ import launch_testing
 import launch_testing.actions
 import launch_testing.asserts
 import launch_testing_ros
+from launch_testing_ros.actions import EnableRmwIsolation
 
 
 def generate_test_description():
-    env = os.environ.copy()
-    env['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '[{severity}] [{name}]: {message}'
-    launch_description = LaunchDescription()
+    additional_env = {
+        'RCUTILS_CONSOLE_OUTPUT_FORMAT': '[{severity}] [{name}]: {message}',
+    }
+    launch_description = LaunchDescription([
+        EnableRmwIsolation(),
+    ])
     process_under_test = ExecuteProcess(
         cmd=['@LOGGING_DEMO_MAIN_EXECUTABLE@'],
         name='test_logging_demo',
         output='screen',
-        env=env,
+        additional_env=additional_env,
     )
     launch_description.add_action(process_under_test)
     launch_description.add_action(

--- a/pendulum_control/CMakeLists.txt
+++ b/pendulum_control/CMakeLists.txt
@@ -107,13 +107,6 @@ if(BUILD_TESTING)
     )
 
     set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
-    # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
-    # Note: This is a temporary change that will be reverted before we branch into Kilted.
-    if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
-      list(APPEND rmw_implementation_env_var
-        ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
-      )
-    endif()
 
     file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_pendulum__${rmw_implementation}")
     add_launch_test(

--- a/pendulum_control/test/test_pendulum_demo.py.in
+++ b/pendulum_control/test/test_pendulum_demo.py.in
@@ -12,6 +12,7 @@ import launch_testing
 import launch_testing.actions
 import launch_testing.asserts
 import launch_testing_ros
+from launch_testing_ros.actions import EnableRmwIsolation
 
 
 def generate_test_description():
@@ -19,7 +20,9 @@ def generate_test_description():
     # bare minimum formatting for console output matching
     os.environ['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '{message}'
 
-    launch_description = LaunchDescription()
+    launch_description = LaunchDescription([
+        EnableRmwIsolation(),
+    ])
 
     pendulum_logger_process = ExecuteProcess(
         cmd=['@RCLCPP_DEMO_PENDULUM_LOGGER_EXECUTABLE@'],

--- a/pendulum_control/test/test_pendulum_teleop.py.in
+++ b/pendulum_control/test/test_pendulum_teleop.py.in
@@ -13,6 +13,7 @@ import launch_testing
 import launch_testing.actions
 import launch_testing.asserts
 import launch_testing_ros
+from launch_testing_ros.actions import EnableRmwIsolation
 
 
 def generate_test_description():
@@ -20,7 +21,9 @@ def generate_test_description():
     # bare minimum formatting for console output matching
     os.environ['RCUTILS_CONSOLE_OUTPUT_FORMAT'] = '{message}'
 
-    launch_description = LaunchDescription()
+    launch_description = LaunchDescription([
+        EnableRmwIsolation(),
+    ])
     pendulum_demo_process = ExecuteProcess(
         cmd=['@RCLCPP_DEMO_PENDULUM_DEMO_EXECUTABLE@', '-i', '0'],
         name='pendulum_demo',


### PR DESCRIPTION
This reverts (most of) #711 in favor of using the recently introduced `rmw_test_fixture`.

This should be backported to `kilted`, but no further.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=23775)](http://ci.ros2.org/job/ci_linux/23775/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=17863)](http://ci.ros2.org/job/ci_linux-aarch64/17863/)
* Linux-rhel [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=3205)](http://ci.ros2.org/job/ci_linux-rhel/3205/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=24463)](http://ci.ros2.org/job/ci_windows/24463/)