### PR TITLE
add child logger under parent node, with different log levels.

### DIFF
--- a/demo_nodes_cpp/src/logging/use_logger_service.cpp
+++ b/demo_nodes_cpp/src/logging/use_logger_service.cpp
@@ -26,27 +26,64 @@
 using namespace std::chrono_literals;
 
 // This demo program shows how to enable logger service and control logger level via logger service.
-// Class LoggerServiceNode enable logger service and create a subscription. The callback of
-// subscription output received message by different log functions.
+// Class LoggerServiceNode enables logger service, creates a child logger, and subscribes to a
+// topic. The subscription callback outputs received messages using both the parent and child
+// loggers at different severity levels, demonstrating how child loggers inherit or independently
+// override the parent logger level.
 // Class TestNode can set/get logger level of LoggerServiceNode and send message to it.
+//
+// Usage:
+//   Default (demo mode): runs the full automated demo sequence with TestNode.
+//   --service-only:      starts only LoggerServiceNode and spins forever,
+//                         so you can interact with it via ros2 CLI tools.
+//
+//   Example ros2 CLI commands (use in a separate terminal while --service-only is running).
+//   Note: each multi-line command below must be joined into a single line before executing.
+//
+//   Get logger level (parent):
+//     ros2 service call /LoggerServiceNode/get_logger_levels
+//       rcl_interfaces/srv/GetLoggerLevels "{names: ['LoggerServiceNode']}"
+//
+//   Get logger level (child):
+//     ros2 service call /LoggerServiceNode/get_logger_levels
+//       rcl_interfaces/srv/GetLoggerLevels "{names: ['LoggerServiceNode.child']}"
+//
+//   Set parent logger level to DEBUG (10):
+//     ros2 service call /LoggerServiceNode/set_logger_levels
+//       rcl_interfaces/srv/SetLoggerLevels
+//       "{levels: [{name: 'LoggerServiceNode', level: 10}]}"
+//
+//   Set child logger level to ERROR (40):
+//     ros2 service call /LoggerServiceNode/set_logger_levels
+//       rcl_interfaces/srv/SetLoggerLevels
+//       "{levels: [{name: 'LoggerServiceNode.child', level: 40}]}"
+//
+//   Publish a test message:
+//     ros2 topic pub /output example_interfaces/msg/String "{data: hello}" --once
 
 class LoggerServiceNode : public rclcpp::Node
 {
 public:
   explicit LoggerServiceNode(const std::string & node_name)
-  : Node(node_name, rclcpp::NodeOptions().enable_logger_service(true))
+  : Node(node_name, rclcpp::NodeOptions().enable_logger_service(true)),
+    child_logger_(this->get_logger().get_child("child"))
   {
     auto callback = [this](example_interfaces::msg::String::ConstSharedPtr msg)-> void {
         RCLCPP_DEBUG(this->get_logger(), "%s with DEBUG logger level.", msg->data.c_str());
         RCLCPP_INFO(this->get_logger(), "%s with INFO logger level.", msg->data.c_str());
         RCLCPP_WARN(this->get_logger(), "%s with WARN logger level.", msg->data.c_str());
         RCLCPP_ERROR(this->get_logger(), "%s with ERROR logger level.", msg->data.c_str());
+        RCLCPP_DEBUG(child_logger_, "[child] %s with DEBUG logger level.", msg->data.c_str());
+        RCLCPP_INFO(child_logger_, "[child] %s with INFO logger level.", msg->data.c_str());
+        RCLCPP_WARN(child_logger_, "[child] %s with WARN logger level.", msg->data.c_str());
+        RCLCPP_ERROR(child_logger_, "[child] %s with ERROR logger level.", msg->data.c_str());
       };
 
     sub_ = this->create_subscription<example_interfaces::msg::String>("output", 10, callback);
   }
 
 private:
+  rclcpp::Logger child_logger_;
   rclcpp::Subscription<example_interfaces::msg::String>::SharedPtr sub_;
 };
 
