### PR TITLE
action_tutorials_py: add ament_mypy support

### DIFF
--- a/action_tutorials/action_tutorials_py/action_tutorials_py/fibonacci_action_client.py
+++ b/action_tutorials/action_tutorials_py/action_tutorials_py/fibonacci_action_client.py
@@ -19,7 +19,7 @@
 # ros2 run action_tutorials_py fibonacci_action_client --ros-args -p
 # "action_client_configure_introspection:=contents"
 
-from typing import List
+from typing import Any
 
 from example_interfaces.action import Fibonacci
 
@@ -27,6 +27,7 @@ from rcl_interfaces.msg import SetParametersResult
 
 import rclpy
 from rclpy.action import ActionClient
+from rclpy.action.client import ClientGoalHandle
 from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from rclpy.parameter import Parameter
@@ -39,12 +40,16 @@ class FibonacciActionClient(Node):
 
     def __init__(self) -> None:
         super().__init__('fibonacci_action_client')
-        self._action_client: ActionClient = ActionClient(self, Fibonacci, 'fibonacci')
+        self._action_client: ActionClient[
+            Fibonacci.Goal,
+            Fibonacci.Result,
+            Fibonacci.Feedback] = ActionClient(self, Fibonacci, 'fibonacci')
         self.add_on_set_parameters_callback(self.on_set_parameters_callback)
         self.add_post_set_parameters_callback(self.on_post_set_parameters_callback)
         self.declare_parameter('action_client_configure_introspection', 'disabled')
 
-    def _check_parameter(self, parameter_list: List[Parameter], parameter_name: str):
+    def _check_parameter(self, parameter_list: list[Parameter[Any]],
+                         parameter_name: str) -> SetParametersResult:
         result = SetParametersResult()
         result.successful = True
         for param in parameter_list:
@@ -58,15 +63,16 @@ class FibonacciActionClient(Node):
 
             if param.value not in ('disabled', 'metadata', 'contents'):
                 result.successful = False
-                result.reason = "must be one of 'disabled', 'metadata', or 'contents"
+                result.reason = "must be one of 'disabled', 'metadata', or 'contents'"
                 break
 
         return result
 
-    def on_set_parameters_callback(self, parameter_list: List[Parameter]) -> SetParametersResult:
+    def on_set_parameters_callback(self,
+                                   parameter_list: list[Parameter[Any]]) -> SetParametersResult:
         return self._check_parameter(parameter_list, 'action_client_configure_introspection')
 
-    def on_post_set_parameters_callback(self, parameter_list: List[Parameter]) -> None:
+    def on_post_set_parameters_callback(self, parameter_list: list[Parameter[Any]]) -> None:
         for param in parameter_list:
             if param.name != 'action_client_configure_introspection':
                 continue
@@ -96,7 +102,10 @@ class FibonacciActionClient(Node):
 
         self._send_goal_future.add_done_callback(self.goal_response_callback)
 
-    def goal_response_callback(self, future: Future) -> None:
+    def goal_response_callback(
+            self,
+            future: Future[
+            ClientGoalHandle[Fibonacci.Goal, Fibonacci.Result, Fibonacci.Feedback]]) -> None:
         goal_handle = future.result()
 
         if goal_handle is None:
@@ -113,7 +122,7 @@ class FibonacciActionClient(Node):
 
         self._get_result_future.add_done_callback(self.get_result_callback)
 
-    def get_result_callback(self, future: Future) -> None:
+    def get_result_callback(self, future: Future[Any]) -> None:
         future_result = future.result()
 
         if future_result is None:
@@ -123,12 +132,11 @@ class FibonacciActionClient(Node):
         self.get_logger().info('Result: {0}'.format(result.sequence))
         rclpy.shutdown()
 
-    def feedback_callback(self, feedback_msg: Fibonacci.Impl.FeedbackMessage):
-        feedback = feedback_msg.feedback
-        self.get_logger().info('Received feedback: {0}'.format(feedback.sequence))
+    def feedback_callback(self, feedback_msg: Fibonacci.Feedback) -> None:
+        self.get_logger().info('Received feedback: {0}'.format(feedback_msg.sequence))
 
 
-def main(args: List[str] | None = None) -> None:
+def main(args: list[str] | None = None) -> None:
     try:
         with rclpy.init(args=args):
             action_client = FibonacciActionClient()

--- a/action_tutorials/action_tutorials_py/action_tutorials_py/fibonacci_action_client.py
+++ b/action_tutorials/action_tutorials_py/action_tutorials_py/fibonacci_action_client.py
@@ -19,8 +19,6 @@
 # ros2 run action_tutorials_py fibonacci_action_client --ros-args -p
 # "action_client_configure_introspection:=contents"
 
