### PR TITLE
Add composition::LifecycleTalker component

### DIFF
--- a/composition/CMakeLists.txt
+++ b/composition/CMakeLists.txt
@@ -88,7 +88,7 @@ target_link_libraries(lifecycle_talker_component PUBLIC
   rclcpp::rclcpp
   rclcpp_components::component
   rclcpp_lifecycle::rclcpp_lifecycle
-  ${std_msgs_TARGETS})
+  ${example_interfaces_TARGETS})
 rclcpp_components_register_nodes(lifecycle_talker_component "composition::LifecycleTalker")
 set(node_plugins "${node_plugins}composition::LifecycleTalker;$<TARGET_FILE:lifecycle_talker_component>\n")
 

--- a/composition/CMakeLists.txt
+++ b/composition/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(ament_cmake REQUIRED)
 find_package(example_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(example_interfaces REQUIRED)
 
@@ -79,6 +80,18 @@ target_link_libraries(client_component PUBLIC
 rclcpp_components_register_nodes(client_component "composition::Client")
 set(node_plugins "${node_plugins}composition::Client;$<TARGET_FILE:client_component>\n")
 
+add_library(lifecycle_component SHARED
+  src/lifecycle_component.cpp)
+target_compile_definitions(lifecycle_component
+  PRIVATE "COMPOSITION_BUILDING_DLL")
+target_link_libraries(lifecycle_component PUBLIC
+  rclcpp::rclcpp
+  rclcpp_components::component
+  rclcpp_lifecycle::rclcpp_lifecycle
+  ${std_msgs_TARGETS})
+rclcpp_components_register_nodes(lifecycle_component "composition::LifecycleTalker")
+set(node_plugins "${node_plugins}composition::LifecycleTalker;$<TARGET_FILE:lifecycle_component>\n")
+
 # since the package installs libraries without exporting them
 # it needs to make sure that the library path is being exported
 if(NOT WIN32)
@@ -127,6 +140,7 @@ install(TARGETS
   node_like_listener_component
   server_component
   client_component
+  lifecycle_component
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)

--- a/composition/CMakeLists.txt
+++ b/composition/CMakeLists.txt
@@ -80,17 +80,17 @@ target_link_libraries(client_component PUBLIC
 rclcpp_components_register_nodes(client_component "composition::Client")
 set(node_plugins "${node_plugins}composition::Client;$<TARGET_FILE:client_component>\n")
 
-add_library(lifecycle_component SHARED
-  src/lifecycle_component.cpp)
-target_compile_definitions(lifecycle_component
+add_library(lifecycle_talker_component SHARED
+  src/lifecycle_talker_component.cpp)
+target_compile_definitions(lifecycle_talker_component
   PRIVATE "COMPOSITION_BUILDING_DLL")
-target_link_libraries(lifecycle_component PUBLIC
+target_link_libraries(lifecycle_talker_component PUBLIC
   rclcpp::rclcpp
   rclcpp_components::component
   rclcpp_lifecycle::rclcpp_lifecycle
   ${std_msgs_TARGETS})
-rclcpp_components_register_nodes(lifecycle_component "composition::LifecycleTalker")
-set(node_plugins "${node_plugins}composition::LifecycleTalker;$<TARGET_FILE:lifecycle_component>\n")
+rclcpp_components_register_nodes(lifecycle_talker_component "composition::LifecycleTalker")
+set(node_plugins "${node_plugins}composition::LifecycleTalker;$<TARGET_FILE:lifecycle_talker_component>\n")
 
 # since the package installs libraries without exporting them
 # it needs to make sure that the library path is being exported
@@ -140,7 +140,7 @@ install(TARGETS
   node_like_listener_component
   server_component
   client_component
-  lifecycle_component
+  lifecycle_talker_component
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin)
@@ -174,6 +174,7 @@ if(BUILD_TESTING)
     set(SERVER_LIBRARY $<TARGET_FILE:server_component>)
     set(CLIENT_LIBRARY $<TARGET_FILE:client_component>)
     set(NODE_LIKE_LISTENER_LIBRARY $<TARGET_FILE:node_like_listener_component>)
+    set(LIFECYCLE_TALKER_LIBRARY $<TARGET_FILE:lifecycle_talker_component>)
     set(EXPECTED_OUTPUT_ALL "${CMAKE_CURRENT_SOURCE_DIR}/test/composition_all")
     set(EXPECTED_OUTPUT_PUBSUB "${CMAKE_CURRENT_SOURCE_DIR}/test/composition_pubsub")
     set(EXPECTED_OUTPUT_SRV "${CMAKE_CURRENT_SOURCE_DIR}/test/composition_srv")

--- a/composition/include/composition/lifecycle_component.hpp
+++ b/composition/include/composition/lifecycle_component.hpp
@@ -1,0 +1,66 @@
+// Copyright 2025 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COMPOSITION__LIFECYCLE_COMPONENT_HPP_
+#define COMPOSITION__LIFECYCLE_COMPONENT_HPP_
+
+#include "composition/visibility_control.h"
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "rclcpp_lifecycle/lifecycle_publisher.hpp"
+
+#include "std_msgs/msg/string.hpp"
+
+namespace composition
+{
+
+class LifecycleTalker : public rclcpp_lifecycle::LifecycleNode {
+public:
+  COMPOSITION_PUBLIC
+  explicit LifecycleTalker(const rclcpp::NodeOptions & options);
+
+protected:
+  void publish();
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_configure(
+    const rclcpp_lifecycle::State & state) override;
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_cleanup(
+    const rclcpp_lifecycle::State & state) override;
+
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_shutdown(
+    const rclcpp_lifecycle::State & state) override;
+
+private:
+  size_t count_;
+
+  // We hold an instance of a lifecycle publisher. This lifecycle publisher
+  // can be activated or deactivated regarding on which state the lifecycle node
+  // is in.
+  // By default, a lifecycle publisher is inactive by creation and has to be
+  // activated to publish messages into the ROS world.
+  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::String>::SharedPtr pub_;
+
+  // We hold an instance of a timer which periodically triggers the publish function.
+  // As for the beta version, this is a regular timer. In a future version, a
+  // lifecycle timer will be created which obeys the same lifecycle management as the
+  // lifecycle publisher.
+  rclcpp::TimerBase::SharedPtr timer_;
+};
+
+}  // namespace composition
+
+#endif  // COMPOSITION__LIFECYCLE_COMPONENT_HPP_

--- a/composition/include/composition/lifecycle_talker_component.hpp
+++ b/composition/include/composition/lifecycle_talker_component.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef COMPOSITION__LIFECYCLE_COMPONENT_HPP_
-#define COMPOSITION__LIFECYCLE_COMPONENT_HPP_
+#ifndef COMPOSITION__LIFECYCLE_TALKER_COMPONENT_HPP_
+#define COMPOSITION__LIFECYCLE_TALKER_COMPONENT_HPP_
 
 #include "composition/visibility_control.h"
 
@@ -63,4 +63,4 @@ private:
 
 }  // namespace composition
 
-#endif  // COMPOSITION__LIFECYCLE_COMPONENT_HPP_
+#endif  // COMPOSITION__LIFECYCLE_TALKER_COMPONENT_HPP_

--- a/composition/include/composition/lifecycle_talker_component.hpp
+++ b/composition/include/composition/lifecycle_talker_component.hpp
@@ -22,7 +22,7 @@
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "rclcpp_lifecycle/lifecycle_publisher.hpp"
 
-#include "std_msgs/msg/string.hpp"
+#include "example_interfaces/msg/string.hpp"
 
 namespace composition
 {
@@ -52,7 +52,7 @@ private:
   // is in.
   // By default, a lifecycle publisher is inactive by creation and has to be
   // activated to publish messages into the ROS world.
-  rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::String>::SharedPtr pub_;
+  rclcpp_lifecycle::LifecyclePublisher<example_interfaces::msg::String>::SharedPtr pub_;
 
   // We hold an instance of a timer which periodically triggers the publish function.
   // As for the beta version, this is a regular timer. In a future version, a

--- a/composition/package.xml
+++ b/composition/package.xml
@@ -18,6 +18,7 @@
   <build_depend>example_interfaces</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>rclcpp_components</build_depend>
+  <build_depend>rclcpp_lifecycle</build_depend>
   <build_depend>rcutils</build_depend>
   <build_depend>example_interfaces</build_depend>
 
@@ -25,6 +26,7 @@
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclcpp_components</exec_depend>
+  <exec_depend>rclcpp_lifecycle</exec_depend>
   <exec_depend>rcutils</exec_depend>
   <exec_depend>example_interfaces</exec_depend>
 

--- a/composition/src/lifecycle_component.cpp
+++ b/composition/src/lifecycle_component.cpp
@@ -1,0 +1,107 @@
+// Copyright 2025 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "composition/lifecycle_component.hpp"
+
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <utility>
+
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/string.hpp"
+
+using namespace std::chrono_literals;
+
+namespace composition
+{
+
+LifecycleTalker::LifecycleTalker(const rclcpp::NodeOptions & options)
+: LifecycleNode("lifecycle_talker", options), count_(0)
+{
+}
+
+/// Callback for walltimer in order to publish the message.
+/**
+  * Callback for walltimer. This function gets invoked by the timer
+  * and executes the publishing.
+  * For this demo, we ask the node for its current state. If the
+  * lifecycle publisher is not activate, we still invoke publish, but
+  * the communication is blocked so that no messages is actually transferred.
+  */
+void LifecycleTalker::publish()
+{
+  auto msg = std::make_unique<std_msgs::msg::String>();
+  msg->data = "Lifecycle Hello World: " + std::to_string(++count_);
+
+  // Print the current state for demo purposes
+  RCLCPP_INFO_EXPRESSION(this->get_logger(), pub_->is_activated(),
+      "Lifecycle Publisher is active. Publishing: '%s'", msg->data.c_str());
+  RCLCPP_INFO_EXPRESSION(this->get_logger(), !pub_->is_activated(),
+      "Lifecycle Publisher is inactive. Not publishing: '%s'", msg->data.c_str());
+  std::flush(std::cout);
+
+  // We independently from the current state call publish on the lifecycle publisher.
+  // Only if the publisher is in an active state, the message transfer is
+  // enabled and the message actually published.
+  // Put the message into a queue to be processed by the middleware.
+  // This call is non-blocking.
+  pub_->publish(std::move(msg));
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+LifecycleTalker::on_configure(const rclcpp_lifecycle::State &)
+{
+  pub_ = create_publisher<std_msgs::msg::String>("lc_chatter", 10);
+  timer_ = create_wall_timer(1s, [this](){return this->publish();});
+
+  RCLCPP_INFO(get_logger(), "on_configure() is called.");
+
+  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+LifecycleTalker::on_cleanup(const rclcpp_lifecycle::State &)
+{
+  // In our cleanup phase, we release the shared pointers to the timer and publisher.
+  // These entities are no longer available and our node is "clean".
+  timer_.reset();
+  pub_.reset();
+
+  RCLCPP_INFO(get_logger(), "on_cleanup() is called.");
+
+  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
+LifecycleTalker::on_shutdown(const rclcpp_lifecycle::State & state)
+{
+  // In our cleanup phase, we release the shared pointers to the timer and publisher.
+  // These entities are no longer available and our node is "clean".
+  timer_.reset();
+  pub_.reset();
+
+  RCLCPP_INFO(get_logger(), "on_shutdown() is called from state %s.", state.label().c_str());
+
+  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+}  // namespace composition
+
+#include "rclcpp_components/register_node_macro.hpp"
+
+// Register the component with class_loader.
+// This acts as a sort of entry point, allowing the component to be discoverable when its library
+// is being loaded into a running process.
+RCLCPP_COMPONENTS_REGISTER_NODE(composition::LifecycleTalker)

--- a/composition/src/lifecycle_talker_component.cpp
+++ b/composition/src/lifecycle_talker_component.cpp
@@ -20,7 +20,7 @@
 #include <utility>
 
 #include "rclcpp/rclcpp.hpp"
-#include "std_msgs/msg/string.hpp"
+#include "example_interfaces/msg/string.hpp"
 
 using namespace std::chrono_literals;
 
@@ -42,7 +42,7 @@ LifecycleTalker::LifecycleTalker(const rclcpp::NodeOptions & options)
   */
 void LifecycleTalker::publish()
 {
-  auto msg = std::make_unique<std_msgs::msg::String>();
+  auto msg = std::make_unique<example_interfaces::msg::String>();
   msg->data = "Lifecycle Hello World: " + std::to_string(++count_);
 
   // Print the current state for demo purposes
@@ -63,7 +63,7 @@ void LifecycleTalker::publish()
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
 LifecycleTalker::on_configure(const rclcpp_lifecycle::State &)
 {
-  pub_ = create_publisher<std_msgs::msg::String>("lc_chatter", 10);
+  pub_ = create_publisher<example_interfaces::msg::String>("lc_chatter", 10);
   timer_ = create_wall_timer(1s, [this](){return this->publish();});
 
   RCLCPP_INFO(get_logger(), "on_configure() is called.");

--- a/composition/src/lifecycle_talker_component.cpp
+++ b/composition/src/lifecycle_talker_component.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "composition/lifecycle_component.hpp"
+#include "composition/lifecycle_talker_component.hpp"
 
 #include <chrono>
 #include <iostream>

--- a/composition/test/test_api_lc_pubsub_composition.py.in
+++ b/composition/test/test_api_lc_pubsub_composition.py.in
@@ -1,4 +1,4 @@
-# Copyright 2016 Open Source Robotics Foundation, Inc.
+# Copyright 2025 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,18 +26,29 @@ import launch_testing_ros
 def generate_test_description():
     launch_description = LaunchDescription()
     process_under_test = ExecuteProcess(
-        cmd=[
-            '@DLOPEN_COMPOSITION_EXECUTABLE@',
-            '@TALKER_LIBRARY@',
-            '@LISTENER_LIBRARY@',
-            '@SERVER_LIBRARY@',
-            '@CLIENT_LIBRARY@',
-            '@LIFECYCLE_LIBRARY@',
-        ],
-        name='test_dlopen_composition',
+        cmd=['@API_COMPOSITION_EXECUTABLE@'],
+        name='test_api_composition',
         output='screen'
     )
     launch_description.add_action(process_under_test)
+    launch_description.add_action(
+        ExecuteProcess(
+            cmd=[
+                '@API_COMPOSITION_CLI_EXECUTABLE@',
+                'composition', 'composition::LifecycleTalker'
+            ],
+            name='load_talker_component'
+        )
+    )
+    launch_description.add_action(
+        ExecuteProcess(
+            cmd=[
+                '@API_COMPOSITION_CLI_EXECUTABLE@',
+                'composition', 'composition::Listener'
+            ],
+            name='load_listener_component'
+        )
+    )
     launch_description.add_action(
         launch_testing.actions.ReadyToTest()
     )
@@ -46,13 +57,13 @@ def generate_test_description():
 
 class TestComposition(unittest.TestCase):
 
-    def test_dlopen_composition(self, proc_output, process_under_test):
+    def test_api_pubsub_composition(self, proc_output, process_under_test):
         """Test process' output against expectations."""
         output_filter = launch_testing_ros.tools.basic_output_filter(
             filtered_rmw_implementation='@rmw_implementation@'
         )
         proc_output.assertWaitFor(
             expected_output=launch_testing.tools.expected_output_from_file(
-                path='@EXPECTED_OUTPUT_ALL@'
+                path='@EXPECTED_OUTPUT_PUBSUB@'
             ), process=process_under_test, output_filter=output_filter, timeout=10
         )


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
Adds a lifecycle component to `composition` (`composition::LifecycleTalker`)

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #745 

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->
Yes, a new component is added.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
No.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
Currently I have put it in the `composition` package, since it is more of a note that a lifecycle component can exist (and therefore does not extensively focus on the lifecycle part).