@@ -70,7 +107,8 @@ public:
   }
 
   bool set_logger_level_on_remote_node(
-    rclcpp::Logger::Level logger_level)
+    rclcpp::Logger::Level logger_level,
+    const std::string & logger_name = "")
   {
     if (!logger_set_client_->wait_for_service(2s)) {
       return false;
@@ -78,7 +116,7 @@ public:
 
     auto request = std::make_shared<rcl_interfaces::srv::SetLoggerLevels::Request>();
     auto set_logger_level = rcl_interfaces::msg::LoggerLevel();
-    set_logger_level.name = remote_node_name_;
+    set_logger_level.name = logger_name.empty() ? remote_node_name_ : logger_name;
     set_logger_level.level = static_cast<uint32_t>(logger_level);
     request->levels.emplace_back(set_logger_level);
 
@@ -100,14 +138,16 @@ public:
     return true;
   }
 
-  bool get_logger_level_on_remote_node(uint32_t & level)
+  bool get_logger_level_on_remote_node(
+    uint32_t & level,
+    const std::string & logger_name = "")
   {
     if (!logger_get_client_->wait_for_service(2s)) {
       return false;
     }
 
     auto request = std::make_shared<rcl_interfaces::srv::GetLoggerLevels::Request>();
-    request->names.emplace_back(remote_node_name_);
+    request->names.emplace_back(logger_name.empty() ? remote_node_name_ : logger_name);
     auto result = logger_get_client_->async_send_request(request);
     if (rclcpp::spin_until_future_complete(shared_from_this(), result) !=
       rclcpp::FutureReturnCode::SUCCESS)
@@ -132,9 +172,31 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
 
+  // Check for --service-only flag before ROS 2 consumes the arguments
+  bool service_only = false;
+  for (int i = 1; i < argc; ++i) {
+    if (std::string(argv[i]) == "--service-only") {
+      service_only = true;
+      break;
+    }
+  }
+
   const std::string node_name = "LoggerServiceNode";
   auto logger_service_node = std::make_shared<LoggerServiceNode>(
     node_name);
+
+  if (service_only) {
+    // Service-only mode: spin LoggerServiceNode forever so that users can
+    // interact with it using ros2 CLI tools (ros2 service, ros2 topic, etc.)
+    RCLCPP_INFO(
+      logger_service_node->get_logger(),
+      "Started in service-only mode. Use ros2 CLI to interact with this node.");
+    rclcpp::spin(logger_service_node);
+    rclcpp::shutdown();
+    return 0;
+  }
+
+  // Default demo mode: run the full automated sequence
   auto test_node = std::make_shared<TestNode>(node_name);
 
   rclcpp::executors::SingleThreadedExecutor executor;
@@ -145,7 +207,9 @@ int main(int argc, char ** argv)
       executor.spin();
     });
 