-from typing import Any
-
 from example_interfaces.action import Fibonacci
 
 from rcl_interfaces.msg import SetParametersResult
@@ -34,21 +32,19 @@ from rclpy.parameter import Parameter
 from rclpy.qos import qos_profile_system_default
 from rclpy.service_introspection import ServiceIntrospectionState
 from rclpy.task import Future
+from rclpy.type_support import GetResultServiceResponse
 
 
 class FibonacciActionClient(Node):
 
     def __init__(self) -> None:
         super().__init__('fibonacci_action_client')
-        self._action_client: ActionClient[
-            Fibonacci.Goal,
-            Fibonacci.Result,
-            Fibonacci.Feedback] = ActionClient(self, Fibonacci, 'fibonacci')
+        self._action_client = ActionClient(self, Fibonacci, 'fibonacci')
         self.add_on_set_parameters_callback(self.on_set_parameters_callback)
         self.add_post_set_parameters_callback(self.on_post_set_parameters_callback)
         self.declare_parameter('action_client_configure_introspection', 'disabled')
 
-    def _check_parameter(self, parameter_list: list[Parameter[Any]],
+    def _check_parameter(self, parameter_list: list[Parameter[str]],
                          parameter_name: str) -> SetParametersResult:
         result = SetParametersResult()
         result.successful = True
@@ -69,10 +65,10 @@ class FibonacciActionClient(Node):
         return result
 
     def on_set_parameters_callback(self,
-                                   parameter_list: list[Parameter[Any]]) -> SetParametersResult:
+                                   parameter_list: list[Parameter[str]]) -> SetParametersResult:
         return self._check_parameter(parameter_list, 'action_client_configure_introspection')
 
-    def on_post_set_parameters_callback(self, parameter_list: list[Parameter[Any]]) -> None:
+    def on_post_set_parameters_callback(self, parameter_list: list[Parameter[str]]) -> None:
         for param in parameter_list:
             if param.name != 'action_client_configure_introspection':
                 continue
@@ -105,7 +101,10 @@ class FibonacciActionClient(Node):
     def goal_response_callback(
             self,
             future: Future[
-            ClientGoalHandle[Fibonacci.Goal, Fibonacci.Result, Fibonacci.Feedback]]) -> None:
+            ClientGoalHandle[Fibonacci.Goal,
+                             Fibonacci.Result,
+                             Fibonacci.Feedback,
+                             Fibonacci.Impl]]) -> None:
         goal_handle = future.result()
 
         if goal_handle is None:
@@ -122,7 +121,8 @@ class FibonacciActionClient(Node):
 
         self._get_result_future.add_done_callback(self.get_result_callback)
 
-    def get_result_callback(self, future: Future[Any]) -> None:
+    def get_result_callback(self, future:
+                            Future[GetResultServiceResponse[Fibonacci.Result]]) -> None:
         future_result = future.result()
 
         if future_result is None:

--- a/action_tutorials/action_tutorials_py/action_tutorials_py/fibonacci_action_client.py
+++ b/action_tutorials/action_tutorials_py/action_tutorials_py/fibonacci_action_client.py
@@ -32,6 +32,7 @@ from rclpy.parameter import Parameter
 from rclpy.qos import qos_profile_system_default
 from rclpy.service_introspection import ServiceIntrospectionState
 from rclpy.task import Future
+from rclpy.type_support import FeedbackMessage
 from rclpy.type_support import GetResultServiceResponse
 
 
@@ -132,8 +133,8 @@ class FibonacciActionClient(Node):
         self.get_logger().info('Result: {0}'.format(result.sequence))
         rclpy.shutdown()
 
-    def feedback_callback(self, feedback_msg: Fibonacci.Feedback) -> None:
-        self.get_logger().info('Received feedback: {0}'.format(feedback_msg.sequence))
+    def feedback_callback(self, feedback_msg: FeedbackMessage[Fibonacci.Feedback]) -> None:
+        self.get_logger().info('Received feedback: {0}'.format(feedback_msg.feedback))
 
 
 def main(args: list[str] | None = None) -> None:

--- a/action_tutorials/action_tutorials_py/action_tutorials_py/fibonacci_action_client.py
+++ b/action_tutorials/action_tutorials_py/action_tutorials_py/fibonacci_action_client.py
@@ -19,6 +19,8 @@
 # ros2 run action_tutorials_py fibonacci_action_client --ros-args -p
 # "action_client_configure_introspection:=contents"
 
+from typing import List
+
 from example_interfaces.action import Fibonacci
 
 from rcl_interfaces.msg import SetParametersResult
