### PR TITLE
Fixed launch file

### DIFF
--- a/dummy_robot/dummy_robot_bringup/launch/dummy_robot_bringup_launch.py
+++ b/dummy_robot/dummy_robot_bringup/launch/dummy_robot_bringup_launch.py
@@ -15,8 +15,9 @@
 import os
 
 from launch import LaunchDescription
+from launch.substitutions import FileContent
 from launch_ros.actions import Node
-from launch_ros.substitutions import FileContent, FindPackageShare
+from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():


### PR DESCRIPTION
`FileContent` is part of `launch` not `launch_ros`. 

Reference https://github.com/ros2/launch/tree/rolling/launch/launch/substitutions