-  auto get_logger_level_func = [&test_node] {
+  const std::string child_logger_name = node_name + ".child";
+
+  auto get_logger_level_func = [&test_node, &child_logger_name] {
       uint32_t get_logger_level = 0;
       if (test_node->get_logger_level_on_remote_node(get_logger_level)) {
         RCLCPP_INFO(test_node->get_logger(), "Current logger level: %u", get_logger_level);
@@ -153,6 +217,15 @@ int main(int argc, char ** argv)
         RCLCPP_ERROR(
           test_node->get_logger(),
           "Failed to get logger level via logger service !");
+      }
+      uint32_t child_level = 0;
+      if (test_node->get_logger_level_on_remote_node(child_level, child_logger_name)) {
+        RCLCPP_INFO(
+          test_node->get_logger(), "Current child logger level: %u", child_level);
+      } else {
+        RCLCPP_ERROR(
+          test_node->get_logger(),
+          "Failed to get child logger level via logger service !");
       }
     };
 
@@ -168,46 +241,61 @@ int main(int argc, char ** argv)
   // Get logger level. Logger level should be 0 (Unset)
   get_logger_level_func();
 
-  // Output with debug logger level
-  RCLCPP_INFO(test_node->get_logger(), "Output with debug logger level:");
-  if (test_node->set_logger_level_on_remote_node(rclcpp::Logger::Level::Debug)) {
+  // Output with parent=debug, child=error logger level
+  // Parent shows all messages, child only shows error.
+  RCLCPP_INFO(
+    test_node->get_logger(), "Output with parent=debug, child=error logger level:");
+  if (test_node->set_logger_level_on_remote_node(rclcpp::Logger::Level::Debug) &&
+    test_node->set_logger_level_on_remote_node(
+      rclcpp::Logger::Level::Error, child_logger_name))
+  {
     auto msg = std::make_unique<example_interfaces::msg::String>();
     msg->data = "Output 2";
     test_node->get_pub()->publish(std::move(msg));
     std::this_thread::sleep_for(200ms);
   } else {
-    RCLCPP_ERROR(test_node->get_logger(), "Failed to set debug logger level via logger service !");
+    RCLCPP_ERROR(test_node->get_logger(), "Failed to set logger levels via logger service !");
   }
 
-  // Get logger level. Logger level should be 10 (Debug)
+  // Parent should be 10 (Debug), child should be 40 (Error)
   get_logger_level_func();
 
-  // Output with warn logger level
-  RCLCPP_INFO(test_node->get_logger(), "Output with warn logger level:");
-  if (test_node->set_logger_level_on_remote_node(rclcpp::Logger::Level::Warn)) {
+  // Output with parent=warn, child=debug logger level
+  // Parent suppresses debug/info, child shows everything.
+  RCLCPP_INFO(
+    test_node->get_logger(), "Output with parent=warn, child=debug logger level:");
+  if (test_node->set_logger_level_on_remote_node(rclcpp::Logger::Level::Warn) &&
+    test_node->set_logger_level_on_remote_node(
+      rclcpp::Logger::Level::Debug, child_logger_name))
+  {
     auto msg = std::make_unique<example_interfaces::msg::String>();
     msg->data = "Output 3";
     test_node->get_pub()->publish(std::move(msg));
     std::this_thread::sleep_for(200ms);
   } else {
-    RCLCPP_ERROR(test_node->get_logger(), "Failed to set warn logger level via logger service !");
+    RCLCPP_ERROR(test_node->get_logger(), "Failed to set logger levels via logger service !");
   }
 
-  // Get logger level. Logger level should be 30 (Warn)
+  // Parent should be 30 (Warn), child should be 10 (Debug)
   get_logger_level_func();
 
-  // Output with error logger level
-  RCLCPP_INFO(test_node->get_logger(), "Output with error logger level:");
-  if (test_node->set_logger_level_on_remote_node(rclcpp::Logger::Level::Error)) {
+  // Output with parent=error, child=debug logger level
+  // Parent only shows error, child shows everything.
+  RCLCPP_INFO(
+    test_node->get_logger(), "Output with parent=error, child=debug logger level:");
+  if (test_node->set_logger_level_on_remote_node(rclcpp::Logger::Level::Error) &&
+    test_node->set_logger_level_on_remote_node(
+      rclcpp::Logger::Level::Debug, child_logger_name))
+  {
     auto msg = std::make_unique<example_interfaces::msg::String>();
     msg->data = "Output 4";
     test_node->get_pub()->publish(std::move(msg));
     std::this_thread::sleep_for(200ms);
   } else {
-    RCLCPP_ERROR(test_node->get_logger(), "Failed to set error logger level via logger service !");
+    RCLCPP_ERROR(test_node->get_logger(), "Failed to set logger levels via logger service !");
   }
 
-  // Get logger level. Logger level should be 40 (Error)
+  // Parent should be 40 (Error), child should be 10 (Debug)
   get_logger_level_func();
 
   executor.cancel();

--- a/demo_nodes_cpp/test/use_logger_service.txt
+++ b/demo_nodes_cpp/test/use_logger_service.txt
@@ -2,17 +2,33 @@ Output with default logger level:
 Output 1 with INFO logger level.
 Output 1 with WARN logger level.
 Output 1 with ERROR logger level.
+[child] Output 1 with INFO logger level.
+[child] Output 1 with WARN logger level.
+[child] Output 1 with ERROR logger level.
 Current logger level: 0
-Output with debug logger level:
+Current child logger level: 0
+Output with parent=debug, child=error logger level:
 Output 2 with DEBUG logger level.
 Output 2 with INFO logger level.
 Output 2 with WARN logger level.
 Output 2 with ERROR logger level.
+[child] Output 2 with ERROR logger level.
 Current logger level: 10
-Output with warn logger level:
+Current child logger level: 40
+Output with parent=warn, child=debug logger level:
 Output 3 with WARN logger level.
 Output 3 with ERROR logger level.
+[child] Output 3 with DEBUG logger level.
+[child] Output 3 with INFO logger level.
+[child] Output 3 with WARN logger level.
+[child] Output 3 with ERROR logger level.
 Current logger level: 30
-Output with error logger level:
+Current child logger level: 10
+Output with parent=error, child=debug logger level:
 Output 4 with ERROR logger level.
+[child] Output 4 with DEBUG logger level.
+[child] Output 4 with INFO logger level.
+[child] Output 4 with WARN logger level.
+[child] Output 4 with ERROR logger level.
 Current logger level: 40
+Current child logger level: 10

--- a/demo_nodes_py/demo_nodes_py/logging/use_logger_service.py
+++ b/demo_nodes_py/demo_nodes_py/logging/use_logger_service.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import threading
 import time
 
@@ -27,9 +28,39 @@ from rclpy.node import Node
 
 """
 This demo program shows how to enable logger service and control logger level via logger service.
-Class LoggerServiceNode enable logger service and create a subscription. The callback of
-subscription output received message by different log functions.
+Class LoggerServiceNode enables logger service, creates a child logger, and subscribes to a
+topic. The subscription callback outputs received messages using both the parent and child
+loggers at different severity levels, demonstrating how child loggers inherit or independently
+override the parent logger level.
 Class TestNode can set/get logger level of LoggerServiceNode and send message to it.
+
+Usage:
+  Default (demo mode): runs the full automated demo sequence with TestNode.
+  --service-only:      starts only LoggerServiceNode and spins forever,
+                        so you can interact with it via ros2 CLI tools.
+
+  Example ros2 CLI commands (use in a separate terminal while --service-only is running).
+
+  Get logger level (parent):
+    ros2 service call /LoggerServiceNode/get_logger_levels \\
+      rcl_interfaces/srv/GetLoggerLevels "{names: ['LoggerServiceNode']}"
+
+  Get logger level (child):
+    ros2 service call /LoggerServiceNode/get_logger_levels \\
+      rcl_interfaces/srv/GetLoggerLevels "{names: ['LoggerServiceNode.child']}"
+
+  Set parent logger level to DEBUG (10):
+    ros2 service call /LoggerServiceNode/set_logger_levels \\
+      rcl_interfaces/srv/SetLoggerLevels \\
+      "{levels: [{name: 'LoggerServiceNode', level: 10}]}"
+
+  Set child logger level to ERROR (40):
+    ros2 service call /LoggerServiceNode/set_logger_levels \\
+      rcl_interfaces/srv/SetLoggerLevels \\
+      "{levels: [{name: 'LoggerServiceNode.child', level: 40}]}"
+
+  Publish a test message:
+    ros2 topic pub /output example_interfaces/msg/String "{data: hello}" --once
 """
 
 
@@ -37,6 +68,7 @@ class LoggerServiceNode(Node):
 
     def __init__(self):
         super().__init__('LoggerServiceNode', enable_logger_service=True)
+        self.child_logger = self.get_logger().get_child('child')
         self.sub = self.create_subscription(String, 'output', self.callback, 10)
 
     def callback(self, msg):
@@ -44,6 +76,10 @@ class LoggerServiceNode(Node):
         self.get_logger().info(msg.data + ' with INFO logger level.')
         self.get_logger().warning(msg.data + ' with WARN logger level.')
         self.get_logger().error(msg.data + ' with ERROR logger level.')
+        self.child_logger.debug('[child] ' + msg.data + ' with DEBUG logger level.')
+        self.child_logger.info('[child] ' + msg.data + ' with INFO logger level.')
+        self.child_logger.warning('[child] ' + msg.data + ' with WARN logger level.')
+        self.child_logger.error('[child] ' + msg.data + ' with ERROR logger level.')
 
 
 class TestNode(Node):
@@ -57,13 +93,13 @@ class TestNode(Node):
             SetLoggerLevels, remote_node_name + '/set_logger_levels')
         self._remote_node_name = remote_node_name
 
-    def set_logger_level_on_remote_node(self, logger_level) -> bool:
+    def set_logger_level_on_remote_node(self, logger_level, logger_name='') -> bool:
         if not self._logger_set_client.service_is_ready():
             return False
 
         request = SetLoggerLevels.Request()
         set_logger_level = LoggerLevel()
-        set_logger_level.name = self._remote_node_name
+        set_logger_level.name = logger_name if logger_name else self._remote_node_name
         set_logger_level.level = logger_level
         request.levels.append(set_logger_level)
 
@@ -81,12 +117,12 @@ class TestNode(Node):
 
         return True
 
-    def get_logger_level_on_remote_node(self):
+    def get_logger_level_on_remote_node(self, logger_name=''):
         if not self.logger_get_client.service_is_ready():
             return [False, None]
 
         request = GetLoggerLevels.Request()
-        request.names.append(self._remote_node_name)
+        request.names.append(logger_name if logger_name else self._remote_node_name)
 
         future = self.logger_get_client.call_async(request)
         rclpy.spin_until_future_complete(self, future)
@@ -98,19 +134,42 @@ class TestNode(Node):
         return [True, ret_results.levels[0].level]
 
 
-def get_logger_level_func(test_node):
+def get_logger_level_func(test_node, child_logger_name):
     ret, level = test_node.get_logger_level_on_remote_node()
     if ret:
         test_node.get_logger().info('Current logger level: ' + str(level))
     else:
         test_node.get_logger().error('Failed to get logger level via logger service !')
+    ret, child_level = test_node.get_logger_level_on_remote_node(child_logger_name)
+    if ret:
+        test_node.get_logger().info('Current child logger level: ' + str(child_level))
+    else:
+        test_node.get_logger().error('Failed to get child logger level via logger service !')
 
 
 def main(args=None):
+    # Check for --service-only flag before ROS 2 consumes the arguments
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument('--service-only', action='store_true', default=False)
+    parsed, remaining = parser.parse_known_args(args)
+    service_only = parsed.service_only
+
     try:
-        with rclpy.init(args=args):
+        with rclpy.init(args=remaining):
+            node_name = 'LoggerServiceNode'
+            child_logger_name = node_name + '.child'
             logger_service_node = LoggerServiceNode()
-            test_node = TestNode('LoggerServiceNode')
+
+            if service_only:
+                # Service-only mode: spin LoggerServiceNode forever so that users can
+                # interact with it using ros2 CLI tools (ros2 service, ros2 topic, etc.)
+                logger_service_node.get_logger().info(
+                    'Started in service-only mode. Use ros2 CLI to interact with this node.')
+                rclpy.spin(logger_service_node)
+                return
+
+            # Default demo mode: run the full automated sequence
+            test_node = TestNode(node_name)
 
             executor = SingleThreadedExecutor()
             executor.add_node(logger_service_node)
@@ -128,46 +187,55 @@ def main(args=None):
             time.sleep(0.5)
 
             # Get logger level. Logger level should be 0 (Unset)
-            get_logger_level_func(test_node)
+            get_logger_level_func(test_node, child_logger_name)
 
-            # Output with debug logger level
-            logger.info('Output with debug logger level:')
-            if test_node.set_logger_level_on_remote_node(LoggingSeverity.DEBUG):
+            # Output with parent=debug, child=error logger level
+            # Parent shows all messages, child only shows error.
+            logger.info('Output with parent=debug, child=error logger level:')
+            if (test_node.set_logger_level_on_remote_node(LoggingSeverity.DEBUG) and
+                    test_node.set_logger_level_on_remote_node(
+                        LoggingSeverity.ERROR, child_logger_name)):
                 msg = String()
                 msg.data = 'Output 2'
                 test_node.pub.publish(msg)
                 time.sleep(0.5)
             else:
-                logger.error('Failed to set debug logger level via logger service !')
+                logger.error('Failed to set logger levels via logger service !')
 
-            # Get logger level. Logger level should be 10 (Debug)
-            get_logger_level_func(test_node)
+            # Parent should be 10 (Debug), child should be 40 (Error)
+            get_logger_level_func(test_node, child_logger_name)
 
-            # Output with warn logger level
-            logger.info('Output with warn logger level:')
-            if test_node.set_logger_level_on_remote_node(LoggingSeverity.WARN):
+            # Output with parent=warn, child=debug logger level
+            # Parent suppresses debug/info, child shows everything.
+            logger.info('Output with parent=warn, child=debug logger level:')
+            if (test_node.set_logger_level_on_remote_node(LoggingSeverity.WARN) and
+                    test_node.set_logger_level_on_remote_node(
+                        LoggingSeverity.DEBUG, child_logger_name)):
                 msg = String()
                 msg.data = 'Output 3'
                 test_node.pub.publish(msg)
                 time.sleep(0.5)
             else:
-                logger.error('Failed to set warn logger level via logger service !')
+                logger.error('Failed to set logger levels via logger service !')
 
-            # Get logger level. Logger level should be 30 (warn)
-            get_logger_level_func(test_node)
+            # Parent should be 30 (Warn), child should be 10 (Debug)
+            get_logger_level_func(test_node, child_logger_name)
 
-            # Output with error logger level
-            logger.info('Output with error logger level:')
-            if test_node.set_logger_level_on_remote_node(LoggingSeverity.ERROR):
+            # Output with parent=error, child=debug logger level
+            # Parent only shows error, child shows everything.
+            logger.info('Output with parent=error, child=debug logger level:')
+            if (test_node.set_logger_level_on_remote_node(LoggingSeverity.ERROR) and
+                    test_node.set_logger_level_on_remote_node(
+                        LoggingSeverity.DEBUG, child_logger_name)):
                 msg = String()
                 msg.data = 'Output 4'
                 test_node.pub.publish(msg)
                 time.sleep(0.5)
             else:
-                logger.error('Failed to set error logger level via logger service !')
+                logger.error('Failed to set logger levels via logger service !')
 
-            # Get logger level. Logger level should be 40 (Error)
-            get_logger_level_func(test_node)
+            # Parent should be 40 (Error), child should be 10 (Debug)
+            get_logger_level_func(test_node, child_logger_name)
 
             executor.shutdown()
             if thread.is_alive():


### PR DESCRIPTION
## Description

The current demonstration does not show how to get and set the child logger under the parent node.
This PR improves the demonstration with child logger management with more detailed exmplanation.
in addition to that, it also supports the new optional argument `--service-only`, so that user can use ros2cli such as ros2 topic and ros2 service command to reconfigure the logging levels for each logger if they want to. this mode is not default behavior, so that default behavior is consistent for user.

Note,

- this PR does not affect https://docs.ros.org/en/rolling/Tutorials/Demos/Logging-and-logger-configuration.html#logger-level-configuration-externally (doc can stay as it is)
- this is related to https://github.com/ros2/ros2cli/issues/1148 (once ros2log new CLI is developed, this demo can be also useful to show how to operate the logger state via ros2log.)

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

No

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

Yes, Claude Sonnet 4.6
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