@@ -30,18 +32,19 @@ from rclpy.node import Node
 from rclpy.parameter import Parameter
 from rclpy.qos import qos_profile_system_default
 from rclpy.service_introspection import ServiceIntrospectionState
+from rclpy.task import Future
 
 
 class FibonacciActionClient(Node):
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__('fibonacci_action_client')
-        self._action_client = ActionClient(self, Fibonacci, 'fibonacci')
+        self._action_client: ActionClient = ActionClient(self, Fibonacci, 'fibonacci')
         self.add_on_set_parameters_callback(self.on_set_parameters_callback)
         self.add_post_set_parameters_callback(self.on_post_set_parameters_callback)
         self.declare_parameter('action_client_configure_introspection', 'disabled')
 
-    def _check_parameter(self, parameter_list, parameter_name):
+    def _check_parameter(self, parameter_list: List[Parameter], parameter_name: str):
         result = SetParametersResult()
         result.successful = True
         for param in parameter_list:
@@ -60,10 +63,10 @@ class FibonacciActionClient(Node):
 
         return result
 
-    def on_set_parameters_callback(self, parameter_list):
+    def on_set_parameters_callback(self, parameter_list: List[Parameter]) -> SetParametersResult:
         return self._check_parameter(parameter_list, 'action_client_configure_introspection')
 
-    def on_post_set_parameters_callback(self, parameter_list):
+    def on_post_set_parameters_callback(self, parameter_list: List[Parameter]) -> None:
         for param in parameter_list:
             if param.name != 'action_client_configure_introspection':
                 continue
@@ -81,7 +84,7 @@ class FibonacciActionClient(Node):
                                                         introspection_state)
             break
 
-    def send_goal(self, order):
+    def send_goal(self, order: int) -> None:
         goal_msg = Fibonacci.Goal()
         goal_msg.order = order
 
@@ -93,8 +96,12 @@ class FibonacciActionClient(Node):
 
         self._send_goal_future.add_done_callback(self.goal_response_callback)
 
-    def goal_response_callback(self, future):
+    def goal_response_callback(self, future: Future) -> None:
         goal_handle = future.result()
+
+        if goal_handle is None:
+            self.get_logger().error('Exception while calling service')
+            return
 
         if not goal_handle.accepted:
             self.get_logger().info('Goal rejected :(')
@@ -106,17 +113,22 @@ class FibonacciActionClient(Node):
 
         self._get_result_future.add_done_callback(self.get_result_callback)
 
-    def get_result_callback(self, future):
-        result = future.result().result
+    def get_result_callback(self, future: Future) -> None:
+        future_result = future.result()
+
+        if future_result is None:
+            self.get_logger().error('Exception while getting result')
+            return
+        result = future_result.result
         self.get_logger().info('Result: {0}'.format(result.sequence))
         rclpy.shutdown()
 
-    def feedback_callback(self, feedback_msg):
+    def feedback_callback(self, feedback_msg: Fibonacci.Impl.FeedbackMessage):
         feedback = feedback_msg.feedback
         self.get_logger().info('Received feedback: {0}'.format(feedback.sequence))
 
 
-def main(args=None):
+def main(args: List[str] | None = None) -> None:
     try:
         with rclpy.init(args=args):
             action_client = FibonacciActionClient()

--- a/action_tutorials/action_tutorials_py/action_tutorials_py/fibonacci_action_client.py
+++ b/action_tutorials/action_tutorials_py/action_tutorials_py/fibonacci_action_client.py
@@ -19,6 +19,8 @@
 # ros2 run action_tutorials_py fibonacci_action_client --ros-args -p
 # "action_client_configure_introspection:=contents"
 
+from typing import Union
+
 from example_interfaces.action import Fibonacci
 
 from rcl_interfaces.msg import SetParametersResult
@@ -137,7 +139,7 @@ class FibonacciActionClient(Node):
         self.get_logger().info('Received feedback: {0}'.format(feedback_msg.feedback))
 
 
-def main(args: list[str] | None = None) -> None:
+def main(args: Union[list[str], None] = None) -> None:
     try:
         with rclpy.init(args=args):
             action_client = FibonacciActionClient()

--- a/action_tutorials/action_tutorials_py/action_tutorials_py/fibonacci_action_server.py
+++ b/action_tutorials/action_tutorials_py/action_tutorials_py/fibonacci_action_server.py
@@ -14,7 +14,6 @@
 # limitations under the License.import time
 
 import time
-from typing import Any
 
 from action_msgs.srv._cancel_goal import CancelGoal
 
