### PR TITLE
fixup image_pipeline_demo

### DIFF
--- a/intra_process_demo/include/image_pipeline/camera_node.hpp
+++ b/intra_process_demo/include/image_pipeline/camera_node.hpp
@@ -41,7 +41,7 @@ public:
   /// \param height What video height to capture at
   explicit CameraNode(
     const std::string & output, const std::string & node_name = "camera_node",
-    bool watermark = true, int device = 0, int width = 320, int height = 240)
+    bool watermark = true, int device = 0, int width = 640, int height = 480)
   : Node(node_name, rclcpp::NodeOptions().use_intra_process_comms(true)),
     canceled_(false), watermark_(watermark)
   {

--- a/intra_process_demo/include/image_pipeline/common.hpp
+++ b/intra_process_demo/include/image_pipeline/common.hpp
@@ -81,7 +81,7 @@ draw_on_image(cv::Mat & image, const std::string & text, int height)
     text.c_str(),
     cv::Point(10, height),
     cv::FONT_HERSHEY_SIMPLEX,
-    0.3,
+    0.5,
     cv::Scalar(0, 255, 0));
 }
 

--- a/intra_process_demo/include/image_pipeline/image_view_node.hpp
+++ b/intra_process_demo/include/image_pipeline/image_view_node.hpp
@@ -41,12 +41,12 @@ public:
     sub_ = this->create_subscription<sensor_msgs::msg::Image>(
       input,
       rclcpp::SensorDataQoS(),
-      [node_name, watermark](sensor_msgs::msg::Image::ConstSharedPtr msg) {
+      [node_name, watermark](sensor_msgs::msg::Image::UniquePtr msg) {
         // Create a cv::Mat from the image message (without copying).
         cv::Mat cv_mat(
           msg->height, msg->width,
           encoding2mat_type(msg->encoding),
-          const_cast<unsigned char *>(msg->data.data()));
+          msg->data.data());
         if (watermark) {
           // Annotate with the pid and pointer address.
           std::stringstream ss;

--- a/intra_process_demo/src/image_pipeline/image_pipeline_all_in_one.cpp
+++ b/intra_process_demo/src/image_pipeline/image_pipeline_all_in_one.cpp
@@ -35,7 +35,7 @@ int main(int argc, char * argv[])
   }
   auto watermark_node =
     std::make_shared<WatermarkNode>("image", "watermarked_image", "Hello world!");
-  auto image_view_node = std::make_shared<ImageViewNode>("watermarked_image");
+  auto image_view_node = std::make_shared<ImageViewNode>("watermarked_image", "image_pipeline_all_in_one");
 
   executor.add_node(camera_node);
   executor.add_node(watermark_node);

--- a/intra_process_demo/src/image_pipeline/image_pipeline_all_in_one.cpp
+++ b/intra_process_demo/src/image_pipeline/image_pipeline_all_in_one.cpp
@@ -35,7 +35,8 @@ int main(int argc, char * argv[])
   }
   auto watermark_node =
     std::make_shared<WatermarkNode>("image", "watermarked_image", "Hello world!");
-  auto image_view_node = std::make_shared<ImageViewNode>("watermarked_image", "image_pipeline_all_in_one");
+  auto image_view_node =
+    std::make_shared<ImageViewNode>("watermarked_image", "image_pipeline_all_in_one");
 
   executor.add_node(camera_node);
   executor.add_node(watermark_node);

--- a/intra_process_demo/src/image_pipeline/image_pipeline_with_two_image_view.cpp
+++ b/intra_process_demo/src/image_pipeline/image_pipeline_with_two_image_view.cpp
@@ -36,8 +36,10 @@ int main(int argc, char * argv[])
   }
   auto watermark_node =
     std::make_shared<WatermarkNode>("image", "watermarked_image", "Hello world!");
-  auto image_view_node = std::make_shared<ImageViewNode>("watermarked_image");
-  auto image_view_node2 = std::make_shared<ImageViewNode>("watermarked_image", "image_view_node2");
+  auto image_view_node =
+    std::make_shared<ImageViewNode>("watermarked_image", "image_pipeline_with_two_image_view");
+  auto image_view_node2 =
+    std::make_shared<ImageViewNode>("watermarked_image", "image_pipeline_with_two_image_view2");
 
   executor.add_node(camera_node);
   executor.add_node(watermark_node);


### PR DESCRIPTION
## Description

User's noticed (https://github.com/ros2/ros2_documentation/issues/2333) that the behavior of the `image_pipeline_demo` related binaries in the `intra_process_demo` package were not behaving as depicted in the screenshots and not as described in the demo text.

This pull request was opened to fix the documentation and screenshots (https://github.com/ros2/ros2_documentation/pull/5988), but I noticed and realized it was actually the demo code that was wrong and the demo documentation and screenshots were what should have been happening. I tracked it down to this commit that I made years ago that broke the expected behavior: https://github.com/ros2/demos/commit/456b5bac8f527141ed4e5af73168b3d31adb9b22

So this pull request fixed the behavior (using a `unique_ptr` instead of a `shared_ptr` in the image viewer), as well as modernizes it a bit, with better resolutions, text font size, and better window titles.

I will fixup the documentation too, with new screenshots and some slightly adjusted text to make sure everything is the way it was supposed to be. See https://github.com/ros2/ros2_documentation/pull/6041

Fixes ros2/ros2_documentation#2333

### Is this user-facing behavior change?

Yes, the demo should now work as intended.

### Did you use Generative AI?

No.

### Additional Information

As the original author of the demo, I believe this is the behavior I was intending to demonstrate here.
