### PR TITLE
Don't use `libopencv-dev` for exec

### DIFF
--- a/image_tools/package.xml
+++ b/image_tools/package.xml
@@ -22,10 +22,10 @@
   <build_depend>example_interfaces</build_depend>
 
   <exec_depend>libopencv-core</exec_depend>
-  <exec_depend>libopencv-codecs</exec_depend>
+  <exec_depend>libopencv-imgcodecs</exec_depend>
   <exec_depend>libopencv-highgui</exec_depend>
   <exec_depend>libopencv-imgproc</exec_depend>
-  <exec_depend>libopencv-videio</exec_depend>
+  <exec_depend>libopencv-videoio</exec_depend>
   
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclcpp_components</exec_depend>

--- a/image_tools/package.xml
+++ b/image_tools/package.xml
@@ -21,7 +21,12 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>example_interfaces</build_depend>
 
-  <exec_depend>libopencv-dev</exec_depend>
+  <exec_depend>libopencv-core</exec_depend>
+  <exec_depend>libopencv-codecs</exec_depend>
+  <exec_depend>libopencv-highgui</exec_depend>
+  <exec_depend>libopencv-imgproc</exec_depend>
+  <exec_depend>libopencv-videio</exec_depend>
+  
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>rclcpp_components</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>

--- a/intra_process_demo/package.xml
+++ b/intra_process_demo/package.xml
@@ -20,7 +20,10 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>example_interfaces</build_depend>
 
-  <exec_depend>libopencv-dev</exec_depend>
+  <exec_depend>libopencv-core</exec_depend>
+  <exec_depend>libopencv-highgui</exec_depend>
+  <exec_depend>libopencv-imgproc</exec_depend>
+  <exec_depend>libopencv-videio</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
 

--- a/intra_process_demo/package.xml
+++ b/intra_process_demo/package.xml
@@ -23,7 +23,7 @@
   <exec_depend>libopencv-core</exec_depend>
   <exec_depend>libopencv-highgui</exec_depend>
   <exec_depend>libopencv-imgproc</exec_depend>
-  <exec_depend>libopencv-videio</exec_depend>
+  <exec_depend>libopencv-videoio</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
 


### PR DESCRIPTION
## Description

Cleans up some dependency leaking when installing `ros-rolling-desktop`.

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