@@ -37,21 +36,17 @@ class FibonacciActionServer(Node):
 
     def __init__(self) -> None:
         super().__init__('fibonacci_action_server')
-        self._action_server: ActionServer[
-            Fibonacci.Goal,
-            Fibonacci.Result,
-            Fibonacci.Feedback
-        ] = ActionServer(
-                self,
-                Fibonacci,
-                'fibonacci',
-                self.execute_callback,
-                cancel_callback=self.cancel_callback)
+        self._action_server = ActionServer(
+            self,
+            Fibonacci,
+            'fibonacci',
+            self.execute_callback,
+            cancel_callback=self.cancel_callback)
         self.add_on_set_parameters_callback(self.on_set_parameters_callback)
         self.add_post_set_parameters_callback(self.on_post_set_parameters_callback)
         self.declare_parameter('action_server_configure_introspection', 'disabled')
 
-    def _check_parameter(self, parameter_list: list[Parameter[Any]],
+    def _check_parameter(self, parameter_list: list[Parameter[str]],
                          parameter_name: str) -> SetParametersResult:
         result = SetParametersResult()
         result.successful = True
@@ -72,10 +67,10 @@ class FibonacciActionServer(Node):
         return result
 
     def on_set_parameters_callback(self,
-                                   parameter_list: list[Parameter[Any]]) -> SetParametersResult:
+                                   parameter_list: list[Parameter[str]]) -> SetParametersResult:
         return self._check_parameter(parameter_list, 'action_server_configure_introspection')
 
-    def on_post_set_parameters_callback(self, parameter_list: list[Parameter[Any]]) -> None:
+    def on_post_set_parameters_callback(self, parameter_list: list[Parameter[str]]) -> None:
         for param in parameter_list:
             if param.name != 'action_server_configure_introspection':
                 continue
@@ -98,7 +93,8 @@ class FibonacciActionServer(Node):
             goal_handle: ServerGoalHandle[
                 Fibonacci.Goal,
                 Fibonacci.Result,
-                Fibonacci.Feedback
+                Fibonacci.Feedback,
+                Fibonacci.Impl
             ], ) -> Fibonacci.Result:
         self.get_logger().info('Executing goal...')
 
@@ -113,7 +109,7 @@ class FibonacciActionServer(Node):
             feedback_msg.sequence.append(
                 feedback_msg.sequence[i] + feedback_msg.sequence[i - 1])
             self.get_logger().info('Feedback: {0}'.format(feedback_msg.sequence))
-            goal_handle.publish_feedback(feedback_msg)  # type: ignore[arg-type]
+            goal_handle.publish_feedback(feedback_msg)
             time.sleep(1)
 
         goal_handle.succeed()

--- a/action_tutorials/action_tutorials_py/action_tutorials_py/fibonacci_action_server.py
+++ b/action_tutorials/action_tutorials_py/action_tutorials_py/fibonacci_action_server.py
@@ -15,6 +15,8 @@
 
 import time
 
+from typing import Union
+
 from example_interfaces.action import Fibonacci
 
 from rcl_interfaces.msg import SetParametersResult
@@ -127,7 +129,7 @@ class FibonacciActionServer(Node):
         return CancelResponse.ACCEPT
 
 
-def main(args: list[str] | None = None) -> None:
+def main(args: Union[list[str], None] = None) -> None:
     try:
         with rclpy.init(args=args):
             fibonacci_action_server = FibonacciActionServer()

--- a/action_tutorials/action_tutorials_py/action_tutorials_py/fibonacci_action_server.py
+++ b/action_tutorials/action_tutorials_py/action_tutorials_py/fibonacci_action_server.py
@@ -14,7 +14,9 @@
 # limitations under the License.import time
 
 import time
-from typing import List
+from typing import Any
+
+from action_msgs.srv._cancel_goal import CancelGoal
 
 from example_interfaces.action import Fibonacci
 
@@ -22,6 +24,7 @@ from rcl_interfaces.msg import SetParametersResult
 
 import rclpy
 from rclpy.action import ActionServer, CancelResponse
+from rclpy.action.server import ServerGoalHandle
 from rclpy.executors import ExternalShutdownException
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
@@ -34,17 +37,21 @@ class FibonacciActionServer(Node):
 
     def __init__(self) -> None:
         super().__init__('fibonacci_action_server')
