### PR TITLE
Add tests isolation in composition tests

### DIFF
--- a/composition/test/test_dlopen_composition.py.in
+++ b/composition/test/test_dlopen_composition.py.in
@@ -21,10 +21,13 @@ import launch_testing
 import launch_testing.actions
 import launch_testing.asserts
 import launch_testing_ros
+from launch_testing_ros.actions import EnableRmwIsolation
 
 
 def generate_test_description():
-    launch_description = LaunchDescription()
+    launch_description = LaunchDescription([
+        EnableRmwIsolation(),
+    ])
     process_under_test = ExecuteProcess(
         cmd=[
             '@DLOPEN_COMPOSITION_EXECUTABLE@',

--- a/composition/test/test_linktime_composition.py.in
+++ b/composition/test/test_linktime_composition.py.in
@@ -24,10 +24,13 @@ import launch_testing
 import launch_testing.actions
 import launch_testing.asserts
 import launch_testing_ros
+from launch_testing_ros.actions import EnableRmwIsolation
 
 
 def generate_test_description():
-    launch_description = LaunchDescription()
+    launch_description = LaunchDescription([
+        EnableRmwIsolation(),
+    ])
     process_under_test = ExecuteProcess(
         cmd=['@LINKTIME_COMPOSITION_EXECUTABLE@'],
         name='test_linktime_composition',


### PR DESCRIPTION
## Description

As discussed in https://github.com/ros2/rmw_zenoh/issues/881#issuecomment-3891134977, this PR adds tests isolation for both `composition/test/test_dlopen_composition.py.in` and `composition/test/test_linktime_composition.py.in`.

Those tests are calling `rclcpp::init(). In case of `rmw_zenoh_cpp`, Zenoh will try to connect to a Zenoh router which isn't running, causing warning logs and unnecessary delay in the test.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No
