### PR TITLE
Use std::endian

### DIFF
--- a/action_tutorials/action_tutorials_cpp/CMakeLists.txt
+++ b/action_tutorials/action_tutorials_cpp/CMakeLists.txt
@@ -1,23 +1,13 @@
 cmake_minimum_required(VERSION 3.20)
 project(action_tutorials_cpp)
 
-# Default to C99
-if(NOT CMAKE_C_STANDARD)
-  set(CMAKE_C_STANDARD 99)
-endif()
-
-# Default to C++17
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-endif()
-
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros_core REQUIRED)
 find_package(example_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
@@ -38,6 +28,7 @@ target_link_libraries(action_tutorials PRIVATE
   rclcpp::rclcpp
   rclcpp_action::rclcpp_action
   rclcpp_components::component
+  ament_cmake_ros_core::ament_ros_defaults
 )
 
 install(TARGETS action_tutorials

--- a/action_tutorials/action_tutorials_cpp/package.xml
+++ b/action_tutorials/action_tutorials_cpp/package.xml
@@ -14,6 +14,7 @@
   <author email="mabel@openrobotics.org">Mabel Zhang</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros_core</buildtool_depend>
 
   <depend>example_interfaces</depend>
   <depend>rclcpp</depend>

--- a/composition/CMakeLists.txt
+++ b/composition/CMakeLists.txt
@@ -2,17 +2,12 @@ cmake_minimum_required(VERSION 3.20)
 
 project(composition)
 
-# Default to C++17
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-endif()
-
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros_core REQUIRED)
 find_package(example_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
@@ -31,6 +26,7 @@ target_compile_definitions(talker_component
 target_link_libraries(talker_component PUBLIC
   rclcpp::rclcpp
   rclcpp_components::component
+  ament_cmake_ros_core::ament_ros_defaults
   example_interfaces::example_interfaces)
 rclcpp_components_register_nodes(talker_component "composition::Talker")
 set(node_plugins "${node_plugins}composition::Talker;$<TARGET_FILE:talker_component>\n")
@@ -42,6 +38,7 @@ target_compile_definitions(listener_component
 target_link_libraries(listener_component PUBLIC
   rclcpp::rclcpp
   rclcpp_components::component
+  ament_cmake_ros_core::ament_ros_defaults
   example_interfaces::example_interfaces)
 rclcpp_components_register_nodes(listener_component "composition::Listener")
 set(node_plugins "${node_plugins}composition::Listener;$<TARGET_FILE:listener_component>\n")
@@ -53,6 +50,7 @@ target_compile_definitions(node_like_listener_component
 target_link_libraries(node_like_listener_component PUBLIC
   rclcpp::rclcpp
   rclcpp_components::component
+  ament_cmake_ros_core::ament_ros_defaults
   example_interfaces::example_interfaces)
 rclcpp_components_register_nodes(node_like_listener_component "composition::NodeLikeListener")
 set(node_plugins "${node_plugins}composition::NodeLikeListener;$<TARGET_FILE:node_like_listener_component>\n")
@@ -64,7 +62,8 @@ target_compile_definitions(server_component
 target_link_libraries(server_component PUBLIC
   example_interfaces::example_interfaces
   rclcpp::rclcpp
-  rclcpp_components::component)
+  rclcpp_components::component
+  ament_cmake_ros_core::ament_ros_defaults)
 rclcpp_components_register_nodes(server_component "composition::Server")
 set(node_plugins "${node_plugins}composition::Server;$<TARGET_FILE:server_component>\n")
 
@@ -75,7 +74,8 @@ target_compile_definitions(client_component
 target_link_libraries(client_component PUBLIC
   example_interfaces::example_interfaces
   rclcpp::rclcpp
-  rclcpp_components::component)
+  rclcpp_components::component
+  ament_cmake_ros_core::ament_ros_defaults)
 rclcpp_components_register_nodes(client_component "composition::Client")
 set(node_plugins "${node_plugins}composition::Client;$<TARGET_FILE:client_component>\n")
 
@@ -93,7 +93,8 @@ target_link_libraries(manual_composition PRIVATE
   listener_component
   server_component
   client_component
-  rclcpp::rclcpp)
+  rclcpp::rclcpp
+  ament_cmake_ros_core::ament_ros_defaults)
 
 add_executable(linktime_composition
   src/linktime_composition.cpp)
@@ -112,14 +113,16 @@ target_link_libraries(linktime_composition PRIVATE
   ${libs}
   class_loader::class_loader
   rclcpp::rclcpp
-  rclcpp_components::component)
+  rclcpp_components::component
+  ament_cmake_ros_core::ament_ros_defaults)
 
 add_executable(dlopen_composition
   src/dlopen_composition.cpp)
 target_link_libraries(dlopen_composition PRIVATE
   class_loader::class_loader
   rclcpp::rclcpp
-  rclcpp_components::component)
+  rclcpp_components::component
+  ament_cmake_ros_core::ament_ros_defaults)
 
 install(TARGETS
   talker_component

--- a/composition/package.xml
+++ b/composition/package.xml
@@ -14,6 +14,7 @@
   <author email="mabel@openrobotics.org">Mabel Zhang</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros_core</buildtool_depend>
 
   <build_depend>example_interfaces</build_depend>
   <build_depend>rclcpp</build_depend>

--- a/demo_nodes_cpp/CMakeLists.txt
+++ b/demo_nodes_cpp/CMakeLists.txt
@@ -2,17 +2,12 @@ cmake_minimum_required(VERSION 3.20)
 
 project(demo_nodes_cpp)
 
-# Default to C++17
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-endif()
-
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros_core REQUIRED)
 find_package(example_interfaces REQUIRED)
 find_package(rcl REQUIRED)
 find_package(rcl_interfaces REQUIRED)
@@ -31,6 +26,7 @@ function(custom_executable subfolder target)
     "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
   target_link_libraries(${target} PRIVATE
     ${ARG_DEPENDENCIES}
+    ament_cmake_ros_core::ament_ros_defaults
   )
   install(TARGETS ${target}
     DESTINATION lib/${PROJECT_NAME})
@@ -51,6 +47,7 @@ target_include_directories(allocator_tutorial PRIVATE
 target_link_libraries(allocator_tutorial PRIVATE
   rclcpp::rclcpp
   example_interfaces::example_interfaces
+  ament_cmake_ros_core::ament_ros_defaults
 )
 install(TARGETS allocator_tutorial
   DESTINATION lib/${PROJECT_NAME})
@@ -87,6 +84,8 @@ function(create_demo_library plugin executable)
     "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
   target_link_libraries(${library} PRIVATE
     ${ARG_DEPENDENCIES}
+    rclcpp::rclcpp
+    ament_cmake_ros_core::ament_ros_defaults
   )
   install(TARGETS ${library}
     ARCHIVE DESTINATION lib

--- a/demo_nodes_cpp/package.xml
+++ b/demo_nodes_cpp/package.xml
@@ -16,6 +16,7 @@
   <author email="william@osrfoundation.org">William Woodall</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros_core</buildtool_depend>
 
   <build_depend>example_interfaces</build_depend>
   <build_depend>rcl</build_depend>

--- a/demo_nodes_cpp_native/CMakeLists.txt
+++ b/demo_nodes_cpp_native/CMakeLists.txt
@@ -8,17 +8,12 @@ if(NOT rmw_fastrtps_cpp_FOUND)
   return()
 endif()
 
-# Default to C++17
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-endif()
-
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros_core REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(rmw REQUIRED)
@@ -33,7 +28,8 @@ target_compile_definitions(talker_native
 target_link_libraries(talker_native PUBLIC
   example_interfaces::example_interfaces
   rclcpp::rclcpp
-  rclcpp_components::component)
+  rclcpp_components::component
+  ament_cmake_ros_core::ament_ros_defaults)
 target_include_directories(talker_native PRIVATE
   ${rmw_fastrtps_cpp_INCLUDE_DIRS})
 target_link_libraries(talker_native PRIVATE

--- a/demo_nodes_cpp_native/package.xml
+++ b/demo_nodes_cpp_native/package.xml
@@ -16,6 +16,7 @@
   <author email="mabel@openrobotics.org">Mabel Zhang</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros_core</buildtool_depend>
 
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/dummy_robot/dummy_map_server/CMakeLists.txt
+++ b/dummy_robot/dummy_map_server/CMakeLists.txt
@@ -2,16 +2,12 @@ cmake_minimum_required(VERSION 3.20)
 
 project(dummy_map_server)
 
-# Default to C++17
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros_core REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rmw REQUIRED)
@@ -20,6 +16,7 @@ add_executable(dummy_map_server src/dummy_map_server.cpp)
 target_link_libraries(dummy_map_server PRIVATE
   rclcpp::rclcpp
   nav_msgs::nav_msgs
+  ament_cmake_ros_core::ament_ros_defaults
 )
 
 install(TARGETS dummy_map_server

--- a/dummy_robot/dummy_map_server/package.xml
+++ b/dummy_robot/dummy_map_server/package.xml
@@ -16,6 +16,7 @@
   <author email="mabel@openrobotics.org">Mabel Zhang</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros_core</buildtool_depend>
 
   <build_depend>nav_msgs</build_depend>
   <build_depend>rclcpp</build_depend>

--- a/dummy_robot/dummy_sensors/CMakeLists.txt
+++ b/dummy_robot/dummy_sensors/CMakeLists.txt
@@ -2,16 +2,12 @@ cmake_minimum_required(VERSION 3.20)
 
 project(dummy_sensors)
 
-# Default to C++17
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-endif()
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros_core REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rmw REQUIRED)
 find_package(sensor_msgs REQUIRED)
@@ -20,12 +16,14 @@ add_executable(dummy_laser src/dummy_laser.cpp)
 target_link_libraries(dummy_laser PRIVATE
   rclcpp::rclcpp
   sensor_msgs::sensor_msgs
+  ament_cmake_ros_core::ament_ros_defaults
 )
 
 add_executable(dummy_joint_states src/dummy_joint_states.cpp)
 target_link_libraries(dummy_joint_states PRIVATE
   rclcpp::rclcpp
   sensor_msgs::sensor_msgs
+  ament_cmake_ros_core::ament_ros_defaults
 )
 install(TARGETS
   dummy_joint_states

--- a/dummy_robot/dummy_sensors/package.xml
+++ b/dummy_robot/dummy_sensors/package.xml
@@ -16,6 +16,7 @@
   <author email="mabel@openrobotics.org">Mabel Zhang</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros_core</buildtool_depend>
 
   <build_depend>rclcpp</build_depend>
   <build_depend>sensor_msgs</build_depend>

--- a/image_tools/CMakeLists.txt
+++ b/image_tools/CMakeLists.txt
@@ -2,17 +2,12 @@ cmake_minimum_required(VERSION 3.20)
 
 project(image_tools)
 
-# Default to C++17
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-endif()
-
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros_core REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(sensor_msgs REQUIRED)
@@ -37,7 +32,8 @@ target_link_libraries(${PROJECT_NAME}
   std_msgs::std_msgs
   example_interfaces::example_interfaces
   rclcpp_components::component
-  ${OpenCV_LIBS})
+  ${OpenCV_LIBS}
+  ament_cmake_ros_core::ament_ros_defaults)
 rclcpp_components_register_node(${PROJECT_NAME} PLUGIN "image_tools::Cam2Image" EXECUTABLE cam2image)
 rclcpp_components_register_node(${PROJECT_NAME} PLUGIN "image_tools::ShowImage" EXECUTABLE showimage)
 

--- a/image_tools/include/image_tools/cv_mat_sensor_msgs_image_type_adapter.hpp
+++ b/image_tools/include/image_tools/cv_mat_sensor_msgs_image_type_adapter.hpp
@@ -18,6 +18,7 @@
 #include <cstddef>
 #include <memory>
 #include <variant>  // NOLINT[build/include_order]
+#include <bit>
 
 #include "opencv2/core/mat.hpp"
 
@@ -28,26 +29,6 @@
 
 namespace image_tools
 {
-namespace detail
-{
-// TODO(audrow): Replace with std::endian when C++ 20 is available
-// https://en.cppreference.com/w/cpp/types/endian
-enum class endian
-{
-#ifdef _WIN32
-  little = 0,
-  big    = 1,
-  native = little
-#else
-  little = __ORDER_LITTLE_ENDIAN__,
-  big    = __ORDER_BIG_ENDIAN__,
-  native = __BYTE_ORDER__
-#endif
-};
-
-}  // namespace detail
-
-
 // TODO(wjwwood): make this as a contribution to vision_opencv's cv_bridge package.
 //   Specifically the CvImage class, which is this is most similar to.
 /// A potentially owning, potentially non-owning, container of a cv::Mat and ROS header.
@@ -85,7 +66,7 @@ enum class endian
  */
 class ROSCvMatContainer
 {
-  static constexpr bool is_bigendian_system = detail::endian::native == detail::endian::big;
+  static constexpr bool is_bigendian_system = std::endian::native == std::endian::big;
 
 public:
   using SensorMsgsImageStorageType = std::variant<

--- a/image_tools/include/image_tools/cv_mat_sensor_msgs_image_type_adapter.hpp
+++ b/image_tools/include/image_tools/cv_mat_sensor_msgs_image_type_adapter.hpp
@@ -15,10 +15,10 @@
 #ifndef IMAGE_TOOLS__CV_MAT_SENSOR_MSGS_IMAGE_TYPE_ADAPTER_HPP_
 #define IMAGE_TOOLS__CV_MAT_SENSOR_MSGS_IMAGE_TYPE_ADAPTER_HPP_
 
+#include <bit>
 #include <cstddef>
 #include <memory>
 #include <variant>  // NOLINT[build/include_order]
-#include <bit>
 
 #include "opencv2/core/mat.hpp"
 

--- a/image_tools/package.xml
+++ b/image_tools/package.xml
@@ -14,6 +14,7 @@
   <author email="mabel@openrobotics.org">Mabel Zhang</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros_core</buildtool_depend>
   <build_depend>libopencv-dev</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>rclcpp_components</build_depend>

--- a/intra_process_demo/CMakeLists.txt
+++ b/intra_process_demo/CMakeLists.txt
@@ -2,17 +2,12 @@ cmake_minimum_required(VERSION 3.20)
 
 project(intra_process_demo)
 
-# Default to C++17
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-endif()
-
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros_core REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rmw REQUIRED)
@@ -34,14 +29,16 @@ add_executable(two_node_pipeline
   src/two_node_pipeline/two_node_pipeline.cpp)
 target_link_libraries(two_node_pipeline
   rclcpp::rclcpp
-  example_interfaces::example_interfaces)
+  example_interfaces::example_interfaces
+  ament_cmake_ros_core::ament_ros_defaults)
 
   # Simple example of a cyclic pipeline which uses no allocation while iterating.
 add_executable(cyclic_pipeline
   src/cyclic_pipeline/cyclic_pipeline.cpp)
 target_link_libraries(cyclic_pipeline
   rclcpp::rclcpp
-  example_interfaces::example_interfaces)
+  example_interfaces::example_interfaces
+  ament_cmake_ros_core::ament_ros_defaults)
 
 # A single program with one of each of the image pipeline demo nodes.
 add_executable(image_pipeline_all_in_one
@@ -51,7 +48,8 @@ target_link_libraries(image_pipeline_all_in_one
   builtin_interfaces::builtin_interfaces
   sensor_msgs::sensor_msgs
   opencv_core
-  opencv_highgui)
+  opencv_highgui
+  ament_cmake_ros_core::ament_ros_defaults)
 
 # A single program with one of each of the image pipeline demo nodes, but two image views.
 add_executable(image_pipeline_with_two_image_view
@@ -61,7 +59,8 @@ target_link_libraries(image_pipeline_with_two_image_view
   builtin_interfaces::builtin_interfaces
   sensor_msgs::sensor_msgs
   opencv_core
-  opencv_highgui)
+  opencv_highgui
+  ament_cmake_ros_core::ament_ros_defaults)
 
 # A stand alone node which produces images from a camera using OpenCV.
 add_executable(camera_node
@@ -72,7 +71,8 @@ target_link_libraries(camera_node
   sensor_msgs::sensor_msgs
   opencv_core
   opencv_highgui
-  opencv_imgproc)
+  opencv_imgproc
+  ament_cmake_ros_core::ament_ros_defaults)
 
 # A stand alone node which adds some text to an image using OpenCV before passing it along.
 add_executable(watermark_node
@@ -82,7 +82,8 @@ target_link_libraries(watermark_node
   builtin_interfaces::builtin_interfaces
   sensor_msgs::sensor_msgs
   opencv_core
-  opencv_videoio)
+  opencv_videoio
+  ament_cmake_ros_core::ament_ros_defaults)
 
 # A stand alone node which consumes images and displays them using OpenCV.
 add_executable(image_view_node
@@ -92,7 +93,8 @@ target_link_libraries(image_view_node
   builtin_interfaces::builtin_interfaces
   sensor_msgs::sensor_msgs
   opencv_core
-  opencv_highgui)
+  opencv_highgui
+  ament_cmake_ros_core::ament_ros_defaults)
 
 install(TARGETS
   two_node_pipeline

--- a/intra_process_demo/package.xml
+++ b/intra_process_demo/package.xml
@@ -14,6 +14,7 @@
   <author email="william@osrfoundation.org">William Woodall</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros_core</buildtool_depend>
 
   <build_depend>libopencv-dev</build_depend>
   <build_depend>rclcpp</build_depend>

--- a/lifecycle/CMakeLists.txt
+++ b/lifecycle/CMakeLists.txt
@@ -2,17 +2,12 @@ cmake_minimum_required(VERSION 3.20)
 
 project(lifecycle)
 
-# Default to C++17
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-endif()
-
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros_core REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -26,6 +21,7 @@ target_link_libraries(lifecycle_talker PRIVATE
   rclcpp::rclcpp
   rclcpp_lifecycle::rclcpp_lifecycle
   example_interfaces::example_interfaces
+  ament_cmake_ros_core::ament_ros_defaults
 )
 add_executable(lifecycle_listener
   src/lifecycle_listener.cpp)
@@ -33,12 +29,14 @@ target_link_libraries(lifecycle_listener PRIVATE
   lifecycle_msgs::lifecycle_msgs
   rclcpp::rclcpp
   example_interfaces::example_interfaces
+  ament_cmake_ros_core::ament_ros_defaults
 )
 add_executable(lifecycle_service_client
   src/lifecycle_service_client.cpp)
 target_link_libraries(lifecycle_service_client PRIVATE
   lifecycle_msgs::lifecycle_msgs
   rclcpp::rclcpp
+  ament_cmake_ros_core::ament_ros_defaults
 )
 
 install(TARGETS

--- a/lifecycle/package.xml
+++ b/lifecycle/package.xml
@@ -14,6 +14,7 @@
   <author email="mabel@openrobotics.org">Mabel Zhang</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros_core</buildtool_depend>
 
   <depend>lifecycle_msgs</depend>
   <depend>rclcpp</depend>

--- a/logging_demo/CMakeLists.txt
+++ b/logging_demo/CMakeLists.txt
@@ -2,17 +2,12 @@ cmake_minimum_required(VERSION 3.20)
 
 project(logging_demo)
 
-# Default to C++17
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-endif()
-
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros_core REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(rcutils REQUIRED)
@@ -31,7 +26,8 @@ target_compile_definitions(logger_config_component
   PRIVATE "LOGGING_DEMO_BUILDING_DLL")
 target_link_libraries(logger_config_component PUBLIC
   rclcpp::rclcpp
-  rclcpp_components::component)
+  rclcpp_components::component
+  ament_cmake_ros_core::ament_ros_defaults)
 rosidl_get_typesupport_target(cpp_typesupport_target "${PROJECT_NAME}" "rosidl_typesupport_cpp")
 target_link_libraries(logger_config_component PUBLIC "${cpp_typesupport_target}")
 rclcpp_components_register_nodes(logger_config_component "logging_demo::LoggerConfig")
@@ -43,7 +39,8 @@ target_compile_definitions(logger_usage_component
 target_link_libraries(logger_usage_component PUBLIC
   rclcpp::rclcpp
   rclcpp_components::component
-  example_interfaces::example_interfaces)
+  example_interfaces::example_interfaces
+  ament_cmake_ros_core::ament_ros_defaults)
 rclcpp_components_register_nodes(logger_usage_component "logging_demo::LoggerUsage")
 
 add_executable(logging_demo_main
@@ -51,7 +48,8 @@ add_executable(logging_demo_main
 target_link_libraries(logging_demo_main PRIVATE
   logger_config_component
   logger_usage_component
-  rclcpp::rclcpp)
+  rclcpp::rclcpp
+  ament_cmake_ros_core::ament_ros_defaults)
 
 install(TARGETS
   logger_config_component

--- a/logging_demo/package.xml
+++ b/logging_demo/package.xml
@@ -16,6 +16,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros_core</buildtool_depend>
 
   <build_depend>rclcpp</build_depend>
   <build_depend>rclcpp_components</build_depend>

--- a/pendulum_control/CMakeLists.txt
+++ b/pendulum_control/CMakeLists.txt
@@ -8,12 +8,7 @@ if(APPLE OR WIN32)
 endif()
 
 find_package(ament_cmake REQUIRED)
-
-# Default to C++17
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-endif()
+find_package(ament_cmake_ros_core REQUIRED)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
@@ -37,21 +32,24 @@ target_link_libraries(pendulum_demo PRIVATE
   pendulum_msgs::pendulum_msgs
   rclcpp::rclcpp
   rttest::rttest
-  tlsf_cpp::tlsf_cpp)
+  tlsf_cpp::tlsf_cpp
+  ament_cmake_ros_core::ament_ros_defaults)
 
 add_executable(pendulum_logger
   src/pendulum_logger.cpp)
 target_link_libraries(pendulum_logger PRIVATE
   pendulum_msgs::pendulum_msgs
   rclcpp::rclcpp
-  rttest::rttest)
+  rttest::rttest
+  ament_cmake_ros_core::ament_ros_defaults)
 
 add_executable(pendulum_teleop
   src/pendulum_teleop.cpp)
 target_link_libraries(pendulum_teleop PRIVATE
   pendulum_msgs::pendulum_msgs
   rclcpp::rclcpp
-  rttest::rttest)
+  rttest::rttest
+  ament_cmake_ros_core::ament_ros_defaults)
 
 install(TARGETS
   pendulum_demo

--- a/pendulum_control/package.xml
+++ b/pendulum_control/package.xml
@@ -16,6 +16,7 @@
   <author>Mikael Arguedas</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros_core</buildtool_depend>
 
   <build_depend>rclcpp</build_depend>
   <build_depend>pendulum_msgs</build_depend>

--- a/pendulum_msgs/CMakeLists.txt
+++ b/pendulum_msgs/CMakeLists.txt
@@ -2,12 +2,6 @@ cmake_minimum_required(VERSION 3.20)
 
 project(pendulum_msgs)
 
-# Default to C++17
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-endif()
-
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()

--- a/quality_of_service_demo/rclcpp/CMakeLists.txt
+++ b/quality_of_service_demo/rclcpp/CMakeLists.txt
@@ -2,17 +2,12 @@ cmake_minimum_required(VERSION 3.20)
 
 project(quality_of_service_demo_cpp)
 
-# Default to C++17
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-endif()
-
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros_core REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(rcutils)
@@ -32,7 +27,8 @@ function(qos_demo_executable target)
   target_link_libraries(${target}
     rclcpp::rclcpp
     rcutils::rcutils
-    example_interfaces::example_interfaces)
+    example_interfaces::example_interfaces
+    ament_cmake_ros_core::ament_ros_defaults)
   install(TARGETS ${target} DESTINATION lib/${PROJECT_NAME})
 endfunction()
 
@@ -50,7 +46,8 @@ target_link_libraries(message_lost
   rclcpp::rclcpp
   rclcpp_components::component
   rcutils::rcutils
-  sensor_msgs::sensor_msgs)
+  sensor_msgs::sensor_msgs
+  ament_cmake_ros_core::ament_ros_defaults)
 target_compile_definitions(message_lost
   PRIVATE "QUALITY_OF_SERVICE_DEMO_BUILDING_DLL")
 rclcpp_components_register_node(message_lost
@@ -68,7 +65,8 @@ target_link_libraries(qos_overrides
   rclcpp::rclcpp
   rclcpp_components::component
   rcutils::rcutils
-  sensor_msgs::sensor_msgs)
+  sensor_msgs::sensor_msgs
+  ament_cmake_ros_core::ament_ros_defaults)
 target_compile_definitions(qos_overrides
   PRIVATE "QUALITY_OF_SERVICE_DEMO_BUILDING_DLL")
 rclcpp_components_register_node(qos_overrides

--- a/quality_of_service_demo/rclcpp/package.xml
+++ b/quality_of_service_demo/rclcpp/package.xml
@@ -15,6 +15,7 @@
   <author email="mabel@openrobotics.org">Mabel Zhang</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros_core</buildtool_depend>
 
   <build_depend>example_interfaces</build_depend>
   <build_depend>rclcpp</build_depend>

--- a/topic_statistics_demo/CMakeLists.txt
+++ b/topic_statistics_demo/CMakeLists.txt
@@ -2,17 +2,12 @@ cmake_minimum_required(VERSION 3.20)
 
 project(topic_statistics_demo)
 
-# Default to C++17
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-endif()
-
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros_core REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcutils)
 find_package(sensor_msgs REQUIRED)
@@ -32,7 +27,8 @@ target_link_libraries(display_topic_statistics
   rcutils::rcutils
   sensor_msgs::sensor_msgs
   statistics_msgs::statistics_msgs
-  example_interfaces::example_interfaces)
+  example_interfaces::example_interfaces
+  ament_cmake_ros_core::ament_ros_defaults)
 install(TARGETS display_topic_statistics DESTINATION lib/${PROJECT_NAME})
 
 if(BUILD_TESTING)

--- a/topic_statistics_demo/package.xml
+++ b/topic_statistics_demo/package.xml
@@ -14,6 +14,7 @@
   <author email="mabel@openrobotics.org">Mabel Zhang</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros_core</buildtool_depend>
 
   <build_depend>rclcpp</build_depend>
   <build_depend>rcutils</build_depend>


### PR DESCRIPTION
## Description

As we are switching to c++20 in lyrical, std::endian is available now and we can remove the defined detail::endian, this PR also bumps all packages to c++20

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