-        self._action_server: ActionServer = ActionServer(
-            self,
-            Fibonacci,
-            'fibonacci',
-            self.execute_callback,
-            cancel_callback=self.cancel_callback)
+        self._action_server: ActionServer[
+            Fibonacci.Goal,
+            Fibonacci.Result,
+            Fibonacci.Feedback
+        ] = ActionServer(
+                self,
+                Fibonacci,
+                'fibonacci',
+                self.execute_callback,
+                cancel_callback=self.cancel_callback)
         self.add_on_set_parameters_callback(self.on_set_parameters_callback)
         self.add_post_set_parameters_callback(self.on_post_set_parameters_callback)
         self.declare_parameter('action_server_configure_introspection', 'disabled')
 
-    def _check_parameter(self, parameter_list: List[Parameter],
+    def _check_parameter(self, parameter_list: list[Parameter[Any]],
                          parameter_name: str) -> SetParametersResult:
         result = SetParametersResult()
         result.successful = True
@@ -59,15 +66,16 @@ class FibonacciActionServer(Node):
 
             if param.value not in ('disabled', 'metadata', 'contents'):
                 result.successful = False
-                result.reason = "must be one of 'disabled', 'metadata', or 'contents"
+                result.reason = "must be one of 'disabled', 'metadata', or 'contents'"
                 break
 
         return result
 
-    def on_set_parameters_callback(self, parameter_list: List[Parameter]) -> SetParametersResult:
+    def on_set_parameters_callback(self,
+                                   parameter_list: list[Parameter[Any]]) -> SetParametersResult:
         return self._check_parameter(parameter_list, 'action_server_configure_introspection')
 
-    def on_post_set_parameters_callback(self, parameter_list: List[Parameter]) -> None:
+    def on_post_set_parameters_callback(self, parameter_list: list[Parameter[Any]]) -> None:
         for param in parameter_list:
             if param.name != 'action_server_configure_introspection':
                 continue
@@ -85,7 +93,13 @@ class FibonacciActionServer(Node):
                                                         introspection_state)
             break
 
-    def execute_callback(self, goal_handle) -> Fibonacci.Result:
+    def execute_callback(
+            self,
+            goal_handle: ServerGoalHandle[
+                Fibonacci.Goal,
+                Fibonacci.Result,
+                Fibonacci.Feedback
+            ], ) -> Fibonacci.Result:
         self.get_logger().info('Executing goal...')
 
         feedback_msg = Fibonacci.Feedback()
@@ -99,7 +113,7 @@ class FibonacciActionServer(Node):
             feedback_msg.sequence.append(
                 feedback_msg.sequence[i] + feedback_msg.sequence[i - 1])
             self.get_logger().info('Feedback: {0}'.format(feedback_msg.sequence))
-            goal_handle.publish_feedback(feedback_msg)
+            goal_handle.publish_feedback(feedback_msg)  # type: ignore[arg-type]
             time.sleep(1)
 
         goal_handle.succeed()
@@ -108,12 +122,12 @@ class FibonacciActionServer(Node):
         result.sequence = feedback_msg.sequence
         return result
 
-    def cancel_callback(self, goal_handle) -> CancelResponse:
+    def cancel_callback(self, goal_handle: CancelGoal.Request) -> CancelResponse:
         self.get_logger().info('Canceling goal...')
         return CancelResponse.ACCEPT
 
 
-def main(args: List[str] | None = None) -> None:
+def main(args: list[str] | None = None) -> None:
     try:
         with rclpy.init(args=args):
             fibonacci_action_server = FibonacciActionServer()

--- a/action_tutorials/action_tutorials_py/action_tutorials_py/fibonacci_action_server.py
+++ b/action_tutorials/action_tutorials_py/action_tutorials_py/fibonacci_action_server.py
@@ -15,8 +15,6 @@
 
 import time
 
-from action_msgs.srv._cancel_goal import CancelGoal
-
 from example_interfaces.action import Fibonacci
 
 from rcl_interfaces.msg import SetParametersResult
@@ -118,7 +116,13 @@ class FibonacciActionServer(Node):
         result.sequence = feedback_msg.sequence
         return result
 
-    def cancel_callback(self, goal_handle: CancelGoal.Request) -> CancelResponse:
+    def cancel_callback(
+            self,
+            goal_handle: ServerGoalHandle[
+                Fibonacci.Goal,
+                Fibonacci.Result,
+                Fibonacci.Feedback,
+                Fibonacci.Impl]) -> CancelResponse:
         self.get_logger().info('Canceling goal...')
         return CancelResponse.ACCEPT
 

--- a/action_tutorials/action_tutorials_py/action_tutorials_py/fibonacci_action_server.py
+++ b/action_tutorials/action_tutorials_py/action_tutorials_py/fibonacci_action_server.py
@@ -14,6 +14,7 @@
 # limitations under the License.import time
 
 import time
+from typing import List
 
 from example_interfaces.action import Fibonacci
 
