### PR TITLE
[composition] Enable tests

### DIFF
--- a/composition/CMakeLists.txt
+++ b/composition/CMakeLists.txt
@@ -170,6 +170,9 @@ if(BUILD_TESTING)
       "test_dlopen_composition"
       "test_linktime_composition"
       "test_manual_composition"
+      "test_api_pubsub_composition"
+      "test_api_srv_composition_client_first"
+      "test_api_srv_composition"
     )
     foreach(test_name IN LISTS test_names)
       configure_file(

--- a/composition/test/test_api_pubsub_composition.py.in
+++ b/composition/test/test_api_pubsub_composition.py.in
@@ -26,7 +26,7 @@ import launch_testing_ros
 def generate_test_description():
     launch_description = LaunchDescription()
     process_under_test = ExecuteProcess(
-        cmd=['@API_COMPOSITION_EXECUTABLE@'],
+        cmd=['ros2', 'run', 'rclcpp_components', 'component_container'],
         name='test_api_composition',
         output='screen'
     )
@@ -34,7 +34,7 @@ def generate_test_description():
     launch_description.add_action(
         ExecuteProcess(
             cmd=[
-                '@API_COMPOSITION_CLI_EXECUTABLE@',
+                'ros2', 'component', 'load', '/ComponentManager',
                 'composition', 'composition::Talker'
             ],
             name='load_talker_component'
@@ -43,7 +43,7 @@ def generate_test_description():
     launch_description.add_action(
         ExecuteProcess(
             cmd=[
-                '@API_COMPOSITION_CLI_EXECUTABLE@',
+                'ros2', 'component', 'load', '/ComponentManager',
                 'composition', 'composition::Listener'
             ],
             name='load_listener_component'

--- a/composition/test/test_api_pubsub_composition.py.in
+++ b/composition/test/test_api_pubsub_composition.py.in
@@ -15,7 +15,8 @@
 import unittest
 
 from launch import LaunchDescription
-from launch.actions import ExecuteProcess
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.descriptions import ComposableNode
 
 import launch_testing
 import launch_testing.actions
@@ -25,30 +26,22 @@ import launch_testing_ros
 
 def generate_test_description():
     launch_description = LaunchDescription()
-    process_under_test = ExecuteProcess(
-        cmd=['ros2', 'run', 'rclcpp_components', 'component_container'],
+    process_under_test = ComposableNodeContainer(
         name='test_api_composition',
+        namespace='',
+        package='rclcpp_components',
+        executable='component_container',
+        composable_node_descriptions=[
+            ComposableNode(
+                package='composition',
+                plugin='composition::Talker'),
+            ComposableNode(
+                package='composition',
+                plugin='composition::Listener'),
+        ],
         output='screen'
     )
     launch_description.add_action(process_under_test)
-    launch_description.add_action(
-        ExecuteProcess(
-            cmd=[
-                'ros2', 'component', 'load', '/ComponentManager',
-                'composition', 'composition::Talker'
-            ],
-            name='load_talker_component'
-        )
-    )
-    launch_description.add_action(
-        ExecuteProcess(
-            cmd=[
-                'ros2', 'component', 'load', '/ComponentManager',
-                'composition', 'composition::Listener'
-            ],
-            name='load_listener_component'
-        )
-    )
     launch_description.add_action(
         launch_testing.actions.ReadyToTest()
     )

--- a/composition/test/test_api_srv_composition.py.in
+++ b/composition/test/test_api_srv_composition.py.in
@@ -15,7 +15,9 @@
 import unittest
 
 from launch import LaunchDescription
-from launch.actions import ExecuteProcess
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.actions import LoadComposableNodes
+from launch_ros.descriptions import ComposableNode
 
 import launch_testing
 import launch_testing.actions
@@ -25,28 +27,32 @@ import launch_testing_ros
 
 def generate_test_description():
     launch_description = LaunchDescription()
-    process_under_test = ExecuteProcess(
-        cmd=['ros2', 'run', 'rclcpp_components', 'component_container'],
+    process_under_test = ComposableNodeContainer(
         name='test_api_composition',
+        namespace='',
+        package='rclcpp_components',
+        executable='component_container',
         output='screen'
     )
     launch_description.add_action(process_under_test)
     launch_description.add_action(
-        ExecuteProcess(
-            cmd=[
-                'ros2', 'component', 'load', '/ComponentManager',
-                'composition', 'composition::Server'
+        LoadComposableNodes(
+            composable_node_descriptions=[
+                ComposableNode(
+                    package='composition',
+                    plugin='composition::Server')
             ],
-            name='load_server_component'
+            target_container=process_under_test
         )
     )
     launch_description.add_action(
-        ExecuteProcess(
-            cmd=[
-                'ros2', 'component', 'load', '/ComponentManager',
-                'composition', 'composition::Client'
+        LoadComposableNodes(
+            composable_node_descriptions=[
+                ComposableNode(
+                    package='composition',
+                    plugin='composition::Client')
             ],
-            name='load_client_component'
+            target_container=process_under_test
         )
     )
     launch_description.add_action(

--- a/composition/test/test_api_srv_composition.py.in
+++ b/composition/test/test_api_srv_composition.py.in
@@ -26,7 +26,7 @@ import launch_testing_ros
 def generate_test_description():
     launch_description = LaunchDescription()
     process_under_test = ExecuteProcess(
-        cmd=['@API_COMPOSITION_EXECUTABLE@'],
+        cmd=['ros2', 'run', 'rclcpp_components', 'component_container'],
         name='test_api_composition',
         output='screen'
     )
@@ -34,7 +34,7 @@ def generate_test_description():
     launch_description.add_action(
         ExecuteProcess(
             cmd=[
-                '@API_COMPOSITION_CLI_EXECUTABLE@',
+                'ros2', 'component', 'load', '/ComponentManager',
                 'composition', 'composition::Server'
             ],
             name='load_server_component'
@@ -43,7 +43,7 @@ def generate_test_description():
     launch_description.add_action(
         ExecuteProcess(
             cmd=[
-                '@API_COMPOSITION_CLI_EXECUTABLE@',
+                'ros2', 'component', 'load', '/ComponentManager',
                 'composition', 'composition::Client'
             ],
             name='load_client_component'

--- a/composition/test/test_api_srv_composition_client_first.py.in
+++ b/composition/test/test_api_srv_composition_client_first.py.in
@@ -16,6 +16,7 @@ import unittest
 
 from launch import LaunchDescription
 from launch.actions import ExecuteProcess
+from launch.actions import TimerAction
 
 import launch_testing
 import launch_testing.actions
@@ -26,7 +27,7 @@ import launch_testing_ros
 def generate_test_description():
     launch_description = LaunchDescription()
     process_under_test = ExecuteProcess(
-        cmd=['@API_COMPOSITION_EXECUTABLE@'],
+        cmd=['ros2', 'run', 'rclcpp_components', 'component_container'],
         name='test_api_composition',
         output='screen'
     )
@@ -34,20 +35,25 @@ def generate_test_description():
     launch_description.add_action(
         ExecuteProcess(
             cmd=[
-                '@API_COMPOSITION_CLI_EXECUTABLE@',
+                'ros2', 'component', 'load', '/ComponentManager',
                 'composition', 'composition::Client'
             ],
             name='load_client_component'
         )
     )
     launch_description.add_action(
-        ExecuteProcess(
-            cmd=[
-                '@API_COMPOSITION_CLI_EXECUTABLE@',
-                'composition', 'composition::Server',
-                '--delay', '5000'
-            ],
-            name='load_server_component'
+        TimerAction(
+            period=5.0,
+            actions=[
+                ExecuteProcess(
+                    cmd=[
+                        'ros2', 'component',
+                        'load', '/ComponentManager',
+                        'composition', 'composition::Server',
+                    ],
+                    name='load_server_component'
+                )
+            ]
         )
     )
     launch_description.add_action(

--- a/composition/test/test_api_srv_composition_client_first.py.in
+++ b/composition/test/test_api_srv_composition_client_first.py.in
@@ -15,8 +15,10 @@
 import unittest
 
 from launch import LaunchDescription
-from launch.actions import ExecuteProcess
 from launch.actions import TimerAction
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.actions import LoadComposableNodes
+from launch_ros.descriptions import ComposableNode
 
 import launch_testing
 import launch_testing.actions
@@ -26,32 +28,35 @@ import launch_testing_ros
 
 def generate_test_description():
     launch_description = LaunchDescription()
-    process_under_test = ExecuteProcess(
-        cmd=['ros2', 'run', 'rclcpp_components', 'component_container'],
+    process_under_test = ComposableNodeContainer(
         name='test_api_composition',
+        namespace='',
+        package='rclcpp_components',
+        executable='component_container',
         output='screen'
     )
     launch_description.add_action(process_under_test)
     launch_description.add_action(
-        ExecuteProcess(
-            cmd=[
-                'ros2', 'component', 'load', '/ComponentManager',
-                'composition', 'composition::Client'
+        LoadComposableNodes(
+            composable_node_descriptions=[
+                ComposableNode(
+                    package='composition',
+                    plugin='composition::Client')
             ],
-            name='load_client_component'
+            target_container=process_under_test
         )
     )
     launch_description.add_action(
         TimerAction(
             period=5.0,
             actions=[
-                ExecuteProcess(
-                    cmd=[
-                        'ros2', 'component',
-                        'load', '/ComponentManager',
-                        'composition', 'composition::Server',
+                LoadComposableNodes(
+                    composable_node_descriptions=[
+                        ComposableNode(
+                            package='composition',
+                            plugin='composition::Server')
                     ],
-                    name='load_server_component'
+                    target_container=process_under_test
                 )
             ]
         )


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
Enables the API launch tests of the composition package (in some workable form)

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #747 

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->
No

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

I do not use a generated substitution anymore, since it was unclear which binary path would have matched:
 - `API_COMPOSITION_EXECUTABLE`
 - `API_COMPOSITION_CLI_EXECUTABLE`