### PR TITLE
Add ament_mypy to quality_of_service_demo_py

### DIFF
--- a/quality_of_service_demo/rclpy/package.xml
+++ b/quality_of_service_demo/rclpy/package.xml
@@ -23,6 +23,7 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
   <test_depend>python3-pytest</test_depend>
+  <test_depend>ament_mypy</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/quality_of_service_demo/rclpy/test/test_mypy.py
+++ b/quality_of_service_demo/rclpy/test/test_mypy.py
@@ -17,5 +17,5 @@ from ament_mypy.main import main
 
 
 def test_mypy() -> None:
-    rc = main(argv=['--ament-strict'])
+    rc = main()
     assert rc == 0, 'Found code style errors / warnings'

--- a/quality_of_service_demo/rclpy/test/test_mypy.py
+++ b/quality_of_service_demo/rclpy/test/test_mypy.py
@@ -1,4 +1,4 @@
-# Copyright 2026 Open Source Robotics Foundation, Inc.
+# Copyright 2019 Canonical, Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
+
+from ament_mypy.main import main
 
 
-@pytest.mark.mypy
-@pytest.mark.linter
-def test_mypy():
-    from ament_mypy.main import main
-    rc = main()
+def test_mypy() -> None:
+    rc = main(argv=['--ament-strict'])
     assert rc == 0, 'Found code style errors / warnings'

--- a/quality_of_service_demo/rclpy/test/test_mypy.py
+++ b/quality_of_service_demo/rclpy/test/test_mypy.py
@@ -1,0 +1,23 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+
+@pytest.mark.mypy
+@pytest.mark.linter
+def test_mypy():
+    from ament_mypy.main import main
+    rc = main()
+    assert rc == 0, 'Found code style errors / warnings'

--- a/quality_of_service_demo/rclpy/test/test_mypy.py
+++ b/quality_of_service_demo/rclpy/test/test_mypy.py
@@ -17,5 +17,5 @@ from ament_mypy.main import main
 
 
 def test_mypy() -> None:
-    rc = main()
+    rc = main(argv=[])
     assert rc == 0, 'Found code style errors / warnings'

--- a/quality_of_service_demo/rclpy/test/test_mypy.py
+++ b/quality_of_service_demo/rclpy/test/test_mypy.py
@@ -17,5 +17,5 @@ from ament_mypy.main import main
 
 
 def test_mypy() -> None:
-    rc = main(argv=[])
+    rc = main(argv=['--ament-strict'])
     assert rc == 0, 'Found code style errors / warnings'


### PR DESCRIPTION
Closes #769 

Adds `ament_mypy` type-checking linter to the `quality_of_service_demo_py` 
package, consistent with other `ament_python` packages in this repo.

## Changes:
- Added `<test_depend>ament_mypy</test_depend>` to `package.xml`
- Added `test/test_mypy.py` with standard linter test boilerplate

## Testing ouptut

```
ubuntu@eef4c7977591:~/workspace/ws4/demos$ colcon build --packages-select quality_of_service_demo_py --allow-overriding quality_of_service_demo_py && \
colcon test --packages-select quality_of_service_demo_py --event-handlers console_cohesion+
Starting >>> quality_of_service_demo_py
Finished <<< quality_of_service_demo_py [4.98s]          

Summary: 1 package finished [5.76s]
Starting >>> quality_of_service_demo_py
--- output: quality_of_service_demo_py                     
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-7.4.4, pluggy-1.4.0
cachedir: build/quality_of_service_demo_py/.pytest_cache
rootdir: /home/ubuntu/workspace/ws4/demos
configfile: pytest.ini
plugins: launch-testing-3.4.10, ament-copyright-0.17.5, launch-testing-ros-0.26.11, ament-lint-0.17.5, ament-flake8-0.17.5, ament-xmllint-0.17.5, ament-pep257-0.17.5, ament-mypy-0.17.5, colcon-core-0.20.1, cov-4.1.0
collecting ... 
collected 5 items                                                              

test/test_linters.py ...                                                 [ 60%]
test/test_mypy.py .                                                      [ 80%]
test/test_xmllint.py .                                                   [100%]

- generated xml file: /home/ubuntu/workspace/ws4/demos/build/quality_of_service_demo_py/pytest.xml -
============================== 5 passed in 16.60s ==============================
---
Finished <<< quality_of_service_demo_py [20.4s]
                      
Summary: 1 package finished [21.4s]

```
All updates done + All test and build passed successfully.

### Kindly review and suggestion are highly appreciated .