@@ -31,9 +32,9 @@ from rclpy.service_introspection import ServiceIntrospectionState
 
 class FibonacciActionServer(Node):
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__('fibonacci_action_server')
-        self._action_server = ActionServer(
+        self._action_server: ActionServer = ActionServer(
             self,
             Fibonacci,
             'fibonacci',
@@ -43,7 +44,8 @@ class FibonacciActionServer(Node):
         self.add_post_set_parameters_callback(self.on_post_set_parameters_callback)
         self.declare_parameter('action_server_configure_introspection', 'disabled')
 
-    def _check_parameter(self, parameter_list, parameter_name):
+    def _check_parameter(self, parameter_list: List[Parameter],
+                         parameter_name: str) -> SetParametersResult:
         result = SetParametersResult()
         result.successful = True
         for param in parameter_list:
@@ -62,10 +64,10 @@ class FibonacciActionServer(Node):
 
         return result
 
-    def on_set_parameters_callback(self, parameter_list) -> SetParametersResult:
+    def on_set_parameters_callback(self, parameter_list: List[Parameter]) -> SetParametersResult:
         return self._check_parameter(parameter_list, 'action_server_configure_introspection')
 
-    def on_post_set_parameters_callback(self, parameter_list):
+    def on_post_set_parameters_callback(self, parameter_list: List[Parameter]) -> None:
         for param in parameter_list:
             if param.name != 'action_server_configure_introspection':
                 continue
@@ -83,7 +85,7 @@ class FibonacciActionServer(Node):
                                                         introspection_state)
             break
 
-    def execute_callback(self, goal_handle):
+    def execute_callback(self, goal_handle) -> Fibonacci.Result:
         self.get_logger().info('Executing goal...')
 
         feedback_msg = Fibonacci.Feedback()
@@ -95,7 +97,7 @@ class FibonacciActionServer(Node):
                 self.get_logger().info('Goal canceled')
                 return Fibonacci.Result()
             feedback_msg.sequence.append(
-                feedback_msg.sequence[i] + feedback_msg.sequence[i-1])
+                feedback_msg.sequence[i] + feedback_msg.sequence[i - 1])
             self.get_logger().info('Feedback: {0}'.format(feedback_msg.sequence))
             goal_handle.publish_feedback(feedback_msg)
             time.sleep(1)
@@ -106,12 +108,12 @@ class FibonacciActionServer(Node):
         result.sequence = feedback_msg.sequence
         return result
 
-    def cancel_callback(self, goal_handle):
+    def cancel_callback(self, goal_handle) -> CancelResponse:
         self.get_logger().info('Canceling goal...')
         return CancelResponse.ACCEPT
 
 
-def main(args=None):
+def main(args: List[str] | None = None) -> None:
     try:
         with rclpy.init(args=args):
             fibonacci_action_server = FibonacciActionServer()

--- a/action_tutorials/action_tutorials_py/package.xml
+++ b/action_tutorials/action_tutorials_py/package.xml
@@ -21,6 +21,7 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>ament_mypy</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/action_tutorials/action_tutorials_py/test/test_copyright.py
+++ b/action_tutorials/action_tutorials_py/test/test_copyright.py
@@ -18,6 +18,6 @@ import pytest
 
 @pytest.mark.copyright
 @pytest.mark.linter
-def test_copyright():
+def test_copyright() -> None:
     rc = main(argv=['.', 'test'])
     assert rc == 0, 'Found errors'

--- a/action_tutorials/action_tutorials_py/test/test_flake8.py
+++ b/action_tutorials/action_tutorials_py/test/test_flake8.py
@@ -18,7 +18,7 @@ import pytest
 
 @pytest.mark.flake8
 @pytest.mark.linter
-def test_flake8():
+def test_flake8() -> None:
     rc, errors = main_with_errors(argv=[])
     assert rc == 0, \
         'Found %d code style errors / warnings:\n' % len(errors) + \

--- a/action_tutorials/action_tutorials_py/test/test_mypy.py
+++ b/action_tutorials/action_tutorials_py/test/test_mypy.py
@@ -1,0 +1,21 @@
+# Copyright 2019 Canonical, Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from ament_mypy.main import main
+
+
+def test_mypy():
+    rc = main(argv=['--exclude', 'test'])
+    assert rc == 0, 'Found code style errors / warnings'

--- a/action_tutorials/action_tutorials_py/test/test_mypy.py
+++ b/action_tutorials/action_tutorials_py/test/test_mypy.py
@@ -17,5 +17,5 @@ from ament_mypy.main import main
 
 
 def test_mypy():
