### PR TITLE
Update showimage.cpp removing extra std::cerr outputs

### DIFF
--- a/image_tools/src/showimage.cpp
+++ b/image_tools/src/showimage.cpp
@@ -174,7 +174,6 @@ private:
     const image_tools::ROSCvMatContainer & container, bool show_image, rclcpp::Logger logger)
   {
     RCLCPP_INFO(logger, "Received image #%s", container.header().frame_id.c_str());
-    std::cerr << "Received image #" << container.header().frame_id.c_str() << std::endl;
 
     if (show_image) {
       cv::Mat frame = container.cv_mat();


### PR DESCRIPTION
## Description
Right now when running this you get the following:
```
/# ros2 run image_tools showimage 
[INFO] [1777605547.094321809] [showimage]: Subscribing to topic 'image'
[INFO] [1777605547.203184824] [showimage]: Received image #camera_frame
Received image #camera_frame
[INFO] [1777605547.533933569] [showimage]: Received image #camera_frame
Received image #camera_frame
[INFO] [1777605547.538867302] [showimage]: Received image #camera_frame
Received image #camera_frame
[INFO] [1777605547.543719581] [showimage]: Received image #camera_frame
Received image #camera_frame
[INFO] [1777605547.548553095] [showimage]: Received image #camera_frame
Received image #camera_frame
[INFO] [1777605547.553280199] [showimage]: Received image #camera_frame
Received image #camera_frame
```

The `std::cerr` message is redundant and doesn't actually display any additional helpful information. I propose we remove it since it doesn't seem to serve a purpose. 

### Is this user-facing behavior change?
This just changes the terminal output when running `showImage`. 

### Did you use Generative AI?
No.
