### PR TITLE
Run lifecycle_py/test with RMW isolation

### DIFF
--- a/lifecycle_py/package.xml
+++ b/lifecycle_py/package.xml
@@ -21,6 +21,7 @@
   <test_depend>ament_pep257</test_depend>
   <test_depend>ament_xmllint</test_depend>
   <test_depend>lifecycle</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
   <test_depend>ros_testing</test_depend>
   <test_depend>ament_mypy</test_depend>
 

--- a/lifecycle_py/test/test_lifecycle.py
+++ b/lifecycle_py/test/test_lifecycle.py
@@ -31,6 +31,7 @@ import launch_testing.actions
 import launch_testing.asserts
 from launch_testing.io_handler import ActiveIoHandler
 from launch_testing.proc_info_handler import ActiveProcInfoHandler
+from launch_testing_ros.actions import EnableRmwIsolation
 
 import lifecycle_msgs.msg
 
@@ -48,6 +49,7 @@ def generate_test_description() -> tuple[launch.LaunchDescription, dict[str, Any
         name='listener', output='screen'
     )
     return launch.LaunchDescription([
+        EnableRmwIsolation(),
         talker_node, listener_node,
         # Right after the talker starts, make it take the 'configure' transition.
         launch.actions.RegisterEventHandler(


### PR DESCRIPTION
## Description

Addresses parts of https://github.com/ros2/rmw_zenoh/issues/1016
Similar to #795 but for `lifecycle_py/test`

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No