-    rc = main(argv=['--exclude', 'test'])
+    rc = main(argv=[])
     assert rc == 0, 'Found code style errors / warnings'

--- a/action_tutorials/action_tutorials_py/test/test_mypy.py
+++ b/action_tutorials/action_tutorials_py/test/test_mypy.py
@@ -16,6 +16,6 @@
 from ament_mypy.main import main
 
 
-def test_mypy():
+def test_mypy() -> None:
     rc = main(argv=[])
     assert rc == 0, 'Found code style errors / warnings'

--- a/action_tutorials/action_tutorials_py/test/test_pep257.py
+++ b/action_tutorials/action_tutorials_py/test/test_pep257.py
@@ -18,6 +18,6 @@ import pytest
 
 @pytest.mark.linter
 @pytest.mark.pep257
-def test_pep257():
+def test_pep257() -> None:
     rc = main(argv=['.', 'test'])
     assert rc == 0, 'Found code style errors / warnings'

--- a/lifecycle_py/launch/lifecycle_demo_launch.py
+++ b/lifecycle_py/launch/lifecycle_demo_launch.py
@@ -17,7 +17,7 @@ from launch_ros.actions import LifecycleNode
 from launch_ros.actions import Node
 
 
-def generate_launch_description():
+def generate_launch_description() -> LaunchDescription:
     return LaunchDescription([
         LifecycleNode(package='lifecycle_py', executable='lifecycle_talker',
                       name='lc_talker', namespace='', output='screen'),

--- a/lifecycle_py/lifecycle_py/talker.py
+++ b/lifecycle_py/lifecycle_py/talker.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+from typing import Any, Optional
 
 import example_interfaces.msg
 
@@ -34,14 +34,14 @@ from rclpy.timer import Timer
 class LifecycleTalker(Node):
     """Our lifecycle talker node."""
 
-    def __init__(self, node_name, **kwargs):
+    def __init__(self, node_name: str, **kwargs: Any) -> None:
         """Construct the node."""
         self._count: int = 0
-        self._pub: Optional[Publisher] = None
+        self._pub: Optional[Publisher[example_interfaces.msg.String]] = None
         self._timer: Optional[Timer] = None
         super().__init__(node_name, **kwargs)
 
-    def publish(self):
+    def publish(self) -> None:
         """Publish a new message when enabled."""
         msg = example_interfaces.msg.String()
         msg.data = 'Lifecycle HelloWorld #' + str(self._count)
@@ -114,8 +114,10 @@ class LifecycleTalker(Node):
             TransitionCallbackReturn.FAILURE transitions to "inactive".
             TransitionCallbackReturn.ERROR or any uncaught exceptions to "errorprocessing"
         """
-        self.destroy_timer(self._timer)
-        self.destroy_publisher(self._pub)
+        if self._timer is not None:
+            self.destroy_timer(self._timer)
+        if self._pub is not None:
+            self.destroy_publisher(self._pub)
 
         self.get_logger().info('on_cleanup() is called.')
         return TransitionCallbackReturn.SUCCESS
@@ -133,8 +135,10 @@ class LifecycleTalker(Node):
             TransitionCallbackReturn.FAILURE transitions to "inactive".
             TransitionCallbackReturn.ERROR or any uncaught exceptions to "errorprocessing"
         """
-        self.destroy_timer(self._timer)
-        self.destroy_publisher(self._pub)
+        if self._timer is not None:
+            self.destroy_timer(self._timer)
+        if self._pub is not None:
+            self.destroy_publisher(self._pub)
 
         self.get_logger().info('on_shutdown() is called.')
         return TransitionCallbackReturn.SUCCESS
@@ -144,7 +148,7 @@ class LifecycleTalker(Node):
 # as a regular node. This means we can spawn a
 # node, give it a name and add it to the executor.
 
-def main():
+def main() -> None:
     try:
         with rclpy.init():
             executor = SingleThreadedExecutor()

--- a/lifecycle_py/package.xml
+++ b/lifecycle_py/package.xml
@@ -22,6 +22,7 @@
   <test_depend>ament_xmllint</test_depend>
   <test_depend>lifecycle</test_depend>
   <test_depend>ros_testing</test_depend>
+  <test_depend>ament_mypy</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/lifecycle_py/test/test_flake8.py
+++ b/lifecycle_py/test/test_flake8.py
@@ -18,7 +18,7 @@ import pytest
 
 @pytest.mark.flake8
 @pytest.mark.linter
-def test_flake8():
+def test_flake8() -> None:
     rc, errors = main_with_errors(argv=[])
     assert rc == 0, \
         'Found %d code style errors / warnings:\n' % len(errors) + \

--- a/lifecycle_py/test/test_lifecycle.py
+++ b/lifecycle_py/test/test_lifecycle.py
@@ -13,19 +13,24 @@
 # limitations under the License.
 
 import re
+from typing import Any, Dict, Tuple
 import unittest
 
 import launch
+
 import launch.actions
 import launch.event_handlers.on_process_start
 
 import launch_ros.actions
+
 import launch_ros.events
 import launch_ros.events.lifecycle
 
 import launch_testing
 import launch_testing.actions
 import launch_testing.asserts
+from launch_testing.io_handler import ActiveIoHandler
+from launch_testing.proc_info_handler import ActiveProcInfoHandler
 
 import lifecycle_msgs.msg
 
@@ -33,7 +38,7 @@ import pytest
 
 
 @pytest.mark.rostest
-def generate_test_description():
+def generate_test_description() -> Tuple[launch.LaunchDescription, Dict[str, Any]]:
     talker_node = launch_ros.actions.LifecycleNode(
         package='lifecycle_py', executable='lifecycle_talker',
         name='lc_talker', namespace='', output='screen'
@@ -120,7 +125,10 @@ def generate_test_description():
 
 class TestLifecyclePubSub(unittest.TestCase):
 
-    def test_talker_lifecycle(self, proc_info, proc_output, talker_node, listener_node):
+    def test_talker_lifecycle(self, proc_info: ActiveProcInfoHandler,
+                              proc_output: ActiveIoHandler,
+                              talker_node: launch_ros.actions.LifecycleNode,
+                              listener_node: launch_ros.actions.Node) -> None:
         """Test lifecycle talker."""
         proc_output.assertWaitFor('on_configure() is called', process=talker_node, timeout=5)
         proc_output.assertWaitFor('on_activate() is called', process=talker_node, timeout=10)
@@ -140,6 +148,7 @@ class TestLifecyclePubSub(unittest.TestCase):
 @launch_testing.post_shutdown_test()
 class TestLifecyclePubSubAfterShutdown(unittest.TestCase):
 
-    def test_talker_graceful_shutdown(self, proc_info, talker_node):
+    def test_talker_graceful_shutdown(self, proc_info: ActiveProcInfoHandler,
+                                      talker_node: launch_ros.actions.LifecycleNode) -> None:
         """Test lifecycle talker graceful shutdown."""
         launch_testing.asserts.assertExitCodes(proc_info, process=talker_node)

--- a/lifecycle_py/test/test_mypy.py
+++ b/lifecycle_py/test/test_mypy.py
@@ -1,4 +1,4 @@
-# Copyright 2015 Open Source Robotics Foundation, Inc.
+# Copyright 2019 Canonical, Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ament_copyright.main import main
-import pytest
+
+from ament_mypy.main import main
 
 
-@pytest.mark.copyright
-@pytest.mark.linter
-def test_copyright() -> None:
-    rc = main(argv=['.', 'test'])
-    assert rc == 0, 'Found errors'
+def test_mypy() -> None:
+    rc = main(argv=[])
+    assert rc == 0, 'Found code style errors / warnings'

--- a/lifecycle_py/test/test_pep257.py
+++ b/lifecycle_py/test/test_pep257.py
@@ -18,6 +18,6 @@ import pytest
 
 @pytest.mark.linter
 @pytest.mark.pep257
-def test_pep257():
+def test_pep257() -> None:
     rc = main(argv=['.', 'test'])
     assert rc == 0, 'Found code style errors / warnings'


### PR DESCRIPTION
## Description
This PR adds `ament_mypy` support and resolves existing type-checking errors in the `action_tutorials_py` package.
<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
- Added explicit is not None checks for future results to resolve [union-attr] errors 
- Added standard type hints for the ActionServer and callbacks. Following @InvincibleRMC recommendation on first commit, I actively explored applying `mypy --strict`. While doing so, it triggered internal rclpy type conflicts. This occurs because `publish_feedback()` expects `FeedbackMessage[FeedbackT]` as per the type hints, while the tutorial publishes a **Fibonacci.Feedback** message directly. The warning is suppressed with # type: ignore[arg-type] to keep the example consistent.
- Removed the --exclude test argument from `test_mypy` for future type checking
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #766

### Is this user-facing behavior change?
No, these are strictly internal static typing improvements.
<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?
Yes, I used ChatGPT to understand the errors thrown from `mypy`
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information
This is one of my first contributions to ROS2 Repositories. I'm very open to any feedback on my approach or styling to ensure this meets the project's standards!. 
Thank You :smiling_face_with_tear: 
<!--
If applicable, provide any additional context or details about the changes.
-->
